### PR TITLE
feat(skills): add Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "pup",
+  "version": "0.62.0",
+  "description": "Datadog API CLI with 49 command groups, 300+ subcommands. Skills and domain agents for monitoring, logs, APM, security, and infrastructure.",
+  "author": {
+    "name": "Datadog",
+    "email": "support@datadoghq.com"
+  },
+  "repository": "https://github.com/DataDog/pup",
+  "license": "Apache-2.0",
+  "keywords": ["datadog", "monitoring", "logs", "apm", "metrics", "security", "infrastructure"],
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -599,6 +599,8 @@ Pup ships plugin manifest files for several AI coding assistants:
 /plugin marketplace add DataDog/pup
 
 # Codex (reads .codex-plugin/plugin.json from the repo, or marketplace.json from ~/.agents/plugins/)
+
+# Cursor (reads .cursor-plugin/plugin.json from the repo)
 ```
 
 ## ACP Server


### PR DESCRIPTION
<!-- dd-meta {"pullId":"22f70f3e-92ce-4981-b792-13980e2d9152","source":"chat","resourceId":"6d25942d-1fee-42c4-a119-0ffbf44aa20b","workflowId":"f0ec06f1-f590-4fd2-b1aa-2d4d8c613ed5","codeChangeId":"f0ec06f1-f590-4fd2-b1aa-2d4d8c613ed5","sourceType":"chat"} -->
## What does this PR do?

Adds a `.cursor-plugin/plugin.json` manifest at the repo root so the `pup` plugin is discoverable by Cursor's plugin marketplace, mirroring the existing `.claude-plugin/` and `.codex-plugin/` manifests. Also documents the Cursor manifest in the README alongside Claude Code and Codex.

## Motivation

Closes #662. Cursor Cloud Agents want the `pup` skills pre-installed via the Cursor marketplace instead of vendoring them every session. PR #507 (the Codex/Cursor/opencode plugin work) added Cursor as a `pup skills install` platform and shipped the Codex marketplace manifests, but never created the Cursor plugin manifest. Cursor discovers plugins from `.cursor-plugin/plugin.json` (the Cursor equivalent of `.claude-plugin/`), so without this file the plugin can't be listed or auto-installed by Cursor.

## Changes

- Add `.cursor-plugin/plugin.json` mirroring the `.codex-plugin/plugin.json` sibling: `name`, `version`, `description`, `author`, `repository`, `license`, `keywords`, and `skills` (`./skills/`).
- Document the Cursor manifest next to Claude Code and Codex in `README.md`.

## Additional Notes

- `pup` is a single-plugin repo, so only the per-plugin `plugin.json` is needed at the root (no `.cursor-plugin/marketplace.json`), matching how `.codex-plugin/` is laid out.
- Field set and structure are copied verbatim from the `.codex-plugin/` manifest. Cursor's plugin schema is strictly validated (`additionalProperties: false`); the fields used here mirror Datadog's published `datadog-labs/cursor-plugin` manifest referenced in the issue. Worth a schema check against the official Cursor spec before merge.
- Version is set to `0.62.0` to match the `.codex-plugin`/`.agents` siblings introduced in the same feature work. Note the existing manifests already drift from `Cargo.toml` (`1.6.6`) and from each other (`.claude-plugin` is `0.25.0`); aligning all manifest versions is out of scope here but flagged as a follow-up.

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable) — n/a, static manifest file with no code paths or existing manifest tests
- [x] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

Closes #662
Related: #507

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/6d25942d-1fee-42c4-a119-0ffbf44aa20b)

Comment @datadog to request changes