### PR TITLE
fix(config): propagate --jq to nested pup calls via PUP_FILTER env

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -110,6 +110,7 @@ Extensions receive pup's auth credentials via environment variables. This means 
 | `DD_SITE` | Always | Datadog site (e.g., `datadoghq.com`) |
 | `DD_ORG` | Org is specified | Named org session |
 | `PUP_OUTPUT` | Always | Output format (`json`, `table`, `yaml`, `csv`, `tsv`) |
+| `PUP_FILTER` | `--jq` flag is set | The jq expression, verbatim |
 | `PUP_AUTO_APPROVE` | `--yes` flag or agent mode | `true` |
 | `PUP_READ_ONLY` | Read-only mode | `true` |
 | `PUP_AGENT_MODE` | Agent mode | `true` |
@@ -118,7 +119,7 @@ Pup refreshes the OAuth2 token if needed before passing it to the extension, so 
 
 Variables not active in the current session are explicitly removed from the child environment to prevent stale credentials from leaking through the parent shell.
 
-The `PUP_OUTPUT`, `PUP_AGENT_MODE`, `PUP_READ_ONLY`, and `PUP_AUTO_APPROVE` variables are read back by a child `pup` process. So if your extension shells out to `pup` (see below), those nested calls automatically inherit the format and mode the user selected on the parent command.
+The `PUP_OUTPUT`, `PUP_FILTER`, `PUP_AGENT_MODE`, `PUP_READ_ONLY`, and `PUP_AUTO_APPROVE` variables are read back by a child `pup` process. So if your extension shells out to `pup` (see below), those nested calls automatically inherit the format, `--jq` filter, and mode the user selected on the parent command. An extension that prints its own JSON directly — rather than delegating to a nested `pup` call — still needs to read `PUP_FILTER` itself and apply the jq expression if it wants to honor `--jq`.
 
 ### Example: using auth in a Python extension
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,10 @@ impl Config {
                 || env_bool("DD_CLI_READ_ONLY")
                 || env_bool("PUP_READ_ONLY")
                 || file_cfg.read_only.unwrap_or(false),
-            jq: None, // set by caller from --jq flag
+            // `PUP_FILTER` is injected into extension subprocesses (like
+            // `PUP_OUTPUT` above) so a child `pup` call inherits the parent's
+            // --jq expression; an explicit --jq flag still overrides it.
+            jq: env_or("PUP_FILTER", None),
         };
 
         Ok(cfg)
@@ -1665,6 +1668,7 @@ mod tests {
             "DD_AUTO_APPROVE",
             "DD_CLI_AUTO_APPROVE",
             "PUP_AUTO_APPROVE",
+            "PUP_FILTER",
         ] {
             std::env::remove_var(var);
         }
@@ -1680,6 +1684,15 @@ mod tests {
         assert_eq!(cfg.output_format, OutputFormat::Yaml);
         std::env::remove_var("DD_OUTPUT");
         std::env::remove_var("PUP_OUTPUT");
+
+        // PUP_FILTER drives cfg.jq so a nested `pup` call spawned by an extension
+        // (e.g. `pup api` invoked from inside a `pup-<ext>` process) inherits the
+        // outer --jq expression, the same way it inherits --output.
+        assert_eq!(Config::from_env().unwrap().jq, None);
+        std::env::set_var("PUP_FILTER", ".[] | .id");
+        let cfg = Config::from_env().unwrap();
+        assert_eq!(cfg.jq.as_deref(), Some(".[] | .id"));
+        std::env::remove_var("PUP_FILTER");
 
         // PUP_READ_ONLY / PUP_AUTO_APPROVE flip the mode flags.
         std::env::set_var("PUP_READ_ONLY", "true");


### PR DESCRIPTION
## Problem

`--jq` is silently ignored when an extension delegates its HTTP call to a nested `pup` process, even though `-o`/`--output` works in the exact same chain. When an extension subcommand shells out through a helper to a nested `pup api` call, `-o table` propagates and takes effect but `--jq` does not:

```
pup --jq '.[] | {id: .id, service: .service_name, admin_teams: .admin_teams}' -o table test-extension list-items
```

**Before this fix** — the jq projection is dropped; every column comes back (data anonymized):

```
+------+--------+----------------------+----------------------+-------------------+-------------------+------------+---------------+--------+--------------+-------------------+-------------------+
| id   | name   | created_at           | updated_at           | created_by        | updated_by        | test_drive | route_id      | domain | service_name | service_namespace | server_group_name |
+==================================================================================================================================================================================================+
| 587  |        | 2026-04-20T20:16:35Z | 2026-04-20T20:16:35Z | agent@example.com | agent@example.com | false      | Rk3Lm9Qp2Xz=  | demo   | edge-backend | platform          | probe             |
|------+--------+----------------------+----------------------+-------------------+-------------------+------------+---------------+--------+--------------+-------------------+-------------------|
| 588  | sample | 2026-04-20T20:16:35Z | 2026-06-24T19:48:17Z | agent@example.com | agent@example.com | false      | 8Hn1Zu7BsfLa= | demo   | edge-backend | platform          | probe             |
|------+--------+----------------------+----------------------+-------------------+-------------------+------------+---------------+--------+--------------+-------------------+-------------------|
| 1104 |        | 2026-05-13T00:49:57Z | 2026-05-13T00:49:57Z | agent@example.com | agent@example.com | false      | eJ5yHpxLNCPc= | demo   | gateway      | commerce          | sandbox           |
|------+--------+----------------------+----------------------+-------------------+-------------------+------------+---------------+--------+--------------+-------------------+-------------------|
| 1    |        | 2026-01-15T09:00:00Z | 2026-01-15T09:00:00Z | agent@example.com | agent@example.com | false      | aB2cnoP8qrS9= | demo   | search-api   | search            | search            |
+------+--------+----------------------+----------------------+-------------------+-------------------+------------+---------------+--------+--------------+-------------------+-------------------+
```

**After this fix** — the jq projection is applied before formatting:

```
+------+--------------+-------------+
| id   | service      | admin_teams |
+===================================+
| 587  | edge-backend | [ops]       |
|------+--------------+-------------|
| 588  | edge-backend | [ops]       |
|------+--------------+-------------|
| 1104 | gateway      | [frontend]  |
|------+--------------+-------------|
| 1    | search-api   | [search]    |
+------+--------------+-------------+
```

## Root cause

`Config::from_env` resolves `output_format` with an env fallback (`DD_OUTPUT` / `PUP_OUTPUT`), which is why a nested `pup` process inherits `--output`. `jq` had no equivalent fallback — it was hardcoded to `None` and only ever set from the literal `--jq` CLI flag. `PUP_FILTER` is already injected into every extension's environment (`src/extensions/exec.rs`) for exactly this purpose, but nothing read it back.

## Fix

One line in `src/config.rs` — give `jq` the same env fallback `output_format` already has:

```rust
jq: env_or("PUP_FILTER", None),
```

Precedence is preserved: an explicit `--jq` flag still overrides the env (`main.rs` applies it after `Config::from_env`). Top-level `pup` behavior is unchanged when `PUP_FILTER` is unset; a manually-exported `PUP_FILTER` is now honored, matching the existing unguarded `PUP_OUTPUT` behavior.

## Testing

- Extended `config::tests::test_pup_env_inherited_by_child` to cover `PUP_FILTER` (asserts `None` when unset, `Some(expr)` when set).
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build --release` all clean.
- Manually verified the repro end-to-end with the patched binary on `PATH`.

## Docs

Added `PUP_FILTER` to the env-var table in `docs/EXTENSIONS.md` and extended the "read back by a child `pup` process" note.
