### PR TITLE
feat(security): add --page-size and --page-number to rules list

### DIFF
--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -170,9 +170,17 @@ pub async fn findings_analyze(
     }
 }
 
-pub async fn rules_list(cfg: &Config, filter: Option<String>, sort: Option<String>) -> Result<()> {
+pub async fn rules_list(
+    cfg: &Config,
+    filter: Option<String>,
+    sort: Option<String>,
+    page_size: i64,
+    page_number: i64,
+) -> Result<()> {
     let api = crate::make_api!(SecurityMonitoringAPI, cfg);
-    let mut params = ListSecurityMonitoringRulesOptionalParams::default();
+    let mut params = ListSecurityMonitoringRulesOptionalParams::default()
+        .page_size(page_size)
+        .page_number(page_number);
     if let Some(s) = sort {
         params = params.sort(parse_rule_sort(&s));
     }
@@ -758,7 +766,17 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::rules_list(&cfg, None, None).await;
+        let _ = super::rules_list(&cfg, None, None, 25, 0).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_security_rules_list_with_pagination() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let _ = super::rules_list(&cfg, Some("test".to_string()), Some("name".to_string()), 50, 2).await;
         cleanup_env();
     }
 

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -776,7 +776,14 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::rules_list(&cfg, Some("test".to_string()), Some("name".to_string()), 50, 2).await;
+        let _ = super::rules_list(
+            &cfg,
+            Some("test".to_string()),
+            Some("name".to_string()),
+            50,
+            2,
+        )
+        .await;
         cleanup_env();
     }
 

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -766,7 +766,7 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::rules_list(&cfg, None, None, 25, 0).await;
+        let _ = super::rules_list(&cfg, None, None, 10, 0).await;
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5041,6 +5041,10 @@ enum SecurityRuleActions {
             help = "Sort order (name, -name, creation_date, -creation_date, update_date, -update_date, enabled, -enabled, type, -type, highest_severity, -highest_severity, source, -source)"
         )]
         sort: Option<String>,
+        #[arg(long, default_value_t = 25, help = "Results per page (max 100)")]
+        page_size: i64,
+        #[arg(long, default_value_t = 0, help = "Page number (0-indexed)")]
+        page_number: i64,
     },
     /// Get rule details
     Get { rule_id: String },
@@ -12794,8 +12798,8 @@ async fn main_inner() -> anyhow::Result<()> {
             cfg.validate_auth()?;
             match action {
                 SecurityActions::Rules { action } => match action {
-                    SecurityRuleActions::List { filter, sort } => {
-                        commands::security::rules_list(&cfg, filter, sort).await?
+                    SecurityRuleActions::List { filter, sort, page_size, page_number } => {
+                        commands::security::rules_list(&cfg, filter, sort, page_size, page_number).await?
                     }
                     SecurityRuleActions::Get { rule_id } => {
                         commands::security::rules_get(&cfg, &rule_id).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5041,7 +5041,7 @@ enum SecurityRuleActions {
             help = "Sort order (name, -name, creation_date, -creation_date, update_date, -update_date, enabled, -enabled, type, -type, highest_severity, -highest_severity, source, -source)"
         )]
         sort: Option<String>,
-        #[arg(long, default_value_t = 25, help = "Results per page (max 100)")]
+        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
         page_size: i64,
         #[arg(long, default_value_t = 0, help = "Page number (0-indexed)")]
         page_number: i64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12798,8 +12798,14 @@ async fn main_inner() -> anyhow::Result<()> {
             cfg.validate_auth()?;
             match action {
                 SecurityActions::Rules { action } => match action {
-                    SecurityRuleActions::List { filter, sort, page_size, page_number } => {
-                        commands::security::rules_list(&cfg, filter, sort, page_size, page_number).await?
+                    SecurityRuleActions::List {
+                        filter,
+                        sort,
+                        page_size,
+                        page_number,
+                    } => {
+                        commands::security::rules_list(&cfg, filter, sort, page_size, page_number)
+                            .await?
                     }
                     SecurityRuleActions::Get { rule_id } => {
                         commands::security::rules_get(&cfg, &rule_id).await?;


### PR DESCRIPTION
## What does this PR do?

- Adds `--page-size` and `--page-number` flags to `pup security rules list`, wiring them into `ListSecurityMonitoringRulesOptionalParams`.
- Without pagination, the API silently caps results at 10 rules, making it impossible to retrieve more than the first page of a large ruleset.

No JIRA ticket — standalone usability fix.

The implementation follows the existing pattern used by `pup users list` and the internal `backend_rules_list` function in `csm_threats.rs`, both of which already use `page_size`/`page_number` on the same SDK type.

## Will it impact other teams?

Only users of `pup security rules list` — no cross-team service impact.

## Deploy plan

CLI binary only — no service deployments required.

## Rollback plan

Revert the commit or pin to the previous `pup` binary version via Homebrew (`brew switch pup <prev-version>`).

## Testing Guidelines

- [x] **Is this change retro-compatible?** Yes — `--page-size` defaults to 10 (matching the API's implicit default) and `--page-number` to 0, so existing callers with no flags get identical behaviour.
- [x] **Tested in staging** — CLI tool, not a service; verified locally that `cargo check` passes clean.
- [x] **Acceptable performance** — no performance concern.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)