### PR TITLE
fix: allow hyphen-prefixed values for --sort flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3070,7 +3070,12 @@ enum LogActions {
         to: String,
         #[arg(long, default_value_t = 10, help = "Number of logs")]
         limit: i32,
-        #[arg(long, allow_hyphen_values = true, default_value = "-timestamp", help = "Sort order")]
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            default_value = "-timestamp",
+            help = "Sort order"
+        )]
         sort: String,
         #[arg(long, help = "Storage tier: indexes, online-archives, or flex")]
         storage: Option<String>,
@@ -3089,7 +3094,12 @@ enum LogActions {
         to: String,
         #[arg(long, default_value_t = 50, help = "Maximum results")]
         limit: i32,
-        #[arg(long, allow_hyphen_values = true, default_value = "-timestamp", help = "Sort order")]
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            default_value = "-timestamp",
+            help = "Sort order"
+        )]
         sort: String,
         #[arg(long, help = "Storage tier: indexes, online-archives, or flex")]
         storage: Option<String>,
@@ -4556,7 +4566,12 @@ enum InfraHostActions {
     List {
         #[arg(long, help = "Filter hosts")]
         filter: Option<String>,
-        #[arg(long, allow_hyphen_values = true, default_value = "status", help = "Sort field")]
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            default_value = "status",
+            help = "Sort field"
+        )]
         sort: String,
         #[arg(long, default_value_t = 100, help = "Maximum hosts")]
         count: i64,
@@ -8254,7 +8269,11 @@ enum ModelLabProjectActions {
         filter: Option<String>,
         #[arg(long, help = "Filter by tags (comma-separated)")]
         filter_tags: Option<String>,
-        #[arg(long, allow_hyphen_values = true, help = "Sort field (e.g. name, created_at)")]
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            help = "Sort field (e.g. name, created_at)"
+        )]
         sort: Option<String>,
         #[arg(long)]
         page_size: Option<i64>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2957,7 +2957,7 @@ enum MonitorActions {
         page: i64,
         #[arg(long, default_value_t = 30, help = "Results per page")]
         per_page: i64,
-        #[arg(long, help = "Sort order")]
+        #[arg(long, allow_hyphen_values = true, help = "Sort order")]
         sort: Option<String>,
     },
     /// Delete a monitor
@@ -3070,7 +3070,7 @@ enum LogActions {
         to: String,
         #[arg(long, default_value_t = 10, help = "Number of logs")]
         limit: i32,
-        #[arg(long, default_value = "-timestamp", help = "Sort order")]
+        #[arg(long, allow_hyphen_values = true, default_value = "-timestamp", help = "Sort order")]
         sort: String,
         #[arg(long, help = "Storage tier: indexes, online-archives, or flex")]
         storage: Option<String>,
@@ -3089,7 +3089,7 @@ enum LogActions {
         to: String,
         #[arg(long, default_value_t = 50, help = "Maximum results")]
         limit: i32,
-        #[arg(long, default_value = "-timestamp", help = "Sort order")]
+        #[arg(long, allow_hyphen_values = true, default_value = "-timestamp", help = "Sort order")]
         sort: String,
         #[arg(long, help = "Storage tier: indexes, online-archives, or flex")]
         storage: Option<String>,
@@ -3125,6 +3125,7 @@ enum LogActions {
         storage: Option<String>,
         #[arg(
             long,
+            allow_hyphen_values = true,
             default_value = "count",
             help = "Sort groups by aggregation (count,cardinality,pc75,pc90,pc95,pc98,pc99,sum,min,max)"
         )]
@@ -3747,7 +3748,7 @@ enum SyntheticsTestActions {
             help = "Offset from which to start returning results"
         )]
         start: i64,
-        #[arg(long, help = "Sort order")]
+        #[arg(long, allow_hyphen_values = true, help = "Sort order")]
         sort: Option<String>,
     },
     /// Run synthetic tests (requires DD_API_KEY + DD_APP_KEY)
@@ -4079,6 +4080,7 @@ enum DbmSamplesActions {
         limit: i32,
         #[arg(
             long,
+            allow_hyphen_values = true,
             default_value = "desc",
             help = "Sort order: asc, desc, timestamp, or -timestamp"
         )]
@@ -4405,6 +4407,7 @@ enum WidgetActions {
         filter_tags: Option<String>,
         #[arg(
             long,
+            allow_hyphen_values = true,
             help = "Sort field (title, created_at, modified_at; prefix with - for descending)"
         )]
         sort: Option<String>,
@@ -4553,7 +4556,7 @@ enum InfraHostActions {
     List {
         #[arg(long, help = "Filter hosts")]
         filter: Option<String>,
-        #[arg(long, default_value = "status", help = "Sort field")]
+        #[arg(long, allow_hyphen_values = true, default_value = "status", help = "Sort field")]
         sort: String,
         #[arg(long, default_value_t = 100, help = "Maximum hosts")]
         count: i64,
@@ -4915,6 +4918,7 @@ enum SecurityRuleActions {
         filter: Option<String>,
         #[arg(
             long,
+            allow_hyphen_values = true,
             help = "Sort order (name, -name, creation_date, -creation_date, update_date, -update_date, enabled, -enabled, type, -type, highest_severity, -highest_severity, source, -source)"
         )]
         sort: Option<String>,
@@ -4958,6 +4962,7 @@ enum SecuritySignalActions {
         limit: i32,
         #[arg(
             long,
+            allow_hyphen_values = true,
             help = "Sort order: timestamp (ascending) or -timestamp (descending)"
         )]
         sort: Option<String>,
