### PR TITLE
fix(on-call): handle empty 200 body in pages get

### DIFF
--- a/src/commands/on_call.rs
+++ b/src/commands/on_call.rs
@@ -830,6 +830,29 @@ mod tests {
         cleanup_env();
     }
 
+    // Regression test for #638: the on-call pages GET endpoint can return a 200
+    // with an empty body (content-length: 0). pages_get must succeed instead of
+    // failing with "EOF while parsing value at line 1 column 0".
+    #[tokio::test]
+    async fn test_on_call_pages_get_empty_body() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        s.mock("GET", "/api/v2/on-call/pages/12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("")
+            .create_async()
+            .await;
+        let result = super::pages_get(&cfg, "12345").await;
+        assert!(
+            result.is_ok(),
+            "pages_get with empty body failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
     #[tokio::test]
     async fn test_on_call_pages_get_not_found() {
         let _lock = lock_env().await;

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -37,6 +37,13 @@ impl std::error::Error for HttpError {}
 async fn parse_response_json(resp: reqwest::Response) -> anyhow::Result<serde_json::Value> {
     use serde::Deserialize;
     let bytes = resp.bytes().await?;
+    // Some endpoints return a success status (e.g. 200) with an empty body, such
+    // as GET /api/v2/on-call/pages/{id} which responds with content-length: 0.
+    // Treat an empty or whitespace-only body as JSON null rather than failing
+    // with "EOF while parsing value at line 1 column 0".
+    if bytes.iter().all(u8::is_ascii_whitespace) {
+        return Ok(serde_json::Value::Null);
+    }
     let mut de = serde_json::Deserializer::from_slice(&bytes);
     de.disable_recursion_limit();
     let de = serde_stacker::Deserializer::new(&mut de);
@@ -1104,6 +1111,74 @@ mod tests {
             "raw_request with query failed: {:?}",
             resp.err()
         );
+        cleanup_env();
+    }
+
+    /// Regression test: a 200 response with an empty body must parse as JSON null
+    /// instead of failing with "EOF while parsing value at line 1 column 0".
+    #[tokio::test]
+    async fn test_raw_get_empty_body_returns_null() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", "/api/v2/on-call/pages/12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("")
+            .create_async()
+            .await;
+        let resp = super::raw_get(&cfg, "/api/v2/on-call/pages/12345", &[]).await;
+        assert!(
+            resp.is_ok(),
+            "raw_get with empty body failed: {:?}",
+            resp.err()
+        );
+        assert_eq!(resp.unwrap(), serde_json::Value::Null);
+        cleanup_env();
+    }
+
+    /// A whitespace-only body is also unparseable JSON and must be treated as null.
+    #[tokio::test]
+    async fn test_raw_get_whitespace_body_returns_null() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", "/api/v2/on-call/pages/12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("  \n\t ")
+            .create_async()
+            .await;
+        let resp = super::raw_get(&cfg, "/api/v2/on-call/pages/12345", &[]).await;
+        assert!(
+            resp.is_ok(),
+            "raw_get with whitespace body failed: {:?}",
+            resp.err()
+        );
+        assert_eq!(resp.unwrap(), serde_json::Value::Null);
+        cleanup_env();
+    }
+
+    /// A non-empty JSON body must still parse normally (the empty-body guard must
+    /// not shadow the regular parse path).
+    #[tokio::test]
+    async fn test_raw_get_nonempty_body_parses() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("GET", "/api/v2/on-call/pages/12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {"id": "12345"}}"#)
+            .create_async()
+            .await;
+        let resp = super::raw_get(&cfg, "/api/v2/on-call/pages/12345", &[])
+            .await
+            .expect("raw_get with JSON body should succeed");
+        assert_eq!(resp["data"]["id"], "12345");
         cleanup_env();
     }
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8907f83f-766f-438d-baa1-4179da89cb2d","source":"chat","resourceId":"0f7e12d8-0f13-4723-8b95-1549d1c02a94","workflowId":"16450339-d207-4605-9120-c62a132a6ae3","codeChangeId":"16450339-d207-4605-9120-c62a132a6ae3","sourceType":"chat"} -->
## What does this PR do?

Fixes `pup on-call pages get <id>` failing with `Error: failed to get page: EOF while parsing value at line 1 column 0`.

The Datadog `GET /api/v2/on-call/pages/{id}` endpoint can return HTTP 200 with an empty body (content-length: 0). The shared `parse_response_json` helper in src/raw_client.rs passed those empty bytes straight to serde_json, which errored on the missing JSON value. That helper backs `raw_get`, `raw_post`, `raw_put`, and every other hand-written raw HTTP call, so the crash could hit any endpoint returning an empty success body.

An empty or whitespace-only success body is now treated as JSON null, mirroring the existing 204 No Content handling already present in `raw_put` and `raw_request`.

## Motivation

Reported in issue #638: `pup on-call pages get` never returns the page and instead errors out. The reporter confirmed via `pup api -i v2/on-call/pages/<id>` that the endpoint responds 200 with content-length: 0, so the body is genuinely empty and the client must not treat that as a parse failure.

## Changes

- src/raw_client.rs: guard empty/whitespace-only bodies in `parse_response_json`, returning `serde_json::Value::Null` instead of failing to parse.
- src/raw_client.rs: add `raw_get` unit tests for an empty body, a whitespace-only body, and a valid JSON body (the last ensures the new guard does not shadow normal parsing).
- src/commands/on_call.rs: add regression test `test_on_call_pages_get_empty_body` for `pages_get` receiving an empty 200 body.

## Testing

- Positive tests: empty body -> null and whitespace-only body -> null (src/raw_client.rs).
- Negative/contrast test: a valid JSON body still parses correctly (src/raw_client.rs).
- Regression test reproducing issue #638: `test_on_call_pages_get_empty_body` (src/commands/on_call.rs).
- Existing `pages_get` tests (success, 404 not found, percent-encoded id) continue to cover the non-empty and error paths.
- `cargo fmt --check` passes. `cargo test` / `cargo clippy` could not be executed in this sandbox because the pinned `datadog-api-client` git dependency is outside the environment's network allowlist; CI will exercise them.

## Additional Notes

The fix is centralized in `parse_response_json` rather than special-cased in the on-call command, so other raw endpoints that return empty success bodies benefit from the same graceful handling.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [x] Code coverage is maintained or improved

## Related Issues

Closes #638

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0f7e12d8-0f13-4723-8b95-1549d1c02a94)

Comment @datadog to request changes