### PR TITLE
[codex] Add Actions Datastore OAuth scopes

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -41,7 +41,13 @@ pub struct ClientCredentials {
 
 /// All known valid OAuth scopes for validation.
 pub fn all_known_scopes() -> Vec<&'static str> {
-    default_scopes()
+    let mut scopes = default_scopes();
+    scopes.extend([
+        "apps_datastore_manage",
+        "apps_datastore_read",
+        "apps_datastore_write",
+    ]);
+    scopes
 }
 
 /// Read-only OAuth scopes for use with --read-only flag.
@@ -323,7 +329,14 @@ mod tests {
 
     #[test]
     fn test_all_known_scopes_matches_default() {
-        assert_eq!(all_known_scopes(), default_scopes());
+        let known = all_known_scopes();
+        let default: std::collections::HashSet<&str> = default_scopes().into_iter().collect();
+        for scope in default {
+            assert!(known.contains(&scope));
+        }
+        assert!(known.contains(&"apps_datastore_manage"));
+        assert!(known.contains(&"apps_datastore_read"));
+        assert!(known.contains(&"apps_datastore_write"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Allow `pup auth login --scopes` to accept Actions Datastore OAuth scopes.
- Keep the scopes out of the default login scope set until the Datadog OAuth server exposes them.

## Why
`pup` previously filtered `apps_datastore_read` as an unknown scope before the OAuth request. That prevented testing Actions Datastore API OAuth access from the CLI.

## Validation
- `cargo test --bin pup auth::types::tests`
- `cargo fmt --check`
- `cargo clippy --bin pup -- -D warnings`
- `target/debug/pup auth login --scopes apps_datastore_read --callback-port 9000` now requests `apps_datastore_read`; the live OAuth server still returns `invalid_scope`, confirming the remaining blocker is server-side scope registration.