### PR TITLE
feat(events): add event posting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3367,7 @@ dependencies = [
  "flate2",
  "futures",
  "futures-util",
+ "gethostname",
  "getrandom 0.4.2",
  "http",
  "jaq-core",
@@ -3447,7 +3458,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4709,10 +4720,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ jaq-json = { version = "2.0.1", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reqwest = { version = ">=0.13, <0.13.3", features = ["stream"] }
+gethostname = "1"
 
 [dev-dependencies]
 mockito = "1"

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -38,7 +38,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | static-analysis | custom-rulesets (get, update, delete), custom-rules (get, create, delete, revisions, revision) | src/commands/static_analysis.rs | ✅ |
 | downtime | list, get, cancel | src/commands/downtime.rs | ✅ |
 | tags | list, get, add, update, delete | src/commands/tags.rs | ✅ |
-| events | list, search, get | src/commands/events.rs | ✅ |
+| events | post, list, search, get | src/commands/events.rs | ✅ |
 | on-call | teams (CRUD, memberships) | src/commands/on_call.rs | ✅ |
 | audit-logs | list, search | src/commands/audit_logs.rs | ✅ |
 | api-keys | list, get, create, delete | src/commands/api_keys.rs | ✅ |
@@ -118,7 +118,6 @@ pup metrics query --query="avg:system.cpu.user{*}" --from="1h"
 pup metrics tags list system.cpu.user --window-seconds=3600
 pup metrics timeseries --file=request.json
 pup events search --query="@user.id:12345"
-pup events post --tags="version:1,application:web" --no_host --type=my_apps --aggregation_key=application:web --alert_type=info "Something big happened!" "And let me tell you all about it here!"
 ```
 
 ### Create/Update/Delete
@@ -126,6 +125,7 @@ pup events post --tags="version:1,application:web" --no_host --type=my_apps --ag
 pup <domain> create [--flags]
 pup <domain> update <id> [--flags]
 pup <domain> delete <id> [--yes]
+pup events post --tags="version:1,application:web" --no_host --type=my_apps --aggregation_key=application:web --alert_type=info "Something big happened!" "And let me tell you all about it here!"
 ```
 
 ### Nested Commands
@@ -145,7 +145,7 @@ pup infrastructure hosts list
 - **dbm** - Database Monitoring query samples (samples search)
 - **traces** - APM spans metrics (list, get, create, update, delete)
 - **rum** - Real User Monitoring (apps, metrics, retention-filters, sessions)
-- **events** - Infrastructure events (list, search, get)
+- **events** - Infrastructure events (post, list, search, get)
 - **ddsql** - DDSQL queries and discovery (table, time-series, spec, schema)
 - **symdb** - Symbol Database queries (search scopes, probe locations)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -118,6 +118,7 @@ pup metrics query --query="avg:system.cpu.user{*}" --from="1h"
 pup metrics tags list system.cpu.user --window-seconds=3600
 pup metrics timeseries --file=request.json
 pup events search --query="@user.id:12345"
+pup events post --tags="version:1,application:web" --no_host --type=my_apps --aggregation_key=application:web --alert_type=info "Something big happened!" "And let me tell you all about it here!"
 ```
 
 ### Create/Update/Delete

--- a/src/client.rs
+++ b/src/client.rs
@@ -724,6 +724,14 @@ static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
         path: "/api/ui/profiling/",
         method: "GET",
     },
+    // Events intake (1)
+    // Posting an event uses the V1 intake endpoint, which authenticates with the
+    // API key and does not accept OAuth2 bearer tokens. Listing/getting events
+    // (GET) is fine over OAuth, so only POST is excluded.
+    EndpointRequirement {
+        path: "/api/v1/events",
+        method: "POST",
+    },
 ];
 
 // ---------------------------------------------------------------------------
@@ -1289,6 +1297,13 @@ mod tests {
     }
 
     #[test]
+    fn test_fallback_for_events_post() {
+        // Posting an event (V1 intake) requires API keys; reading events does not.
+        assert!(requires_api_key_fallback("POST", "/api/v1/events"));
+        assert!(!requires_api_key_fallback("GET", "/api/v1/events"));
+    }
+
+    #[test]
     fn test_no_fallback_for_standard_endpoints() {
         assert!(!requires_api_key_fallback("GET", "/api/v1/monitor"));
         assert!(!requires_api_key_fallback("GET", "/api/v1/dashboard"));
@@ -1324,7 +1339,7 @@ mod tests {
 
     #[test]
     fn test_oauth_excluded_count() {
-        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 54);
+        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 55);
     }
 
     #[test]

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,6 +1,8 @@
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 
-use anyhow::{Context, Result};
+#[cfg(not(target_arch = "wasm32"))]
+use anyhow::Context;
+use anyhow::Result;
 use datadog_api_client::datadogV1::api_events::{
     EventsAPI as EventsV1API, ListEventsOptionalParams,
 };
@@ -66,8 +68,19 @@ pub(crate) struct PostOptions {
 }
 
 pub async fn post(cfg: &Config, mut options: PostOptions) -> Result<()> {
-    let api = crate::make_api!(EventsV1API, cfg);
-    let message = resolve_message(options.message.take(), std::io::stdin().lock())?;
+    // The V1 events intake endpoint (POST /api/v1/events) authenticates with the
+    // API key and does not accept OAuth2 bearer tokens, so require API+APP keys up
+    // front and skip bearer auth on the request.
+    cfg.validate_api_and_app_keys()?;
+    if options.title.trim().is_empty() {
+        anyhow::bail!("event title is empty");
+    }
+    let api = crate::make_api_no_auth!(EventsV1API, cfg);
+    let message = resolve_message(
+        options.message.take(),
+        std::io::stdin().is_terminal(),
+        std::io::stdin().lock(),
+    )?;
     let body = build_post_request(options, message);
     let resp = api
         .create_event(body)
@@ -76,48 +89,80 @@ pub async fn post(cfg: &Config, mut options: PostOptions) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
-pub(crate) fn resolve_host(host: String, no_host: bool) -> Result<Option<String>> {
-    resolve_host_with(host, no_host, || {
-        let output = std::process::Command::new("hostname")
-            .output()
-            .context("failed to determine local hostname")?;
-        if !output.status.success() {
-            anyhow::bail!("failed to determine local hostname");
-        }
+pub(crate) fn resolve_host(host: String, no_host: bool) -> Option<String> {
+    resolve_host_with(host, no_host, local_hostname)
+}
 
-        let hostname =
-            String::from_utf8(output.stdout).context("local hostname is not valid UTF-8")?;
-        let hostname = hostname.trim();
-        if hostname.is_empty() {
-            anyhow::bail!("local hostname is empty");
-        }
-        Ok(hostname.to_owned())
-    })
+// `gethostname` is a native-only dependency (the `events` module still compiles
+// for wasm32), so keep the wasm path a graceful failure that falls back to no host.
+#[cfg(not(target_arch = "wasm32"))]
+fn local_hostname() -> Result<String> {
+    let hostname = gethostname::gethostname();
+    let hostname = hostname
+        .to_str()
+        .context("local hostname is not valid UTF-8")?
+        .trim();
+    if hostname.is_empty() {
+        anyhow::bail!("local hostname is empty");
+    }
+    Ok(hostname.to_owned())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn local_hostname() -> Result<String> {
+    anyhow::bail!("local hostname lookup is not supported on this platform")
 }
 
 fn resolve_host_with(
     host: String,
     no_host: bool,
     local_hostname: impl FnOnce() -> Result<String>,
-) -> Result<Option<String>> {
+) -> Option<String> {
     if no_host {
-        Ok(None)
+        None
     } else if host.is_empty() {
-        local_hostname().map(Some)
+        // Default to the local hostname, but a lookup failure (e.g. a non-UTF-8
+        // hostname) must not abort the whole command — post without a host instead.
+        match local_hostname() {
+            Ok(hostname) => Some(hostname),
+            Err(e) => {
+                eprintln!(
+                    "warning: could not determine local hostname ({e}); posting event \
+                     without a host (use --host to set one or --no_host to silence this)"
+                );
+                None
+            }
+        }
     } else {
-        Ok(Some(host))
+        Some(host)
     }
 }
 
-fn resolve_message(message: Option<String>, mut reader: impl Read) -> Result<String> {
-    if let Some(message) = message {
-        return Ok(message);
-    }
+fn resolve_message(
+    message: Option<String>,
+    stdin_is_tty: bool,
+    reader: impl Read,
+) -> Result<String> {
+    let message = match message {
+        Some(message) => message,
+        None => {
+            // Only read stdin when it is piped; reading an interactive terminal
+            // would block forever waiting for EOF.
+            if stdin_is_tty {
+                anyhow::bail!(
+                    "no event message provided: pass it as an argument or pipe it via stdin"
+                );
+            }
+            let buf = util::read_to_string(reader, "failed to read event message from stdin")?;
+            // Drop the trailing newline shells add to piped input so stdin and
+            // argument messages produce the same event text.
+            buf.trim_end().to_owned()
+        }
+    };
 
-    let mut message = String::new();
-    reader
-        .read_to_string(&mut message)
-        .context("failed to read event message from stdin")?;
+    if message.trim().is_empty() {
+        anyhow::bail!("event message is empty");
+    }
     Ok(message)
 }
 
@@ -126,7 +171,13 @@ fn build_post_request(options: PostOptions, message: String) -> EventCreateReque
         EventCreateRequest::new(message, options.title).priority(Some(options.priority.into()));
 
     if let Some(tags) = options.tags {
-        body = body.tags(tags.split(',').map(str::trim).map(str::to_owned).collect());
+        body = body.tags(
+            tags.split(',')
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .map(str::to_owned)
+                .collect(),
+        );
     }
     if let Some(host) = options.host {
         body = body.host(host);
@@ -295,6 +346,81 @@ mod tests {
         cleanup_env();
     }
 
+    #[tokio::test]
+    async fn test_events_post_includes_host_in_payload() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", "/api/v1/events")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "host": "resolved-host",
+                "text": "Test message",
+                "title": "Test title"
+            })))
+            .with_status(202)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"status":"ok","event":{"id":12345}}"#)
+            .create_async()
+            .await;
+
+        let mut options = post_options();
+        options.host = Some("resolved-host".into());
+        let result = super::post(&cfg, options).await;
+        assert!(
+            result.is_ok(),
+            "events post with host failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_events_post_requires_api_keys() {
+        // The V1 events intake endpoint rejects OAuth2 bearer tokens, so posting
+        // must fail fast when only an access token is configured. This is caught
+        // before any request, so no mock server or env setup is needed.
+        let cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: Some("token".into()),
+            site: "datadoghq.com".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+            jq: None,
+        };
+
+        let result = super::post(&cfg, post_options()).await;
+        assert!(result.is_err(), "events post should require API keys");
+    }
+
+    #[tokio::test]
+    async fn test_events_post_rejects_empty_title() {
+        // Title emptiness is checked before any request, so no server is needed.
+        let cfg = Config {
+            api_key: Some("test-api-key".into()),
+            app_key: Some("test-app-key".into()),
+            access_token: None,
+            site: "datadoghq.com".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+            jq: None,
+        };
+
+        let mut options = post_options();
+        options.title = "   ".into();
+        let result = super::post(&cfg, options).await;
+        assert!(result.is_err(), "empty title should be rejected");
+    }
+
     #[test]
     fn test_events_post_accepts_dogshell_flag_names() {
         let result = crate::Cli::try_parse_from([
@@ -361,8 +487,46 @@ mod tests {
     #[test]
     fn test_events_post_reads_message_from_stdin() {
         let message =
-            super::resolve_message(None, std::io::Cursor::new("Message from stdin")).unwrap();
+            super::resolve_message(None, false, std::io::Cursor::new("Message from stdin"))
+                .unwrap();
         assert_eq!(message, "Message from stdin");
+    }
+
+    #[test]
+    fn test_events_post_errors_on_tty_without_message() {
+        // An interactive terminal with no message must error instead of blocking.
+        let result = super::resolve_message(None, true, std::io::empty());
+        assert!(result.is_err(), "TTY stdin with no message should error");
+    }
+
+    #[test]
+    fn test_events_post_rejects_empty_message() {
+        let from_stdin = super::resolve_message(None, false, std::io::Cursor::new("   \n"));
+        assert!(
+            from_stdin.is_err(),
+            "blank stdin message should be rejected"
+        );
+        let from_arg = super::resolve_message(Some(String::new()), false, std::io::empty());
+        assert!(
+            from_arg.is_err(),
+            "empty message argument should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_events_post_trims_trailing_newline_from_stdin() {
+        let message =
+            super::resolve_message(None, false, std::io::Cursor::new("Message from stdin\n"))
+                .unwrap();
+        assert_eq!(message, "Message from stdin");
+    }
+
+    #[test]
+    fn test_events_post_filters_empty_tags() {
+        let mut options = post_options();
+        options.tags = Some("a,, b ,".into());
+        let body = super::build_post_request(options, "msg".into());
+        assert_eq!(body.tags, Some(vec!["a".to_string(), "b".to_string()]));
     }
 
     #[test]
@@ -370,15 +534,13 @@ mod tests {
         assert_eq!(
             super::resolve_host_with("test-host".into(), true, || {
                 panic!("hostname lookup must not run")
-            })
-            .unwrap(),
+            }),
             None
         );
         assert_eq!(
             super::resolve_host_with("test-host".into(), false, || {
                 panic!("hostname lookup must not run")
-            })
-            .unwrap(),
+            }),
             Some("test-host".into())
         );
     }
@@ -386,17 +548,20 @@ mod tests {
     #[test]
     fn test_events_post_defaults_to_local_host() {
         assert_eq!(
-            super::resolve_host_with(String::new(), false, || Ok("local-host".into())).unwrap(),
+            super::resolve_host_with(String::new(), false, || Ok("local-host".into())),
             Some("local-host".into())
         );
     }
 
     #[test]
-    fn test_events_post_reports_local_host_error() {
-        let result = super::resolve_host_with(String::new(), false, || {
-            anyhow::bail!("hostname unavailable")
-        });
-        assert!(result.is_err(), "hostname errors should be reported");
+    fn test_events_post_falls_back_to_no_host_when_lookup_fails() {
+        // A hostname lookup failure must not abort the post; fall back to no host.
+        assert_eq!(
+            super::resolve_host_with(String::new(), false, || {
+                anyhow::bail!("hostname unavailable")
+            }),
+            None
+        );
     }
 
     #[tokio::test]

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,7 +1,10 @@
-use anyhow::Result;
+use std::io::Read;
+
+use anyhow::{Context, Result};
 use datadog_api_client::datadogV1::api_events::{
     EventsAPI as EventsV1API, ListEventsOptionalParams,
 };
+use datadog_api_client::datadogV1::model::{EventAlertType, EventCreateRequest, EventPriority};
 use datadog_api_client::datadogV2::api_events::{
     EventsAPI as EventsV2API, SearchEventsOptionalParams,
 };
@@ -12,6 +15,147 @@ use datadog_api_client::datadogV2::model::{
 use crate::config::Config;
 use crate::formatter;
 use crate::util;
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub(crate) enum EventAlertTypeArg {
+    Error,
+    Warning,
+    Info,
+    Success,
+}
+
+impl From<EventAlertTypeArg> for EventAlertType {
+    fn from(value: EventAlertTypeArg) -> Self {
+        match value {
+            EventAlertTypeArg::Error => Self::ERROR,
+            EventAlertTypeArg::Warning => Self::WARNING,
+            EventAlertTypeArg::Info => Self::INFO,
+            EventAlertTypeArg::Success => Self::SUCCESS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub(crate) enum EventPriorityArg {
+    Normal,
+    Low,
+}
+
+impl From<EventPriorityArg> for EventPriority {
+    fn from(value: EventPriorityArg) -> Self {
+        match value {
+            EventPriorityArg::Normal => Self::NORMAL,
+            EventPriorityArg::Low => Self::LOW,
+        }
+    }
+}
+
+pub(crate) struct PostOptions {
+    pub title: String,
+    pub message: Option<String>,
+    pub date_happened: Option<i64>,
+    pub handle: Option<String>,
+    pub priority: EventPriorityArg,
+    pub related_event_id: Option<i64>,
+    pub tags: Option<String>,
+    pub host: Option<String>,
+    pub device: Option<String>,
+    pub event_type: Option<String>,
+    pub aggregation_key: Option<String>,
+    pub alert_type: Option<EventAlertTypeArg>,
+}
+
+pub async fn post(cfg: &Config, mut options: PostOptions) -> Result<()> {
+    let api = crate::make_api!(EventsV1API, cfg);
+    let message = resolve_message(options.message.take(), std::io::stdin().lock())?;
+    let body = build_post_request(options, message);
+    let resp = api
+        .create_event(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to post event: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub(crate) fn resolve_host(host: String, no_host: bool) -> Result<Option<String>> {
+    resolve_host_with(host, no_host, || {
+        let output = std::process::Command::new("hostname")
+            .output()
+            .context("failed to determine local hostname")?;
+        if !output.status.success() {
+            anyhow::bail!("failed to determine local hostname");
+        }
+
+        let hostname =
+            String::from_utf8(output.stdout).context("local hostname is not valid UTF-8")?;
+        let hostname = hostname.trim();
+        if hostname.is_empty() {
+            anyhow::bail!("local hostname is empty");
+        }
+        Ok(hostname.to_owned())
+    })
+}
+
+fn resolve_host_with(
+    host: String,
+    no_host: bool,
+    local_hostname: impl FnOnce() -> Result<String>,
+) -> Result<Option<String>> {
+    if no_host {
+        Ok(None)
+    } else if host.is_empty() {
+        local_hostname().map(Some)
+    } else {
+        Ok(Some(host))
+    }
+}
+
+fn resolve_message(message: Option<String>, mut reader: impl Read) -> Result<String> {
+    if let Some(message) = message {
+        return Ok(message);
+    }
+
+    let mut message = String::new();
+    reader
+        .read_to_string(&mut message)
+        .context("failed to read event message from stdin")?;
+    Ok(message)
+}
+
+fn build_post_request(options: PostOptions, message: String) -> EventCreateRequest {
+    let mut body =
+        EventCreateRequest::new(message, options.title).priority(Some(options.priority.into()));
+
+    if let Some(tags) = options.tags {
+        body = body.tags(tags.split(',').map(str::trim).map(str::to_owned).collect());
+    }
+    if let Some(host) = options.host {
+        body = body.host(host);
+    }
+    if let Some(date_happened) = options.date_happened {
+        body = body.date_happened(date_happened);
+    }
+    if let Some(handle) = options.handle {
+        body.additional_properties
+            .insert("handle".into(), serde_json::Value::String(handle));
+    }
+    if let Some(related_event_id) = options.related_event_id {
+        body = body.related_event_id(related_event_id);
+    }
+    if let Some(device) = options.device {
+        body = body.device_name(device);
+    }
+    if let Some(event_type) = options.event_type {
+        body = body.source_type_name(event_type);
+    }
+    if let Some(aggregation_key) = options.aggregation_key {
+        body = body.aggregation_key(aggregation_key);
+    }
+    if let Some(alert_type) = options.alert_type {
+        body = body.alert_type(alert_type.into());
+    }
+
+    body
+}
 
 pub async fn list(cfg: &Config, start: i64, end: i64, tags: Option<String>) -> Result<()> {
     let api = crate::make_api!(EventsV1API, cfg);
@@ -83,6 +227,177 @@ mod tests {
 
     use crate::config::{Config, OutputFormat};
     use crate::test_support::*;
+    use clap::Parser;
+
+    fn post_options() -> super::PostOptions {
+        super::PostOptions {
+            title: "Test title".into(),
+            message: Some("Test message".into()),
+            date_happened: Some(1_700_000_000),
+            handle: Some("test-user".into()),
+            priority: super::EventPriorityArg::Low,
+            related_event_id: Some(42),
+            tags: Some("test:first, test:second".into()),
+            host: None,
+            device: Some("test-device".into()),
+            event_type: Some("test-source".into()),
+            aggregation_key: Some("test-group".into()),
+            alert_type: Some(super::EventAlertTypeArg::Warning),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_events_post_sends_dogshell_fields_without_host() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", "/api/v1/events")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "aggregation_key": "test-group",
+                "alert_type": "warning",
+                "date_happened": 1_700_000_000,
+                "device_name": "test-device",
+                "handle": "test-user",
+                "priority": "low",
+                "related_event_id": 42,
+                "source_type_name": "test-source",
+                "tags": ["test:first", "test:second"],
+                "text": "Test message",
+                "title": "Test title"
+            })))
+            .with_status(202)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"status":"ok","event":{"id":12345}}"#)
+            .create_async()
+            .await;
+
+        let result = super::post(&cfg, post_options()).await;
+        assert!(result.is_ok(), "events post failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_events_post_reports_api_error() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", "/api/v1/events")
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["Bad Request"]}"#)
+            .create_async()
+            .await;
+
+        let result = super::post(&cfg, post_options()).await;
+        assert!(result.is_err(), "events post should report API errors");
+        cleanup_env();
+    }
+
+    #[test]
+    fn test_events_post_accepts_dogshell_flag_names() {
+        let result = crate::Cli::try_parse_from([
+            "pup",
+            "events",
+            "post",
+            "--date_happened",
+            "1700000000",
+            "--handle",
+            "test-user",
+            "--priority",
+            "low",
+            "--related_event_id",
+            "42",
+            "--tags",
+            "test:first,test:second",
+            "--host",
+            "ignored-host",
+            "--no_host",
+            "--device",
+            "test-device",
+            "--type",
+            "test-source",
+            "--aggregation_key",
+            "test-group",
+            "--alert_type",
+            "warning",
+            "Test title",
+        ]);
+
+        assert!(result.is_ok(), "dogshell flags should parse");
+    }
+
+    #[test]
+    fn test_events_post_rejects_invalid_alert_type() {
+        let result = crate::Cli::try_parse_from([
+            "pup",
+            "events",
+            "post",
+            "--alert_type",
+            "critical",
+            "Test title",
+            "Test message",
+        ]);
+
+        assert!(result.is_err(), "invalid alert type should be rejected");
+    }
+
+    #[test]
+    fn test_events_post_rejects_invalid_priority() {
+        let result = crate::Cli::try_parse_from([
+            "pup",
+            "events",
+            "post",
+            "--priority",
+            "urgent",
+            "Test title",
+            "Test message",
+        ]);
+
+        assert!(result.is_err(), "invalid priority should be rejected");
+    }
+
+    #[test]
+    fn test_events_post_reads_message_from_stdin() {
+        let message =
+            super::resolve_message(None, std::io::Cursor::new("Message from stdin")).unwrap();
+        assert_eq!(message, "Message from stdin");
+    }
+
+    #[test]
+    fn test_events_post_no_host_overrides_host() {
+        assert_eq!(
+            super::resolve_host_with("test-host".into(), true, || {
+                panic!("hostname lookup must not run")
+            })
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            super::resolve_host_with("test-host".into(), false, || {
+                panic!("hostname lookup must not run")
+            })
+            .unwrap(),
+            Some("test-host".into())
+        );
+    }
+
+    #[test]
+    fn test_events_post_defaults_to_local_host() {
+        assert_eq!(
+            super::resolve_host_with(String::new(), false, || Ok("local-host".into())).unwrap(),
+            Some("local-host".into())
+        );
+    }
+
+    #[test]
+    fn test_events_post_reports_local_host_error() {
+        let result = super::resolve_host_with(String::new(), false, || {
+            anyhow::bail!("hostname unavailable")
+        });
+        assert!(result.is_err(), "hostname errors should be reported");
+    }
 
     #[tokio::test]
     async fn test_events_list() {

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -28,17 +28,11 @@ pub fn run(
 /// Read the JSON document from a file (`Some(path)` other than `"-"`) or from the
 /// provided reader (`None` or `"-"`, i.e. stdin). The reader is a parameter so the
 /// stdin path can be tested without touching the process's real stdin.
-fn read_input(input: Option<&str>, mut reader: impl Read) -> Result<String> {
+fn read_input(input: Option<&str>, reader: impl Read) -> Result<String> {
     match input {
         Some(path) if path != "-" => std::fs::read_to_string(path)
             .map_err(|e| anyhow::anyhow!("failed to read --input {path:?}: {e}")),
-        _ => {
-            let mut buf = String::new();
-            reader
-                .read_to_string(&mut buf)
-                .context("failed to read JSON from stdin")?;
-            Ok(buf)
-        }
+        _ => crate::util::read_to_string(reader, "failed to read JSON from stdin"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4080,7 +4080,7 @@ enum EventActions {
         #[arg(
             long,
             default_value = "",
-            help = "Host to associate with the event; defaults to the local hostname"
+            help = "Host to associate with the event; defaults to the local hostname when it can be determined"
         )]
         host: String,
         #[arg(
@@ -10654,6 +10654,7 @@ pub(crate) fn is_write_command_name(name: &str) -> bool {
         || name.starts_with("create-")
         || name.ends_with("-create")
         || name == "submit"
+        || name == "post"
         || name == "send"
         || name == "import"
         || name == "register"
@@ -10827,6 +10828,18 @@ mod test_agent_schema {
     fn schema_has_commands_array() {
         let schema = get_schema();
         assert!(schema.get("commands").and_then(|v| v.as_array()).is_some());
+    }
+
+    #[test]
+    fn events_post_is_classified_as_write() {
+        // Regression: the "post" verb must count as a write so read-only mode
+        // blocks it and the agent schema does not advertise it as read-only.
+        assert!(is_write_command_name("post"));
+
+        let schema = get_schema();
+        let commands = schema["commands"].as_array().unwrap();
+        let cmd = find_command(commands, &["events", "post"]).expect("events post not found");
+        assert_eq!(cmd["read_only"].as_bool(), Some(false));
     }
 
     #[test]
@@ -12497,7 +12510,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             priority,
                             related_event_id,
                             tags,
-                            host: commands::events::resolve_host(host, no_host)?,
+                            host: commands::events::resolve_host(host, no_host),
                             device,
                             event_type,
                             aggregation_key,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1255,17 +1255,23 @@ enum Commands {
     },
     /// Manage Datadog events
     ///
-    /// Query and search Datadog events.
+    /// Post, query, and search Datadog events.
     ///
     /// Events represent important occurrences in your infrastructure such as
     /// deployments, configuration changes, alerts, and custom events.
     ///
     /// CAPABILITIES:
+    ///   • Post custom events
     ///   • List recent events
     ///   • Search events with queries
     ///   • Get event details
     ///
     /// EXAMPLES:
+    ///   # Post an event using dogshell-compatible flags
+    ///   pup events post --tags="version:1,application:web" --no_host --type=my_apps \
+    ///     --aggregation_key=application:web --alert_type=info \
+    ///     "Something big happened!" "And let me tell you all about it here!"
+    ///
     ///   # List recent events
     ///   pup events list
     ///
@@ -4051,6 +4057,56 @@ enum TestOptimizationFlakyTestsPoliciesActions {
 // ---- Events ----
 #[derive(Subcommand)]
 enum EventActions {
+    /// Post an event
+    Post {
+        #[arg(help = "Event title")]
+        title: String,
+        #[arg(help = "Event message body; reads from stdin when omitted")]
+        message: Option<String>,
+        #[arg(
+            long,
+            visible_alias = "date_happened",
+            help = "POSIX timestamp when the event occurred"
+        )]
+        date_happened: Option<i64>,
+        #[arg(long, help = "User to post the event as")]
+        handle: Option<String>,
+        #[arg(long, value_enum, default_value = "normal", help = "Event priority")]
+        priority: commands::events::EventPriorityArg,
+        #[arg(long, visible_alias = "related_event_id", help = "Parent event ID")]
+        related_event_id: Option<i64>,
+        #[arg(long, help = "Comma-separated event tags")]
+        tags: Option<String>,
+        #[arg(
+            long,
+            default_value = "",
+            help = "Host to associate with the event; defaults to the local hostname"
+        )]
+        host: String,
+        #[arg(
+            long,
+            visible_alias = "no_host",
+            help = "Do not associate a host with the event; overrides --host"
+        )]
+        no_host: bool,
+        #[arg(long, help = "Device to associate with the event")]
+        device: Option<String>,
+        #[arg(long = "type", help = "Event source type")]
+        event_type: Option<String>,
+        #[arg(
+            long,
+            visible_alias = "aggregation_key",
+            help = "Key used to aggregate related events"
+        )]
+        aggregation_key: Option<String>,
+        #[arg(
+            long,
+            visible_alias = "alert_type",
+            value_enum,
+            help = "Event alert type"
+        )]
+        alert_type: Option<commands::events::EventAlertTypeArg>,
+    },
     /// List recent events
     List {
         #[arg(
@@ -12416,6 +12472,40 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::Events { action } => {
             cfg.validate_auth()?;
             match action {
+                EventActions::Post {
+                    title,
+                    message,
+                    date_happened,
+                    handle,
+                    priority,
+                    related_event_id,
+                    tags,
+                    host,
+                    no_host,
+                    device,
+                    event_type,
+                    aggregation_key,
+                    alert_type,
+                } => {
+                    commands::events::post(
+                        &cfg,
+                        commands::events::PostOptions {
+                            title,
+                            message,
+                            date_happened,
+                            handle,
+                            priority,
+                            related_event_id,
+                            tags,
+                            host: commands::events::resolve_host(host, no_host)?,
+                            device,
+                            event_type,
+                            aggregation_key,
+                            alert_type,
+                        },
+                    )
+                    .await?;
+                }
                 EventActions::List { from, to, tags, .. } => {
                     let start = util::parse_time_to_unix_millis(&from)? / 1000;
                     let end = util::parse_time_to_unix_millis(&to)? / 1000;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use anyhow::{bail, Result};
 use chrono::Utc;
 use regex::Regex;
@@ -127,6 +129,19 @@ pub fn parse_duration_to_millis(input: &str) -> Result<i64> {
 
 pub fn now_millis() -> i64 {
     Utc::now().timestamp() * 1000
+}
+
+/// Read an entire reader into a `String`, attaching `err_context` on I/O failure.
+///
+/// Shared by commands that accept stdin input (e.g. `format::read_input` and
+/// `events::resolve_message`) so the read-and-contextualize pattern lives in one
+/// place instead of being duplicated per command.
+pub fn read_to_string(mut reader: impl Read, err_context: &str) -> Result<String> {
+    let mut buf = String::new();
+    reader
+        .read_to_string(&mut buf)
+        .map_err(|e| anyhow::anyhow!("{err_context}: {e}"))?;
+    Ok(buf)
 }
 
 /// Read a JSON file and deserialize into the specified type.


### PR DESCRIPTION
## What does this PR do?

Adds `pup events post` with feature parity for the dogshell event post command. The new command maps all supported post fields to the Datadog V1 Events API, supports messages from either an argument or stdin, defaults to the local hostname, and allows `--no_host` to suppress host association.

## Motivation

Pup could list, search, and retrieve events but could not create them. This change enables existing dogshell users to migrate event-posting workflows to pup without losing supported fields or behavior.

## Additional Notes

- Dogshell underscore-style flags such as `--no_host`, `--aggregation_key`, and `--alert_type` are accepted alongside clap's hyphenated forms.
- Alert type and priority values are validated by clap before sending a request.
- The focused event suite passes 13 tests, including payload matching, API errors, invalid arguments, stdin input, local-host defaults, and `--no_host` overrides.
- `cargo clippy --tests -- -D warnings` and `cargo fmt --check` pass.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

N/A

---
Generated with [GitHub Copilot](https://github.com/features/copilot)