### PR TITLE
data-deletion: send OAuth bearer token, document scope requirement | DAL-547

### DIFF
--- a/src/commands/data_deletion.rs
+++ b/src/commands/data_deletion.rs
@@ -8,7 +8,7 @@ use crate::formatter;
 use crate::util;
 
 fn make_api(cfg: &Config) -> DataDeletionAPI {
-    crate::make_api_no_auth!(DataDeletionAPI, cfg)
+    crate::make_api!(DataDeletionAPI, cfg)
 }
 
 pub async fn requests_list(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1030,6 +1030,12 @@ enum Commands {
     ///   pup data-deletion requests list
     ///   pup data-deletion requests create --product logs --file request.json
     ///   pup data-deletion requests cancel <request-id>
+    ///
+    /// AUTHENTICATION:
+    ///   Requires either OAuth2 authentication or API keys.
+    ///   All operations require the logs_delete_data and/or rum_delete_data
+    ///   scopes, which are not requested by default -- opt in with:
+    ///     pup auth login --extra-scopes logs_delete_data,rum_delete_data
     #[command(name = "data-deletion", verbatim_doc_comment)]
     DataDeletion {
         #[command(subcommand)]


### PR DESCRIPTION
## Summary

- Flip `pup data-deletion requests {list,create,cancel}` from `make_api_no_auth!` to `make_api!` so the OAuth bearer is actually sent.
- Document in the command help text that all operations require `logs_delete_data` and/or `rum_delete_data`, which are not requested by default.

## Scope check

Neither `logs_delete_data` nor `rum_delete_data` is in `default_scopes()` or `read_only_scopes()` today. All 3 routes require one of these permissions (`OR`), including the list/GET route, so there's no scope-free read path. Users must opt in with `pup auth login --extra-scopes logs_delete_data,rum_delete_data`.

## Test plan

- [x] `cargo test data_deletion` passes
- [x] CI passes
- [x] Manually verify `pup data-deletion requests list` works after `pup auth login --extra-scopes logs_delete_data,rum_delete_data`

Jira: DAL-547