### PR TITLE
chore(deps): bump datadog-api-client-rust to v0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1041,8 +1041,8 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datadog-api-client"
-version = "0.32.0"
-source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=b769778d0c58806b615165fb444e6f02dc2e86c0#b769778d0c58806b615165fb444e6f02dc2e86c0"
+version = "0.33.0"
+source = "git+https://github.com/DataDog/datadog-api-client-rust?rev=192bab111da84a83968b12528e4bc6bab7ac94a9#192bab111da84a83968b12528e4bc6bab7ac94a9"
 dependencies = [
  "async-stream",
  "chrono",
@@ -1187,7 +1187,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3458,7 +3458,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3957,7 +3957,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4014,7 +4014,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4723,7 +4723,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5408,7 +5408,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,9 +133,9 @@ flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
 zip = { version = "8", default-features = false, features = ["deflate"], optional = true }
 
-# Datadog API client — pinned to 0.32.0 tag
+# Datadog API client — pinned to 0.33.0 tag
 # Use default-features = false; feature sets are activated per-target via features above
-datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "b769778d0c58806b615165fb444e6f02dc2e86c0", optional = true, default-features = false }
+datadog-api-client = { git = "https://github.com/DataDog/datadog-api-client-rust", rev = "192bab111da84a83968b12528e4bc6bab7ac94a9", optional = true, default-features = false }
 
 # HTTP middleware (version-matched to DD client; compiles on all targets)
 reqwest-middleware = "0.5"

--- a/src/commands/code_coverage.rs
+++ b/src/commands/code_coverage.rs
@@ -13,7 +13,7 @@ use crate::formatter;
 pub async fn branch_summary(cfg: &Config, repo: String, branch: String) -> Result<()> {
     let api = crate::make_api!(CodeCoverageAPI, cfg);
     let body = BranchCoverageSummaryRequest::new(BranchCoverageSummaryRequestData::new(
-        BranchCoverageSummaryRequestAttributes::new(branch, repo),
+        BranchCoverageSummaryRequestAttributes::new(branch).repository_url(repo),
         BranchCoverageSummaryRequestType::CI_APP_COVERAGE_BRANCH_SUMMARY_REQUEST,
     ));
     let resp = api
@@ -26,7 +26,7 @@ pub async fn branch_summary(cfg: &Config, repo: String, branch: String) -> Resul
 pub async fn commit_summary(cfg: &Config, repo: String, commit: String) -> Result<()> {
     let api = crate::make_api!(CodeCoverageAPI, cfg);
     let body = CommitCoverageSummaryRequest::new(CommitCoverageSummaryRequestData::new(
-        CommitCoverageSummaryRequestAttributes::new(commit, repo),
+        CommitCoverageSummaryRequestAttributes::new(commit).repository_url(repo),
         CommitCoverageSummaryRequestType::CI_APP_COVERAGE_COMMIT_SUMMARY_REQUEST,
     ));
     let resp = api


### PR DESCRIPTION
## Context

Routine update of the pinned `datadog-api-client-rust` SDK rev from `b769778d` (v0.32.0) to `192bab11` (v0.33.0), the latest commit on the SDK repo.

## Changes

`BranchCoverageSummaryRequestAttributes::new` and `CommitCoverageSummaryRequestAttributes::new` dropped their second positional `repository_id` argument — the SDK deprecated that field in favor of `repository_url`. Updated `src/commands/code_coverage.rs` to set the repo value via the new `.repository_url(...)` builder method instead of the deprecated `repository_id`, rather than reintroducing the deprecated field.

## Tests

`cargo build`, `cargo test` (full suite passes; 4 tests failed only under parallel execution due to pre-existing port/DNS contention unrelated to this change, confirmed passing individually with `--test-threads=1`), `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` all pass.