### PR TITLE
Add octo-sts trust policy for datadog-api-spec merge-dependents

### DIFF
--- a/.github/chainguard/datadog-api-spec.merge-queue.merge-dependents.sts.yaml
+++ b/.github/chainguard/datadog-api-spec.merge-queue.merge-dependents.sts.yaml
@@ -1,0 +1,16 @@
+# Policy for: .github/workflows/merge-queue.yml (pipeline merge-dependents step) in DataDog/datadog-api-spec.
+# Sibling to datadog-api-spec.ci-cd.generate: that policy trusts the PR-time generation workflow
+# (ci-cd.yml on pull_request); this one trusts the merge-queue workflow that, at merge time, repoints
+# pup's Cargo.toml at the just-merged Rust client commit and merges pup's generated PR.
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:DataDog/datadog-api-spec:ref:refs/heads/mq-working-branch-.*
+
+claim_pattern:
+  event_name: push
+  ref: refs/heads/mq-working-branch-.*
+  job_workflow_ref: DataDog/datadog-api-spec/\.github/workflows/merge-queue\.yml@.*
+  repository: DataDog/datadog-api-spec
+
+permissions:
+  contents: write
+  pull_requests: write


### PR DESCRIPTION
## Context

datadog-api-spec generates pup's CLI commands from the OpenAPI spec and pushes them here as PRs. When a spec PR also regenerates the Rust client (`datadog-api-client`, pinned in `Cargo.toml` by commit `rev`), pup must be repointed at the new Rust commit before/at merge. datadog-api-spec's merge queue now runs a `pipeline merge-dependents` step (in `.github/workflows/merge-queue.yml`) that, after the Rust client merges, rewrites pup's `Cargo.toml` `rev` and merges pup's generated PR. That step authenticates to pup with an octo-sts token, which requires a trust policy in this repo.

This is the merge-time sibling of the existing `.github/chainguard/datadog-api-spec.ci-cd.generate.sts.yaml`. That policy trusts the PR-time generation workflow (`ci-cd.yml` on `pull_request`); this one trusts the merge-queue workflow (`merge-queue.yml` on `push` to the MergeQueue working branch). They must be separate because the event and workflow differ.

## Changes

Adds one octo-sts trust policy: `.github/chainguard/datadog-api-spec.merge-queue.merge-dependents.sts.yaml`, granting `contents: write` and `pull_requests: write` to the `merge-queue.yml` workflow running on `mq-working-branch-*` refs in DataDog/datadog-api-spec.

Required for datadog-api-spec's pup generation merge step to authenticate and land the repointed Cargo.toml.