### PR TITLE
fix(docs): correct pup agent guide description in LLM_GUIDE.md

### DIFF
--- a/docs/LLM_GUIDE.md
+++ b/docs/LLM_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide helps AI coding agents understand and effectively use the Pup CLI tool. It covers the agent operability system, discovery commands, query syntax, and common workflows.
 
-For the runtime version of this guide (embedded in the binary), run `pup agent guide`.
+For the machine-readable runtime reference (embedded in the binary), run `pup agent schema` (JSON).
 
 ## Agent Mode
 
@@ -60,8 +60,6 @@ pup metrics --help   # Only metrics commands
 ```bash
 pup agent schema              # Full JSON schema
 pup agent schema --compact    # Minimal schema (names + flags only, fewer tokens)
-pup agent guide               # Full steering guide (markdown)
-pup agent guide logs          # Domain-specific guide section
 ```
 
 ## Authentication


### PR DESCRIPTION
## Summary

`docs/LLM_GUIDE.md` incorrectly told readers to run `pup agent guide` for "the runtime version of this guide." That command actually prints an operational reference for the **datadog-agent host daemon** — not the LLM steering guide. The machine-readable runtime reference for AI coding assistants is `pup agent schema`.

## Changes

- `docs/LLM_GUIDE.md:5` — corrected the "runtime version" sentence to point at `pup agent schema` (JSON)
- `docs/LLM_GUIDE.md:63-64` — removed two non-existent `pup agent guide` / `pup agent guide logs` lines from the "Explicit schema commands" block

No code changes; command behavior is unchanged.

## Testing

- `grep -rni "runtime version of this guide\|guide logs\|steering guide" docs/` returns nothing
- `pup agent guide` still prints the datadog-agent daemon reference (unchanged)
- `pup agent schema` still prints JSON schema (unchanged)

## Related Issues

Closes #612

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)