### PR TITLE
(fix) add OAuth scope for status page degradation

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -235,6 +235,7 @@ pub fn default_scopes() -> Vec<&'static str> {
         "slos_read",
         "slos_write",
         // Status Pages
+        "status_pages_notice_write",
         "status_pages_settings_read",
         "status_pages_settings_write",
         // Synthetics


### PR DESCRIPTION
## What does this PR do?

Add the OAuth scope to be able to create/update status page degradation.

## Motivation

Currently, it's not working. We're getting HTTP 403 when trying to interact with status page degradation.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [x] All CI checks pass
- [x] Code coverage is maintained or improved

