### PR TITLE
scaffold generated CLI integration point in main.rs

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -1,0 +1,15 @@
+// Stable integration point for openapi-transformer-generated pup commands.
+//
+// Future regenerations add variants to `GeneratedCommand` (and new modules
+// alongside this file) in place; main.rs never needs to change again.
+
+use anyhow::Result;
+
+use crate::config::Config;
+
+#[derive(clap::Subcommand)]
+pub enum GeneratedCommand {}
+
+pub async fn run(_cfg: &Config, command: GeneratedCommand) -> Result<()> {
+    match command {}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod extensions;
 mod filter;
 mod formatter;
+mod generated;
 #[cfg(not(target_arch = "wasm32"))]
 mod runbooks;
 #[cfg(not(target_arch = "wasm32"))]
@@ -2865,6 +2866,8 @@ enum Commands {
         #[command(subcommand)]
         action: WorkflowActions,
     },
+    #[command(flatten)]
+    Generated(generated::GeneratedCommand),
 }
 
 // ---- Extensions ----
@@ -15905,6 +15908,11 @@ async fn main_inner() -> anyhow::Result<()> {
                 }
             },
         },
+        // --- Generated ---
+        Commands::Generated(action) => {
+            cfg.validate_auth()?;
+            generated::run(&cfg, action).await?;
+        }
         // --- LLM Observability ---
         Commands::LlmObs { action } => {
             cfg.validate_auth()?;


### PR DESCRIPTION
## Context

openapi-transformer will regenerate pup CLI command modules from the OpenAPI spec into src/generated.rs — DataDog/pup#651 is the pilot run for this pipeline. This PR lands the main.rs wiring ahead of that so the integration point is stable: every future openapi-transformer regeneration only adds variants to GeneratedCommand (and sibling modules) inside generated.rs, and main.rs never needs to change again.

## Changes

Added mod generated alongside the other top-level module declarations, and flattened GeneratedCommand into the Commands enum with #[command(flatten)] rather than nesting it under a pup generated subcommand — generated subcommands will appear as top-level peers (e.g. pup downtime get ...), matching how every other domain is exposed today. Routed the new arm through main_inner() following the existing per-domain pattern (cfg.validate_auth() then dispatch).

src/generated.rs here is a placeholder with an empty GeneratedCommand enum, not #651's actual generated output. #651 introduces a generated Downtime variant that collides on the subcommand name with pup's existing hand-written top-level downtime command (list/get/create/cancel): clap panics at runtime with "command name `downtime` is duplicated" on any invocation that builds the full Command tree. That collision needs a product decision — retire/merge the hand-written downtime command, or pick a different pilot operation upstream in datadog-api-spec — before any generated variants can land. This PR only establishes the scaffold; once that decision is made, #651 becomes a pure additive diff to generated.rs and its sibling modules, with no main.rs changes required.

## Tests

- cargo build, cargo clippy --all-targets -- -D warnings, and cargo fmt --check all pass.
- cargo test passes except 4 pre-existing failures unrelated to this change (DNS lookup failures against unused.local in commands::cases, commands::dbm, commands::monitors, commands::traces tests) — confirmed identical on a clean main checkout.
- Manually confirmed pup --no-agent --help renders without panicking (no subcommand collision, since the placeholder enum has zero variants).