### PR TITLE
Add dora_metrics_read to known OAuth scopes

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -61,6 +61,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "ci_visibility_read",
         "cloud_cost_management_read",
         "code_coverage_read",
+        "dora_metrics_read",
         "test_optimization_read",
         "dashboards_read",
         "built_in_features",
@@ -140,6 +141,7 @@ pub fn default_scopes() -> Vec<&'static str> {
         // Cloud Cost Management
         "cloud_cost_management_read",
         "cloud_cost_management_write",
+        "dora_metrics_read",
         "dora_metrics_write",
         "test_optimization_read",
         "test_optimization_write",


### PR DESCRIPTION
## Summary
- `dora_metrics_write` is in `default_scopes()` (backing `pup dora patch-deployment`), but `dora_metrics_read` was never added.
- Since `all_known_scopes()` derives from `default_scopes()`, this made `dora_metrics_read` get rejected as unknown when requested via `--scopes`, and meant OAuth tokens never carried it by default, causing DORA read endpoints (list/get deployments and failures) to 403.
- Confirmed server-side that `dora_metrics_read` / `dora_metrics_write` are both valid, existing permissions, and the API spec gates all four DORA read endpoints (`list_dora_deployments`, `list_dora_failures`, `get_dora_deployment`, `get_dora_failure`) on `dora_metrics_read` specifically.

## Changes
- Added `dora_metrics_read` to `default_scopes()` next to `dora_metrics_write`.
- Added `dora_metrics_read` to `read_only_scopes()` for `--read-only` parity.

Fixes #635

## Test plan
- [x] `cargo check`
- [x] `cargo test` (auth module + full suite pass locally)