### PR TITLE
feat(synthetics): accept OAuth2 for `synthetics tests run`

### DIFF
--- a/src/commands/synthetics.rs
+++ b/src/commands/synthetics.rs
@@ -29,23 +29,29 @@ fn synthetics_intake_base_url(cfg: &Config) -> String {
 #[cfg(not(target_arch = "wasm32"))]
 fn build_auth_headers(cfg: &Config) -> anyhow::Result<reqwest::header::HeaderMap> {
     use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-    let api_key = cfg
-        .api_key
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("DD_API_KEY is required for 'synthetics tests run'"))?;
-    let app_key = cfg
-        .app_key
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("DD_APP_KEY is required for 'synthetics tests run'"))?;
     let mut headers = HeaderMap::new();
-    headers.insert(
-        HeaderName::from_static("dd-api-key"),
-        HeaderValue::from_str(api_key)?,
-    );
-    headers.insert(
-        HeaderName::from_static("dd-application-key"),
-        HeaderValue::from_str(app_key)?,
-    );
+
+    // Prefer OAuth2 bearer token, falling back to API + app keys.
+    if let Some(token) = cfg.access_token.as_ref() {
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}"))?,
+        );
+    } else if let (Some(api_key), Some(app_key)) = (cfg.api_key.as_ref(), cfg.app_key.as_ref()) {
+        headers.insert(
+            HeaderName::from_static("dd-api-key"),
+            HeaderValue::from_str(api_key)?,
+        );
+        headers.insert(
+            HeaderName::from_static("dd-application-key"),
+            HeaderValue::from_str(app_key)?,
+        );
+    } else {
+        anyhow::bail!(
+            "'synthetics tests run' requires authentication: run 'pup auth login' or set DD_API_KEY and DD_APP_KEY"
+        );
+    }
+
     headers.insert(
         reqwest::header::USER_AGENT,
         HeaderValue::from_str(&crate::useragent::get())?,
@@ -957,6 +963,41 @@ mod tests {
         let result = super::downtime_delete(&cfg, "nonexistent-dt").await;
         assert!(result.is_err(), "expected 404 error from downtime_delete");
         cleanup_env();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_build_auth_headers_prefers_bearer() {
+        let mut cfg = test_config("http://unused.local");
+        cfg.access_token = Some("tok-123".into());
+        let headers = super::build_auth_headers(&cfg).expect("bearer headers");
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer tok-123");
+        assert!(headers.get("dd-api-key").is_none());
+        assert!(headers.get("dd-application-key").is_none());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_build_auth_headers_falls_back_to_api_keys() {
+        let mut cfg = test_config("http://unused.local");
+        cfg.access_token = None;
+        cfg.api_key = Some("api-1".into());
+        cfg.app_key = Some("app-1".into());
+        let headers = super::build_auth_headers(&cfg).expect("api-key headers");
+        assert_eq!(headers.get("dd-api-key").unwrap(), "api-1");
+        assert_eq!(headers.get("dd-application-key").unwrap(), "app-1");
+        assert!(headers.get("authorization").is_none());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_build_auth_headers_requires_some_auth() {
+        let mut cfg = test_config("http://unused.local");
+        cfg.access_token = None;
+        cfg.api_key = None;
+        cfg.app_key = None;
+        let err = super::build_auth_headers(&cfg).expect_err("should require auth");
+        assert!(err.to_string().contains("requires authentication"));
     }
 
     async fn server_mock_delete(s: &mut mockito::Server) -> mockito::Mock {


### PR DESCRIPTION
## Summary

`synthetics tests run` is the only synthetics command that rejects an OAuth2 session (`pup auth login`). It hard-requires `DD_API_KEY` + `DD_APP_KEY`, while every sibling command works with a bearer token. This makes it accept OAuth2 too — preferring the bearer, falling back to keys.

## Why

`tests_run` builds its own `reqwest::Client` and its `build_auth_headers` only ever set `dd-api-key`/`dd-application-key` — it never reads `cfg.access_token`. Every other synthetics command routes through `make_dd_client`/`apply_auth`, which prefers the bearer.

The Datadog CI endpoints this command calls already accept OAuth2 server-side (verified in dogweb):

| Endpoint | Accepts OAuth | Permission |
|---|---|---|
| `GET /synthetics/ci/tunnel` | yes | `SYNTHETICS_WRITE` or `CREATE_EDIT_TRIGGER` |
| `POST /synthetics/tests/trigger/ci` | yes | `SYNTHETICS_WRITE` or `CREATE_EDIT_TRIGGER` |
| `GET /synthetics/ci/batch/{id}` | yes | `SYNTHETICS_READ` |

pup already requests `synthetics_write`/`synthetics_read` by default. So this was a client-side gap, not a backend limit — no backend change required, and it applies to `--tunnel` runs too.

## Changes

- `build_auth_headers` (`src/commands/synthetics.rs`): prefer OAuth2 bearer, fall back to API + app keys, mirroring `client::apply_auth`.
- Clearer error when no auth is configured.
- Positive/negative tests for all three auth paths (bearer, key fallback, none).

## Testing

- Added unit tests: bearer preferred, key fallback, no-auth error.