### PR TITLE
datasets: send OAuth bearer token, document user_access_manage scope requirement | DAL-548

### DIFF
--- a/src/commands/datasets.rs
+++ b/src/commands/datasets.rs
@@ -77,6 +77,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_datasets_list_accepts_oauth_bearer_token() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let mut cfg = test_config(&server.url());
+        // Simulate OAuth-only auth: bearer token configured, no API/APP keys.
+        cfg.api_key = None;
+        cfg.app_key = None;
+        cfg.access_token = Some("oauth-bearer-token".into());
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_header("Authorization", "Bearer oauth-bearer-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::list(&cfg).await;
+        assert!(
+            result.is_ok(),
+            "datasets list with OAuth bearer failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
     async fn test_datasets_get() {
         let _lock = lock_env().await;
         std::env::set_var("DD_TOKEN_STORAGE", "file");

--- a/src/commands/datasets.rs
+++ b/src/commands/datasets.rs
@@ -6,7 +6,7 @@ use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> DatasetsAPI {
-    crate::make_api_no_auth!(DatasetsAPI, cfg)
+    crate::make_api!(DatasetsAPI, cfg)
 }
 
 pub async fn list(cfg: &Config) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1074,6 +1074,12 @@ enum Commands {
     ///   pup datasets list
     ///   pup datasets get my-dataset-id
     ///   pup datasets create --file dataset.json
+    ///
+    /// AUTHENTICATION:
+    ///   Requires either OAuth2 authentication or API keys.
+    ///   All operations, including list/get, require the user_access_manage
+    ///   scope, which is not requested by default -- opt in with:
+    ///     pup auth login --extra-scopes user_access_manage
     #[command(verbatim_doc_comment)]
     Datasets {
         #[command(subcommand)]


### PR DESCRIPTION
## Summary

- Flip `pup datasets {list,get,create,update,delete}` from `make_api_no_auth!` to `make_api!` so the OAuth bearer is actually sent.
- Document in the command help text that all 5 operations require `user_access_manage`, which is not requested by default -- mirrors the existing `logs-restriction` precedent (`pup auth login --extra-scopes user_access_manage`).

## Why not just add the scope to defaults?

`user_access_manage` is deliberately excluded from pup's default/read-only scope lists (same as for logs-restriction writes) since it's broad and sensitive. This PR sends the token when present and lets users opt in explicitly, rather than changing that policy.

## Test plan

- [x] `cargo test datasets` passes
- [x] CI passes
- [x] Manually verify `pup datasets list` works with `pup auth login --extra-scopes user_access_manage`

Jira: DAL-548