### PR TITLE
feat(agent-obs): add Topic Discovery (Patterns) commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -66,7 +66,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | data-deletion | requests (list, create, cancel) | src/commands/data_deletion.rs | ✅ |
 | data-governance | scanner-rules (list) | src/commands/data_governance.rs | ✅ |
 | obs-pipelines | list, get, create, update, delete, validate | src/commands/obs_pipelines.rs | ✅ |
-| llm-obs | projects (create, list), experiments (create, list, update, delete, summary, events (list, get, submit), metric-values, dimension-values), datasets (create, list, batch-update, clone, restore, records, records-add, records-all, records-full), spans (search) | src/commands/llm_obs.rs | ✅ |
+| llm-obs | projects (create, list), experiments (create, list, update, delete, summary, events (list, get, submit), metric-values, dimension-values), datasets (create, list, batch-update, clone, restore, records, records-add, records-all, records-full), spans (search), patterns (configs (list, get), runs (list, status), topics, topics-with-points, points) | src/commands/llm_obs.rs | ✅ |
 | reference-tables | list, get, create, batch-query | src/commands/reference_tables.rs | ✅ |
 | network | flows list, devices (list, get, interfaces, tags), interfaces (list, update) | src/commands/network.rs | ✅ |
 | cloud | aws, gcp, azure, oci | src/commands/cloud.rs | ✅ |

--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -971,6 +971,114 @@ pub async fn spans_get_agent_loop(
     formatter::output(cfg, &resp)
 }
 
