### PR TITLE
feat(dbm): add OAuth support for dbm samples search | DAL-647

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -62,6 +62,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "test_optimization_read",
         "dashboards_read",
         "data_scanner_read",
+        "dbm_read",
         "error_tracking_read",
         "events_read",
         "gcp_configuration_read",
@@ -146,6 +147,11 @@ pub fn default_scopes() -> Vec<&'static str> {
         "data_scanner_read",
         // Data Streams
         "data_streams_monitoring_capture_messages",
+        // Database Monitoring
+        // built_in_features is required on US1/EU1 while the DBM team migrates to dbm_read.
+        // Both are requested so the command works on all sites.
+        "built_in_features",
+        "dbm_read",
         // Error Tracking
         "error_tracking_read",
         // Events
@@ -318,6 +324,9 @@ mod tests {
         assert!(scopes.contains(&"apps_run"));
         assert!(scopes.contains(&"apps_write"));
         assert!(scopes.contains(&"connections_read"));
+        // Database Monitoring
+        assert!(scopes.contains(&"dbm_read"));
+        assert!(scopes.contains(&"built_in_features"));
     }
 
     #[test]

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -61,6 +61,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "code_coverage_read",
         "test_optimization_read",
         "dashboards_read",
+        "built_in_features",
         "data_scanner_read",
         "dbm_read",
         "error_tracking_read",
@@ -149,7 +150,8 @@ pub fn default_scopes() -> Vec<&'static str> {
         "data_streams_monitoring_capture_messages",
         // Database Monitoring
         // built_in_features is required on US1/EU1 while the DBM team migrates to dbm_read.
-        // Both are requested so the command works on all sites.
+        // Both are requested so the command works on all sites during the transition.
+        // Once the migration is complete, built_in_features can be removed from both scope lists.
         "built_in_features",
         "dbm_read",
         // Error Tracking
@@ -343,6 +345,8 @@ mod tests {
         assert!(ro.contains(&"dashboards_read"));
         assert!(ro.contains(&"monitors_read"));
         assert!(ro.contains(&"apps_run"));
+        assert!(ro.contains(&"dbm_read"));
+        assert!(ro.contains(&"built_in_features"));
         assert!(!ro.contains(&"org_management"));
         assert!(!ro.contains(&"teams_manage"));
         assert!(!ro.contains(&"monitors_write"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1054,8 +1054,7 @@ enum Commands {
     ///   pup dbm samples search --query "dbm_type:activity service:orders env:prod" --from 1h --limit 10
     ///
     /// AUTHENTICATION:
-    ///   Accepts OAuth2 (`pup auth login`, requires `dbm_read` scope) or
-    ///   DD_API_KEY + DD_APP_KEY.
+    ///   Accepts OAuth2 (`pup auth login`) or DD_API_KEY + DD_APP_KEY.
     #[command(verbatim_doc_comment)]
     Dbm {
         #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1054,7 +1054,8 @@ enum Commands {
     ///   pup dbm samples search --query "dbm_type:activity service:orders env:prod" --from 1h --limit 10
     ///
     /// AUTHENTICATION:
-    ///   Requires DD_API_KEY + DD_APP_KEY.
+    ///   Accepts OAuth2 (`pup auth login`, requires `dbm_read` scope) or
+    ///   DD_API_KEY + DD_APP_KEY.
     #[command(verbatim_doc_comment)]
     Dbm {
         #[command(subcommand)]


### PR DESCRIPTION
Addresses https://github.com/DataDog/pup/issues/445

Adds `dbm_read` and `built_in_features` to the OAuth scope list so `pup auth login` sessions can call `pup dbm samples search`.

**Why two scopes:** the DBM team is migrating permission gating from `built_in_features` to `dbm_read`. US1/EU1 currently require `built_in_features`; the other sites use `dbm_read`. Requesting both ensures the command works on all sites during the transition. `built_in_features` can be removed once the migration is complete.

Also updates the `pup dbm --help` AUTHENTICATION note to reflect OAuth support.

Note: the server-side configuration for the `datadog-pup-cli` OAuth client already has both `dbm_read` and `built_in_features` allowed.

Tested end-to-end against...
* datad0g.com (staging) - which requires dbm_read
* us5.datadoghq.com (US5) site - which requires dbm_read
* app.datadoghq.com (US1) site - which requires built_in_features

https://datadoghq.atlassian.net/browse/DAL-647