### PR TITLE
fix: char-safe table cell truncation

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -470,17 +470,24 @@ fn extract_rows(value: &serde_json::Value) -> Vec<&serde_json::Value> {
     }
 }
 
+/// Truncate `s` to at most `max` characters, appending "..." when shortened.
+/// Cuts on character boundaries so multi-byte UTF-8 text never panics.
+fn truncate_ellipsis(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let keep: String = s.chars().take(max.saturating_sub(3)).collect();
+        format!("{keep}...")
+    } else {
+        s.to_string()
+    }
+}
+
 /// Compact label for a single array element, used when previewing arrays in table cells.
 /// For objects, tries id/name/title/type in order; falls back to format_cell for primitives.
 fn format_array_item(value: &serde_json::Value) -> String {
     if let serde_json::Value::Object(map) = value {
         for key in &["name", "title", "id", "type"] {
             if let Some(serde_json::Value::String(s)) = map.get(*key) {
-                return if s.len() > 16 {
-                    format!("{}...", &s[..13])
-                } else {
-                    s.clone()
-                };
+                return truncate_ellipsis(s, 16);
             }
         }
         return format!("{{{} fields}}", map.len());
@@ -491,13 +498,7 @@ fn format_array_item(value: &serde_json::Value) -> String {
 fn format_cell(value: Option<&serde_json::Value>) -> String {
     match value {
         None | Some(serde_json::Value::Null) => String::new(),
-        Some(serde_json::Value::String(s)) => {
-            if s.len() > 50 {
-                format!("{}...", &s[..47])
-            } else {
-                s.clone()
-            }
-        }
+        Some(serde_json::Value::String(s)) => truncate_ellipsis(s, 50),
         Some(serde_json::Value::Number(n)) => n.to_string(),
         Some(serde_json::Value::Bool(b)) => b.to_string(),
         Some(serde_json::Value::Array(arr)) => {
@@ -509,11 +510,7 @@ fn format_cell(value: Option<&serde_json::Value>) -> String {
                 parts.push(format!("+{} more", arr.len() - 4));
             }
             let result = format!("[{}]", parts.join(", "));
-            if result.len() > 50 {
-                format!("{}...", &result[..47])
-            } else {
-                result
-            }
+            truncate_ellipsis(&result, 50)
         }
         Some(serde_json::Value::Object(map)) => format!("{{{} fields}}", map.len()),
     }
@@ -567,6 +564,27 @@ mod tests {
         let result = format_cell(Some(&serde_json::json!(long)));
         assert_eq!(result.len(), 50);
         assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_format_cell_long_multibyte_string_char_boundary() {
+        // Regression: truncating by byte index used to panic when the cut point
+        // landed inside a multi-byte UTF-8 character (issue #676).
+        let name = "Resx V4 ;-) (vérifier que c'est bien un problème de resx avant de recycler)";
+        let result = format_cell(Some(&serde_json::json!(name)));
+        // 47 kept chars + the ellipsis, counted by characters not bytes.
+        let expected: String = name.chars().take(47).collect();
+        assert_eq!(result, format!("{expected}..."));
+        assert_eq!(result.chars().count(), 50, "got: {result}");
+    }
+
+    #[test]
+    fn test_format_array_item_multibyte_no_panic() {
+        // The array-preview path (16-char cap) is also char-boundary safe.
+        let arr = serde_json::json!([{"name": "problème récurrent de résolution"}]);
+        let result = format_cell(Some(&arr));
+        assert!(result.contains("..."), "got: {result}");
+        assert!(result.starts_with("[problème réc"), "got: {result}");
     }
 
     #[test]


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c0cc3920-f3c2-41f4-bcfa-fc0fa9e939f2","source":"chat","resourceId":"1c646dc1-3dab-4733-83d8-18950ea63365","workflowId":"95c03503-011a-4168-9199-97bea02ef250","codeChangeId":"95c03503-011a-4168-9199-97bea02ef250","sourceType":"chat"} -->
## What does this PR do?

Fixes a panic in the `-o table` formatter when a cell value longer than the column cap is cut inside a multi-byte UTF-8 character. Cell truncation now cuts on character boundaries via a shared `truncate_ellipsis` helper instead of slicing by byte index.

## Motivation

`src/formatter.rs` truncated table cells with byte-index slices (`&s[..47]`, `&s[..13]`, `&result[..47]`). Any value whose cut point landed inside a multi-byte character panicked, e.g. `end byte index 47 is not a char boundary; it is inside 'è'`. This makes `pup monitors list -o table` (and any table with non-ASCII cells: dashboard titles, log messages, incident titles, tags) crash for non-English orgs. `comfy_table` already handles display-width column alignment, so a character-boundary cap is sufficient to both stop the panic and keep alignment correct — no new dependency required. Closes #676.

## Changes

- Add `truncate_ellipsis(s, max)` helper in `src/commands/../formatter.rs` (`src/formatter.rs`) that counts characters and cuts on `char` boundaries, appending `...` when shortened.
- Replace the three byte-index truncation sites in `format_cell` (string and array paths) and `format_array_item` with calls to the helper.
- Add regression tests: a long accented monitor-name string (the exact value from the report) and an accented array-preview value, asserting no panic and correct character-count truncation.

## Additional Notes

Existing ASCII behavior is unchanged (byte length equals char count), so prior tests and outputs are preserved. Full `cargo test`/`clippy` could not be executed in the sandbox because the `datadog-api-client` git dependency is unreachable; the truncation logic and test assertions were verified with a standalone `rustc` build and `rustfmt --check` passes on the file.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [x] Code coverage is maintained or improved

## Related Issues

Closes #676

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1c646dc1-3dab-4733-83d8-18950ea63365)

Comment @datadog to request changes