### PR TITLE
INPLAT-1168: update apm troubleshooting list for new instrumentation-errors endpoint

### DIFF
--- a/src/commands/apm.rs
+++ b/src/commands/apm.rs
@@ -86,16 +86,25 @@ pub async fn flow_map(
 
 pub async fn troubleshooting_list(
     cfg: &Config,
-    hostname: String,
+    hostname: Option<String>,
     timeframe: Option<String>,
+    result: Option<String>,
 ) -> Result<()> {
     let path = "/api/unstable/apm/instrumentation-errors";
-    let mut query = vec![("hostname", hostname.as_str())];
-    let tf_owned;
-    if let Some(tf) = &timeframe {
-        tf_owned = tf.clone();
-        query.push(("timeframe", tf_owned.as_str()));
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    if let Some(h) = hostname {
+        pairs.push(("hostname".to_string(), h));
     }
+    if let Some(tf) = timeframe {
+        pairs.push(("timeframe".to_string(), tf));
+    }
+    if let Some(r) = result {
+        pairs.push(("result".to_string(), r));
+    }
+    let query: Vec<(&str, &str)> = pairs
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
     let data = client::raw_get(cfg, path, &query).await?;
     formatter::output(cfg, &data)
 }
@@ -279,7 +288,7 @@ mod tests {
             .create_async()
             .await;
 
-        let result = super::troubleshooting_list(&cfg, "my-host".into(), None).await;
+        let result = super::troubleshooting_list(&cfg, Some("my-host".into()), None, None).await;
         assert!(
             result.is_ok(),
             "troubleshooting list failed: {:?}",
@@ -307,10 +316,71 @@ mod tests {
             .create_async()
             .await;
 
-        let result = super::troubleshooting_list(&cfg, "my-host".into(), Some("4h".into())).await;
+        let result =
+            super::troubleshooting_list(&cfg, Some("my-host".into()), Some("4h".into()), None)
+                .await;
         assert!(
             result.is_ok(),
             "troubleshooting list with timeframe failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_apm_troubleshooting_list_org_wide() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("GET", "/api/unstable/apm/instrumentation-errors")
+            .match_query(mockito::Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": []}"#)
+            .create_async()
+            .await;
+
+        let result = super::troubleshooting_list(&cfg, None, None, None).await;
+        assert!(
+            result.is_ok(),
+            "troubleshooting list org-wide failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_apm_troubleshooting_list_with_result_filter() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("GET", "/api/unstable/apm/instrumentation-errors")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("hostname".into(), "my-host".into()),
+                mockito::Matcher::UrlEncoded("result".into(), "error,abort".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": []}"#)
+            .create_async()
+            .await;
+
+        let result = super::troubleshooting_list(
+            &cfg,
+            Some("my-host".into()),
+            None,
+            Some("error,abort".into()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "troubleshooting list with result filter failed: {:?}",
             result.err()
         );
         mock.assert_async().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8489,12 +8489,17 @@ enum ApmDependencyActions {
 
 #[derive(Subcommand)]
 enum ApmTroubleshootingActions {
-    /// List instrumentation errors for a host
+    /// List instrumentation errors for a host or org-wide
     List {
-        #[arg(long, help = "Hostname to query (required)")]
-        hostname: String,
+        #[arg(long, help = "Hostname to query (omit for org-wide results)")]
+        hostname: Option<String>,
         #[arg(long, help = "Time window (e.g. 4h, 24h, 1h30m)")]
         timeframe: Option<String>,
+        #[arg(
+            long,
+            help = "Filter by result (success, error, abort, unknown; comma-separated)"
+        )]
+        result: Option<String>,
     },
 }
 
@@ -14716,8 +14721,10 @@ async fn main_inner() -> anyhow::Result<()> {
                     ApmTroubleshootingActions::List {
                         hostname,
                         timeframe,
+                        result,
                     } => {
-                        commands::apm::troubleshooting_list(&cfg, hostname, timeframe).await?;
+                        commands::apm::troubleshooting_list(&cfg, hostname, timeframe, result)
+                            .await?;
                     }
                 },
                 ApmActions::ServiceRemapping { action } => match action {


### PR DESCRIPTION
## Summary

Updates `pup apm troubleshooting list` to match the updated `/api/unstable/apm/instrumentation-errors` endpoint:

- `--hostname` is now optional — omitting it queries org-wide (previously required)
- `--result` filter added, accepting comma-separated values: `success`, `error`, `abort`, `unknown`
- Per-row `hostname` field in responses requires no changes — pup's JSON passthrough handles it automatically

Jira: [INPLAT-1168](https://datadoghq.atlassian.net/browse/INPLAT-1168)

## How this was tested

- Updated existing tests to use `Option<String>` for hostname
- Added `test_apm_troubleshooting_list_org_wide`: verifies no `hostname` param is sent when omitted
- Added `test_apm_troubleshooting_list_with_result_filter`: verifies `result` param is passed correctly
- All 508 tests pass; `cargo clippy -- -D warnings` and `cargo fmt --check` clean

[INPLAT-1168]: https://datadoghq.atlassian.net/browse/INPLAT-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