### PR TITLE
Add octo-sts trust policy for datadog-api-spec pup generation

### DIFF
--- a/.github/chainguard/datadog-api-spec.ci-cd.generate.sts.yaml
+++ b/.github/chainguard/datadog-api-spec.ci-cd.generate.sts.yaml
@@ -1,0 +1,14 @@
+# Policy for: .github/workflows/ci-cd.yml (generate-client job) in DataDog/datadog-api-spec
+# Allows that workflow to push a branch and open a PR against this repo.
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/datadog-api-spec:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/datadog-api-spec/\.github/workflows/ci-cd\.yml@.*
+  ref: refs/pull/[0-9]+/merge
+  repository: DataDog/datadog-api-spec
+
+permissions:
+  contents: write
+  pull_requests: write


### PR DESCRIPTION
## Context
datadog-api-spec generates pup's Rust CLI and needs to push the generated code here as a PR. This adds an octo-sts trust policy so that pipeline can authenticate and open the PR against this repo.

## Changes
The policy's `name` (derived from the filename, minus `.sts.yaml`) must match the name configured on the datadog-api-spec side — the filename is the contract, not just documentation. Format mirrors the existing `release.sts.yaml`.

Note: octo-sts reads policies from the default branch, so this must merge to `main` before the token can be minted against it.

## Tests
N/A — static policy file, no code path to exercise locally. Correctness will be observed when the datadog-api-spec workflow successfully mints a token and opens its PR after this merges.