+// ---- Topic Discovery / Patterns (no typed equivalent — unstable MCP endpoints) ----
+//
+// Topic Discovery clusters LLM Obs spans into a topic hierarchy. A config defines
+// what to cluster; a run is one clustering of those spans at a point in time; a
+// completed run yields topics, each backed by clustering points (spans). The usual
+// read flow is:
+//
+//   patterns configs list -> patterns runs status -> patterns topics
+//     -> patterns points
+
+const PATTERNS_BASE: &str = "/api/unstable/llm-obs-mcp/v1/topic-discovery";
+
+/// POSTs `body` to a topic-discovery endpoint and prints the response.
+async fn patterns_post(
+    cfg: &Config,
+    endpoint: &str,
+    body: serde_json::Value,
+    what: &str,
+) -> Result<()> {
+    let path = format!("{PATTERNS_BASE}/{endpoint}");
+    let resp = raw_client::raw_post(cfg, &path, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to {what}: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn patterns_configs_list(cfg: &Config) -> Result<()> {
+    patterns_post(
+        cfg,
+        "configs/list",
+        serde_json::json!({}),
+        "list pattern configs",
+    )
+    .await
+}
+
+/// Gets the most-recently-modified pattern config for the org. Takes no arguments —
+/// use `patterns configs list` to see all configs or resolve a specific config_id.
+pub async fn patterns_configs_get(cfg: &Config) -> Result<()> {
+    patterns_post(
+        cfg,
+        "config/get",
+        serde_json::json!({}),
+        "get pattern config",
+    )
+    .await
+}
+
+pub async fn patterns_runs_list(cfg: &Config, config_id: &str) -> Result<()> {
+    patterns_post(
+        cfg,
+        "runs/list",
+        serde_json::json!({ "config_id": config_id }),
+        "list pattern runs",
+    )
+    .await
+}
+
+pub async fn patterns_runs_status(cfg: &Config, config_id: &str) -> Result<()> {
+    patterns_post(
+        cfg,
+        "run-status",
+        serde_json::json!({ "config_id": config_id }),
+        "get pattern run status",
+    )
+    .await
+}
+
+pub async fn patterns_topics(cfg: &Config, config_id: &str, run_id: Option<String>) -> Result<()> {
+    let mut body = serde_json::json!({ "config_id": config_id });
+    if let Some(r) = run_id {
+        body["run_id"] = serde_json::json!(r);
+    }
+    patterns_post(cfg, "topics", body, "get patterns").await
+}
+
+pub async fn patterns_topics_with_points(
+    cfg: &Config,
+    config_id: &str,
+    run_id: Option<String>,
+    include_metrics: bool,
+) -> Result<()> {
+    let mut body = serde_json::json!({ "config_id": config_id });
+    if let Some(r) = run_id {
+        body["run_id"] = serde_json::json!(r);
+    }
+    if include_metrics {
+        body["include_metrics"] = serde_json::json!(true);
+    }
+    patterns_post(cfg, "topics-with-points", body, "get patterns with points").await
+}
+
+pub async fn patterns_points(
+    cfg: &Config,
+    topic_id: &str,
+    page_size: Option<u32>,
+    page_token: Option<String>,
+) -> Result<()> {
+    let mut body = serde_json::json!({ "topic_id": topic_id });
+    if let Some(s) = page_size {
+        body["page_size"] = serde_json::json!(s);
+    }
+    if let Some(t) = page_token {
+        body["page_token"] = serde_json::json!(t);
+    }
+    patterns_post(cfg, "clustered-points", body, "get pattern points").await
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -3706,6 +3814,376 @@ mod tests {
         // Malformed --metrics should fail locally before any request is made.
         let result = super::experiments_events_submit(&cfg, "exp-1", "not-json", None).await;
         assert!(result.is_err(), "should fail on invalid metrics JSON");
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    // ---- Topic Discovery / Patterns ----
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_configs_list() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let body =
+            r#"{"configs":[{"id":"cfg-1","name":"prod spans","evp_query":"@ml_app:my-app"}]}"#;
+        let _mock = mock_post(
+            &mut server,
+            "/api/unstable/llm-obs-mcp/v1/topic-discovery/configs/list",
+            200,
+            body,
+        )
+        .await;
+
+        let result = super::patterns_configs_list(&cfg).await;
+        assert!(
+            result.is_ok(),
+            "patterns_configs_list failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_configs_get() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let _mock = mock_post(
+            &mut server,
+            "/api/unstable/llm-obs-mcp/v1/topic-discovery/config/get",
+            200,
+            r#"{"config":{"id":"cfg-1","name":"prod spans"}}"#,
+        )
+        .await;
+
+        let result = super::patterns_configs_get(&cfg).await;
+        assert!(
+            result.is_ok(),
+            "patterns_configs_get failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_configs_get_404() {
+        // The org may have no config yet; the endpoint 404s rather than returning empty.
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let _mock = mock_post(
+            &mut server,
+            "/api/unstable/llm-obs-mcp/v1/topic-discovery/config/get",
+            404,
+            r#"{"reason":"not_found"}"#,
+        )
+        .await;
+
+        let result = super::patterns_configs_get(&cfg).await;
+        assert!(result.is_err(), "should fail on 404");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_runs_list() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        // Strict body check: config_id must reach the endpoint.
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/runs/list",
+            )
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"config_id": "cfg-1"}),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"runs":[{"id":"run-1","status":"completed"}]}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns_runs_list(&cfg, "cfg-1").await;
+        assert!(
+            result.is_ok(),
+            "patterns_runs_list failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_runs_status() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/run-status",
+            )
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"config_id": "cfg-1"}),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"id":"run-1","status":"running","step":"clustering","progress":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns_runs_status(&cfg, "cfg-1").await;
+        assert!(
+            result.is_ok(),
+            "patterns_runs_status failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_runs_status_500() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let _mock = mock_post(
+            &mut server,
+            "/api/unstable/llm-obs-mcp/v1/topic-discovery/run-status",
+            500,
+            r#"{"errors":["internal server error"]}"#,
+        )
+        .await;
+
+        let result = super::patterns_runs_status(&cfg, "cfg-1").await;
+        assert!(result.is_err(), "should fail on 500");
+        assert!(result.unwrap_err().to_string().contains("500"));
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_topics_latest_run() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        // Omitting run_id must leave the key out entirely so the server picks the latest run.
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/topics",
+            )
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"config_id": "cfg-1"}),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"topics":[{"id":"topic-1","name":"billing questions","point_count":42}]}"#,
+            )
+            .create_async()
+            .await;
+
+        let result = super::patterns_topics(&cfg, "cfg-1", None).await;
+        assert!(result.is_ok(), "patterns_topics failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_topics_specific_run() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/topics",
+            )
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"config_id": "cfg-1", "run_id": "run-7"}),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"topics":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns_topics(&cfg, "cfg-1", Some("run-7".into())).await;
+        assert!(
+            result.is_ok(),
+            "patterns_topics with run_id failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_topics_with_points() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        // include_metrics is only sent when the flag is passed.
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/topics-with-points",
+            )
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "config_id": "cfg-1",
+                "run_id": "run-7",
+                "include_metrics": true,
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"topics":[{"id":"topic-1","points":[{"span_id":"s-1"}]}]}"#)
+            .create_async()
+            .await;
+
+        let result =
+            super::patterns_topics_with_points(&cfg, "cfg-1", Some("run-7".into()), true).await;
+        assert!(
+            result.is_ok(),
+            "patterns_topics_with_points failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_topics_with_points_omits_metrics() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        // Without the flag, include_metrics must be absent (not false) so the
+        // server default applies — matching the MCP tool's behavior.
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/topics-with-points",
+            )
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"config_id": "cfg-1"}),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"topics":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns_topics_with_points(&cfg, "cfg-1", None, false).await;
+        assert!(
+            result.is_ok(),
+            "patterns_topics_with_points without metrics failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_points_paginated() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/clustered-points",
+            )
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "topic_id": "topic-1",
+                "page_size": 50,
+                "page_token": "tok-abc",
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"points":[{"span_id":"s-1","session_id":"sess-1"}],"next_page_token":"tok-def"}"#)
+            .create_async()
+            .await;
+
+        let result =
+            super::patterns_points(&cfg, "topic-1", Some(50), Some("tok-abc".into())).await;
+        assert!(result.is_ok(), "patterns_points failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_points_defaults() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        // Omitted paging args must not appear in the body.
+        let _mock = server
+            .mock(
+                "POST",
+                "/api/unstable/llm-obs-mcp/v1/topic-discovery/clustered-points",
+            )
+            .match_body(mockito::Matcher::Json(
+                serde_json::json!({"topic_id": "topic-1"}),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"points":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns_points(&cfg, "topic-1", None, None).await;
+        assert!(
+            result.is_ok(),
+            "patterns_points defaults failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_points_404() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let _mock = mock_post(
+            &mut server,
+            "/api/unstable/llm-obs-mcp/v1/topic-discovery/clustered-points",
+            404,
+            r#"{"reason":"unknown_topic"}"#,
+        )
+        .await;
+
+        let result = super::patterns_points(&cfg, "missing", None, None).await;
+        assert!(result.is_err(), "should fail on 404");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_llm_obs_patterns_no_auth() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: None,
+            site: "datadoghq.com".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+            jq: None,
+        };
+        let result = super::patterns_configs_list(&cfg).await;
+        assert!(result.is_err(), "should fail without auth");
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9088,6 +9088,79 @@ enum LlmObsActions {
         #[command(subcommand)]
         action: LlmObsEvalsActions,
     },
+    /// Explore Topic Discovery (Patterns): span clusters and their topic hierarchy
+    Patterns {
+        #[command(subcommand)]
+        action: LlmObsPatternsActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum LlmObsPatternsActions {
+    /// Manage Topic Discovery configurations
+    Configs {
+        #[command(subcommand)]
+        action: LlmObsPatternConfigsActions,
+    },
+    /// Inspect Topic Discovery runs for a config
+    Runs {
+        #[command(subcommand)]
+        action: LlmObsPatternRunsActions,
+    },
+    /// Get the topic hierarchy discovered by a run
+    Topics {
+        #[arg(long, help = "Pattern config ID (required)")]
+        config_id: String,
+        #[arg(long, help = "Specific run ID (defaults to the latest completed run)")]
+        run_id: Option<String>,
+    },
+    /// Get the topic hierarchy with clustering point span IDs inlined on leaf topics
+    #[command(name = "topics-with-points")]
+    TopicsWithPoints {
+        #[arg(long, help = "Pattern config ID (required)")]
+        config_id: String,
+        #[arg(long, help = "Specific run ID (defaults to the latest completed run)")]
+        run_id: Option<String>,
+        #[arg(
+            long,
+            help = "Inline per-span duration, cost, token counts, and evaluations (heavier response)"
+        )]
+        include_metrics: bool,
+    },
+    /// Get a page of clustering points (spans) for a single topic
+    Points {
+        #[arg(long, help = "Topic ID (required)")]
+        topic_id: String,
+        #[arg(
+            long,
+            help = "Max points per page (server default applies when omitted)"
+        )]
+        page_size: Option<u32>,
+        #[arg(long, help = "Pagination cursor (next_page_token) from a prior call")]
+        page_token: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum LlmObsPatternConfigsActions {
+    /// List all Topic Discovery configs for the org
+    List,
+    /// Get the most-recently-modified Topic Discovery config for the org
+    Get,
+}
+
+#[derive(Subcommand)]
+enum LlmObsPatternRunsActions {
+    /// List completed runs for a config, newest first
+    List {
+        #[arg(long, help = "Pattern config ID (required)")]
+        config_id: String,
+    },
+    /// Get status and per-activity progress of the most recent run for a config
+    Status {
+        #[arg(long, help = "Pattern config ID (required)")]
+        config_id: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -16633,6 +16706,48 @@ async fn main_inner() -> anyhow::Result<()> {
                     }
                     LlmObsEvalsActions::Delete { eval_name } => {
                         commands::llm_obs::evals_delete(&cfg, &eval_name).await?;
+                    }
+                },
+                LlmObsActions::Patterns { action } => match action {
+                    LlmObsPatternsActions::Configs { action } => match action {
+                        LlmObsPatternConfigsActions::List => {
+                            commands::llm_obs::patterns_configs_list(&cfg).await?;
+                        }
+                        LlmObsPatternConfigsActions::Get => {
+                            commands::llm_obs::patterns_configs_get(&cfg).await?;
+                        }
+                    },
+                    LlmObsPatternsActions::Runs { action } => match action {
+                        LlmObsPatternRunsActions::List { config_id } => {
+                            commands::llm_obs::patterns_runs_list(&cfg, &config_id).await?;
+                        }
+                        LlmObsPatternRunsActions::Status { config_id } => {
+                            commands::llm_obs::patterns_runs_status(&cfg, &config_id).await?;
+                        }
+                    },
+                    LlmObsPatternsActions::Topics { config_id, run_id } => {
+                        commands::llm_obs::patterns_topics(&cfg, &config_id, run_id).await?;
+                    }
+                    LlmObsPatternsActions::TopicsWithPoints {
+                        config_id,
+                        run_id,
+                        include_metrics,
+                    } => {
+                        commands::llm_obs::patterns_topics_with_points(
+                            &cfg,
+                            &config_id,
+                            run_id,
+                            include_metrics,
+                        )
+                        .await?;
+                    }
+                    LlmObsPatternsActions::Points {
+                        topic_id,
+                        page_size,
+                        page_token,
+                    } => {
+                        commands::llm_obs::patterns_points(&cfg, &topic_id, page_size, page_token)
+                            .await?;
                     }
                 },
             }


### PR DESCRIPTION
## Summary

Adds `pup llm-obs patterns`, closing the last fully-missing LLM Observability MCP domain in pup. All 7 Topics Discovery tools now have a CLI equivalent.

Topic Discovery clusters LLM Obs spans into a topic hierarchy: a **config** defines what to cluster (via `evp_query`), a **run** is one clustering of those spans at a point in time, and a completed run yields **topics**, each backed by **clustering points** (spans).

Follow-up to #681, which closed the project/dataset/span-search gaps.

## Changes

Seven new commands, one per MCP tool — all read-only (`src/commands/llm_obs.rs:974`):

| Command | MCP tool | Endpoint |
|---|---|---|
| `patterns configs list` | `list_llmobs_pattern_configs` | `topic-discovery/configs/list` |
| `patterns configs get` | `get_llmobs_pattern_config` | `topic-discovery/config/get` |
| `patterns runs list --config-id` | `list_llmobs_pattern_runs` | `topic-discovery/runs/list` |
| `patterns runs status --config-id` | `get_llmobs_pattern_run_status` | `topic-discovery/run-status` |
| `patterns topics --config-id [--run-id]` | `get_llmobs_patterns` | `topic-discovery/topics` |
| `patterns topics-with-points --config-id [--run-id] [--include-metrics]` | `get_llmobs_patterns_with_points` | `topic-discovery/topics-with-points` |
| `patterns points --topic-id [--page-size] [--page-token]` | `get_llmobs_pattern_points` | `topic-discovery/clustered-points` |

The subcommand layout follows the natural read flow: `configs list` → `runs status` → `topics` → `points`.

Two design notes:

- **Optional args are omitted from the request body rather than sent as explicit defaults**, so the server's own defaults apply — matching MCP behavior for `run_id` (latest completed run), `include_metrics`, and the `page_size`/`page_token` cursor. Two tests pin this by asserting the key is *absent* rather than `false`/null.
- A shared `patterns_post` helper keeps the seven wrappers to one line of transport each, rather than repeating the path-build/POST/map_err/output chain seven times.

Arg schemas were taken from the **live MCP server**, not the dd-source checkout, which was several days stale. They matched, including the non-obvious detail that `configs get` takes no arguments — it returns the most-recently-modified config for the org, so `configs list` is how you resolve a specific `config_id`.

## Testing

14 new tests:

- Strict `Matcher::Json` body assertions per endpoint, verifying `config_id` / `run_id` / `topic_id` and the paging args reach the server exactly as expected
- Both branches of every optional arg — including two tests asserting omitted args produce an absent key rather than an explicit default
- Error paths: 404 on `configs get` (an org with no config yet), 404 on unknown topic, 500 on run-status, and a no-auth case

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test llm_obs` (116 passing) are clean.

I also verified all 7 leaves classify as `read_only: true` in the agent schema. Worth checking because `patterns runs status` yields the leaf name `status`, which sits close to the write-verb list in `is_write_command_name`.

**Smoke-tested end to end against the live API** on a real config (`Eval: product-analytics-vs-rum-tool-selection`): listed configs, resolved the latest run as `completed`, read the topic hierarchy (`Incorrect Datadog tool or action choice`, 3 points), pulled a page of 2 points, then followed the returned `next_page_token` to page 2 and got a different set of spans — confirming the cursor actually advances.

## Still open

From the same audit, for follow-up: Agent Insights (4 tools, gated behind the `llm-obs-insights` feature flag), `get_llmobs_model_pricing` and `get_llmobs_bits_session` (both org-2 allowlisted in the MCP), and the 9 LLM-Obs workflow skills that `pup skills` can't reach (it targets `/api/v2/onboarding/skills`, a different backend).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)