@@ -5071,6 +5076,7 @@ enum SecuritySuppressionActions {
     List {
         #[arg(
             long,
+            allow_hyphen_values = true,
             help = "Sort order (name, -name, start_date, -start_date, expiration_date, -expiration_date, update_date, -update_date, -creation_date, enabled, -enabled)"
         )]
         sort: Option<String>,
@@ -5898,6 +5904,7 @@ enum AppKeyActions {
         /// Sort field (name, -name, created_at, -created_at)
         #[arg(
             long,
+            allow_hyphen_values = true,
             default_value = "",
             help = "Sort field (name, -name, created_at, -created_at)"
         )]
@@ -6384,6 +6391,7 @@ enum CicdFlakyTestActions {
         limit: i64,
         #[arg(
             long,
+            allow_hyphen_values = true,
             help = "Sort order (fqn, -fqn, first_flaked, -first_flaked, last_flaked, -last_flaked, failure_rate, -failure_rate, pipelines_failed, -pipelines_failed, pipelines_duration_lost, -pipelines_duration_lost)"
         )]
         sort: Option<String>,
@@ -6565,6 +6573,7 @@ enum OnCallMembershipActions {
         page_number: i64,
         #[arg(
             long,
+            allow_hyphen_values = true,
             default_value = "name",
             help = "Sort: name, -name, email, -email, handle, -handle, manager_name, -manager_name"
         )]
@@ -7893,6 +7902,7 @@ enum CostCcmCustomCostsActions {
         status: Option<String>,
         #[arg(
             long,
+            allow_hyphen_values = true,
             help = "Sort key (prefix with '-' for descending, e.g. '-created_at')"
         )]
         sort: Option<String>,
