### PR TITLE
authn-mappings: send OAuth bearer token, document user_access_manage scope | DAL-546

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -697,11 +697,11 @@ mod tests {
     /// Same coverage for the no-auth variant. Asserts the UA is overridden
     /// AND that no `Authorization` header leaks through, even when a bearer
     /// token exists in the config — that's the contract of `make_api_no_auth!`.
+    /// Uses `ApplicationSecurityAPI` (ASM WAF custom rules), which is still a
+    /// genuinely no-auth production call site as of this test.
     #[tokio::test]
     async fn test_make_api_no_auth_sends_pup_user_agent() {
-        use datadog_api_client::datadogV2::api_authn_mappings::{
-            AuthNMappingsAPI, ListAuthNMappingsOptionalParams,
-        };
+        use datadog_api_client::datadogV2::api_application_security::ApplicationSecurityAPI;
         let _lock = lock_env().await;
         let mut server = mockito::Server::new_async().await;
         let mock = server
@@ -719,10 +719,8 @@ mod tests {
         // Set a token so the Authorization-absent assertion meaningfully
         // exercises that `make_api_no_auth!` actively suppresses bearer.
         cfg.access_token = Some("test-bearer-token".into());
-        let api: AuthNMappingsAPI = crate::make_api_no_auth!(AuthNMappingsAPI, &cfg);
-        let resp = api
-            .list_authn_mappings(ListAuthNMappingsOptionalParams::default())
-            .await;
+        let api: ApplicationSecurityAPI = crate::make_api_no_auth!(ApplicationSecurityAPI, &cfg);
+        let resp = api.list_application_security_waf_custom_rules().await;
         assert!(
             resp.is_ok(),
             "make_api_no_auth! request leaked Authorization or wrong UA: {:?}",

--- a/src/commands/authn_mappings.rs
+++ b/src/commands/authn_mappings.rs
@@ -116,6 +116,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_authn_mappings_list_accepts_oauth_bearer_token() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let mut cfg = test_config(&server.url());
+        // Simulate OAuth-only auth: bearer token configured, no API/APP keys.
+        cfg.api_key = None;
+        cfg.app_key = None;
+        cfg.access_token = Some("oauth-bearer-token".into());
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_header("Authorization", "Bearer oauth-bearer-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::list(&cfg).await;
+        assert!(
+            result.is_ok(),
+            "authn mappings list with OAuth bearer failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
     async fn test_authn_mappings_list_error() {
         let _lock = lock_env().await;
         std::env::set_var("DD_TOKEN_STORAGE", "file");

--- a/src/commands/authn_mappings.rs
+++ b/src/commands/authn_mappings.rs
@@ -9,7 +9,7 @@ use crate::formatter;
 use crate::util;
 
 pub async fn list(cfg: &Config) -> Result<()> {
-    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
+    let api = crate::make_api!(AuthNMappingsAPI, cfg);
     let resp = api
         .list_authn_mappings(ListAuthNMappingsOptionalParams::default())
         .await
@@ -18,7 +18,7 @@ pub async fn list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn get(cfg: &Config, mapping_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
+    let api = crate::make_api!(AuthNMappingsAPI, cfg);
     let resp = api
         .get_authn_mapping(mapping_id.to_string())
         .await
@@ -28,7 +28,7 @@ pub async fn get(cfg: &Config, mapping_id: &str) -> Result<()> {
 
 pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let body: AuthNMappingCreateRequest = util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
+    let api = crate::make_api!(AuthNMappingsAPI, cfg);
     let resp = api
         .create_authn_mapping(body)
         .await
@@ -38,7 +38,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn update(cfg: &Config, mapping_id: &str, file: &str) -> Result<()> {
     let body: AuthNMappingUpdateRequest = util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
+    let api = crate::make_api!(AuthNMappingsAPI, cfg);
     let resp = api
         .update_authn_mapping(mapping_id.to_string(), body)
         .await
@@ -47,7 +47,7 @@ pub async fn update(cfg: &Config, mapping_id: &str, file: &str) -> Result<()> {
 }
 
 pub async fn delete(cfg: &Config, mapping_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(AuthNMappingsAPI, cfg);
+    let api = crate::make_api!(AuthNMappingsAPI, cfg);
     api.delete_authn_mapping(mapping_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete AuthN mapping: {e:?}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -617,6 +617,10 @@ enum Commands {
     ///
     /// AUTHENTICATION:
     ///   Requires either OAuth2 authentication or API keys.
+    ///   list/get work with default OAuth scopes. create/update/delete
+    ///   require the user_access_manage scope, which is not requested by
+    ///   default -- opt in with:
+    ///     pup auth login --extra-scopes user_access_manage
     #[command(name = "authn-mappings", verbatim_doc_comment)]
     AuthnMappings {
         #[command(subcommand)]


### PR DESCRIPTION
## Summary

- Flip `pup authn-mappings {list,get,create,update,delete}` from `make_api_no_auth!` to `make_api!` so the OAuth bearer is actually sent.
- Document in the command help text that `create`/`update`/`delete` require `user_access_manage`, which is not requested by default -- mirrors the existing `logs-restriction` precedent.

## Scope check

- `list`/`get` require `user_access_read` -- already in both `default_scopes()` and `read_only_scopes()`.
- `create`/`update`/`delete` require `user_access_manage` -- intentionally **not** in `default_scopes()` or `read_only_scopes()` (same treatment as `logs-restriction` writes), since it's a broad/sensitive scope. Users must opt in with `pup auth login --extra-scopes user_access_manage`.

## Test plan

- [x] `cargo test authn_mappings` passes
- [x] CI passes
- [x] Manually verify `pup authn-mappings list` works with OAuth login, and `create`/`update`/`delete` work after `pup auth login --extra-scopes user_access_manage`

Jira: DAL-546