@@ -8244,7 +8254,7 @@ enum ModelLabProjectActions {
         filter: Option<String>,
         #[arg(long, help = "Filter by tags (comma-separated)")]
         filter_tags: Option<String>,
-        #[arg(long, help = "Sort field (e.g. name, created_at)")]
+        #[arg(long, allow_hyphen_values = true, help = "Sort field (e.g. name, created_at)")]
         sort: Option<String>,
         #[arg(long)]
         page_size: Option<i64>,
@@ -8295,7 +8305,7 @@ enum ModelLabRunActions {
         pinned_first: bool,
         #[arg(long, default_value_t = false, help = "Include pinned runs")]
         include_pinned: bool,
-        #[arg(long, help = "Sort field")]
+        #[arg(long, allow_hyphen_values = true, help = "Sort field")]
         sort: Option<String>,
         #[arg(long)]
         page_size: Option<i64>,
@@ -9539,6 +9549,7 @@ enum TracesActions {
         limit: i32,
         #[arg(
             long,
+            allow_hyphen_values = true,
             default_value = "-timestamp",
             help = "Sort order: timestamp or -timestamp"
         )]

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -397,6 +397,146 @@ fn test_ddsql_table_query_requires_explicit_value() {
 }
 
 // -------------------------------------------------------------------------
+// --sort with hyphen-prefixed values (e.g. -failure_rate, -timestamp)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_cicd_flaky_tests_search_sort_accepts_hyphen_value() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "cicd",
+        "flaky-tests",
+        "search",
+        "--query",
+        "*",
+        "--sort",
+        "-failure_rate",
+    ])
+    .expect("cicd flaky-tests search --sort -failure_rate should parse");
+
+    match cli.command {
+        crate::Commands::Cicd { action } => match action {
+            crate::CicdActions::FlakyTests { action } => match action {
+                crate::CicdFlakyTestActions::Search { sort, .. } => {
+                    assert_eq!(sort.as_deref(), Some("-failure_rate"));
+                }
+                _ => panic!("expected CicdFlakyTestActions::Search"),
+            },
+            _ => panic!("expected CicdActions::FlakyTests"),
+        },
+        _ => panic!("expected Commands::Cicd"),
+    }
+}
+
+#[test]
+fn test_cicd_flaky_tests_search_sort_accepts_positive_value() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "cicd",
+        "flaky-tests",
+        "search",
+        "--sort",
+        "fqn",
+    ])
+    .expect("cicd flaky-tests search --sort fqn should parse");
+
+    match cli.command {
+        crate::Commands::Cicd { action } => match action {
+            crate::CicdActions::FlakyTests { action } => match action {
+                crate::CicdFlakyTestActions::Search { sort, .. } => {
+                    assert_eq!(sort.as_deref(), Some("fqn"));
+                }
+                _ => panic!("expected CicdFlakyTestActions::Search"),
+            },
+            _ => panic!("expected CicdActions::FlakyTests"),
+        },
+        _ => panic!("expected Commands::Cicd"),
+    }
+}
+
+#[test]
+fn test_logs_list_sort_accepts_hyphen_timestamp() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "logs",
+        "list",
+        "--sort",
+        "-timestamp",
+    ])
+    .expect("logs list --sort -timestamp should parse");
+
+    match cli.command {
+        crate::Commands::Logs { action } => match action {
+            crate::LogActions::List { sort, .. } => {
+                assert_eq!(sort, "-timestamp");
+            }
+            _ => panic!("expected LogActions::List"),
+        },
+        _ => panic!("expected Commands::Logs"),
+    }
+}
+
+#[test]
+fn test_traces_search_sort_accepts_hyphen_timestamp() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "traces",
+        "search",
+        "--query",
+        "*",
+        "--sort",
+        "-timestamp",
+    ])
+    .expect("traces search --sort -timestamp should parse");
+
+    match cli.command {
+        crate::Commands::Traces { action } => match action {
+            crate::TracesActions::Search { sort, .. } => {
+                assert_eq!(sort, "-timestamp");
+            }
+            _ => panic!("expected TracesActions::Search"),
+        },
+        _ => panic!("expected Commands::Traces"),
+    }
+}
+
+#[test]
+fn test_security_rules_list_sort_accepts_hyphen_name() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "security",
+        "rules",
+        "list",
+        "--sort",
+        "-name",
+    ])
+    .expect("security rules list --sort -name should parse");
+
+    match cli.command {
+        crate::Commands::Security { action } => match action {
+            crate::SecurityActions::Rules { action } => match action {
+                crate::SecurityRuleActions::List { sort, .. } => {
+                    assert_eq!(sort.as_deref(), Some("-name"));
+                }
+                _ => panic!("expected SecurityRuleActions::List"),
+            },
+            _ => panic!("expected SecurityActions::Rules"),
+        },
+        _ => panic!("expected Commands::Security"),
+    }
+}
+
+// -------------------------------------------------------------------------
 // SymDB (duplicate of commands::symdb::tests::test_symdb_view_display, kept
 // here because colocating would collide with the pre-existing copy).
 // -------------------------------------------------------------------------

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -434,15 +434,8 @@ fn test_cicd_flaky_tests_search_sort_accepts_hyphen_value() {
 fn test_cicd_flaky_tests_search_sort_accepts_positive_value() {
     use clap::Parser;
 
-    let cli = crate::Cli::try_parse_from([
-        "pup",
-        "cicd",
-        "flaky-tests",
-        "search",
-        "--sort",
-        "fqn",
-    ])
-    .expect("cicd flaky-tests search --sort fqn should parse");
+    let cli = crate::Cli::try_parse_from(["pup", "cicd", "flaky-tests", "search", "--sort", "fqn"])
+        .expect("cicd flaky-tests search --sort fqn should parse");
 
     match cli.command {
         crate::Commands::Cicd { action } => match action {
@@ -462,14 +455,8 @@ fn test_cicd_flaky_tests_search_sort_accepts_positive_value() {
 fn test_logs_list_sort_accepts_hyphen_timestamp() {
     use clap::Parser;
 
-    let cli = crate::Cli::try_parse_from([
-        "pup",
-        "logs",
-        "list",
-        "--sort",
-        "-timestamp",
-    ])
-    .expect("logs list --sort -timestamp should parse");
+    let cli = crate::Cli::try_parse_from(["pup", "logs", "list", "--sort", "-timestamp"])
+        .expect("logs list --sort -timestamp should parse");
 
     match cli.command {
         crate::Commands::Logs { action } => match action {
@@ -512,15 +499,8 @@ fn test_traces_search_sort_accepts_hyphen_timestamp() {
 fn test_security_rules_list_sort_accepts_hyphen_name() {
     use clap::Parser;
 
-    let cli = crate::Cli::try_parse_from([
-        "pup",
-        "security",
-        "rules",
-        "list",
-        "--sort",
-        "-name",
-    ])
-    .expect("security rules list --sort -name should parse");
+    let cli = crate::Cli::try_parse_from(["pup", "security", "rules", "list", "--sort", "-name"])
+        .expect("security rules list --sort -name should parse");
 
     match cli.command {
         crate::Commands::Security { action } => match action {


### PR DESCRIPTION
## Problem

`pup cicd flaky-tests search --sort "-failure_rate"` fails with `improper flag parsed as "-f" not supported`. clap treats values starting with `-` as unknown flags instead of `--sort` values.

## Fix

Add `allow_hyphen_values = true` to all 18 `--sort` `#[arg]` attributes that accept hyphen-prefixed values (e.g. `-failure_rate`, `-timestamp`, `-name`).

Affected commands: `cicd flaky-tests search`, `logs list/query/aggregate`, `traces search`, `monitors search`, `synthetics search`, `dbm samples search`, `dashboards search`, `infra hosts list`, `security rules/signals/suppressions list`, `api-keys list`, `on-call memberships list`, `cost custom-costs files list`, `model-lab projects/runs list`.

## Tests

Added 5 CLI parsing tests verifying `--sort` accepts hyphen-prefixed values for the most impactful commands.