### PR TITLE
traces metrics: send OAuth bearer token, request apm_generate_metrics by default | DAL-744

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -337,6 +337,14 @@ mod tests {
         assert!(scopes.contains(&"built_in_features"));
         // Logs
         assert!(scopes.contains(&"logs_write_pipelines"));
+        // APM trace metrics
+        assert!(scopes.contains(&"apm_generate_metrics"));
+    }
+
+    #[test]
+    fn test_read_only_scopes_excludes_apm_generate_metrics() {
+        let ro = read_only_scopes();
+        assert!(!ro.contains(&"apm_generate_metrics"));
     }
 
     #[test]

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -106,6 +106,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
 pub fn default_scopes() -> Vec<&'static str> {
     vec![
         // APM
+        "apm_generate_metrics",
         "apm_read",
         "apm_remote_configuration_read",
         "apm_remote_configuration_write",

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -373,6 +373,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_spans_metrics_list_accepts_oauth_bearer_token() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let mut cfg = test_config(&server.url());
+        // Simulate OAuth-only auth: bearer token configured, no API/APP keys.
+        cfg.api_key = None;
+        cfg.app_key = None;
+        cfg.access_token = Some("oauth-bearer-token".into());
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::Any)
+            .match_header("Authorization", "Bearer oauth-bearer-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[]}"#)
+            .create_async()
+            .await;
+
+        let result = super::metrics_list(&cfg).await;
+        assert!(
+            result.is_ok(),
+            "spans metrics list with OAuth bearer failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
     async fn test_spans_metrics_get() {
         let _lock = lock_env().await;
         std::env::set_var("DD_TOKEN_STORAGE", "file");

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -18,7 +18,7 @@ use crate::util_ext;
 // ---------------------------------------------------------------------------
 
 pub async fn metrics_list(cfg: &Config) -> Result<()> {
-    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
+    let api = crate::make_api!(SpansMetricsAPI, cfg);
     let resp = api
         .list_spans_metrics()
         .await
@@ -27,7 +27,7 @@ pub async fn metrics_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
+    let api = crate::make_api!(SpansMetricsAPI, cfg);
     let resp = api
         .get_spans_metric(metric_id.to_string())
         .await
@@ -38,7 +38,7 @@ pub async fn metrics_get(cfg: &Config, metric_id: &str) -> Result<()> {
 pub async fn metrics_create(cfg: &Config, file: &str) -> Result<()> {
     let body: datadog_api_client::datadogV2::model::SpansMetricCreateRequest =
         util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
+    let api = crate::make_api!(SpansMetricsAPI, cfg);
     let resp = api
         .create_spans_metric(body)
         .await
@@ -49,7 +49,7 @@ pub async fn metrics_create(cfg: &Config, file: &str) -> Result<()> {
 pub async fn metrics_update(cfg: &Config, metric_id: &str, file: &str) -> Result<()> {
     let body: datadog_api_client::datadogV2::model::SpansMetricUpdateRequest =
         util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
+    let api = crate::make_api!(SpansMetricsAPI, cfg);
     let resp = api
         .update_spans_metric(metric_id.to_string(), body)
         .await
@@ -58,7 +58,7 @@ pub async fn metrics_update(cfg: &Config, metric_id: &str, file: &str) -> Result
 }
 
 pub async fn metrics_delete(cfg: &Config, metric_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(SpansMetricsAPI, cfg);
+    let api = crate::make_api!(SpansMetricsAPI, cfg);
     api.delete_spans_metric(metric_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete spans metric: {e:?}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10001,6 +10001,19 @@ enum TracesActions {
         group_by: Option<String>,
     },
     /// Manage span-based metrics
+    ///
+    /// Create, list, get, update, and delete metrics generated from span data.
+    ///
+    /// EXAMPLES:
+    ///   pup traces metrics list
+    ///   pup traces metrics get my-metric-id
+    ///   pup traces metrics create --file metric.json
+    ///
+    /// AUTHENTICATION:
+    ///   Requires either OAuth2 authentication or API keys.
+    ///   list/get work with the default apm_read scope. create/update/delete
+    ///   require apm_generate_metrics, which is also requested by default.
+    #[command(verbatim_doc_comment)]
     Metrics {
         #[command(subcommand)]
         action: SpansMetricsActions,


### PR DESCRIPTION
## Summary

- Flip `pup traces metrics {list,get,create,update,delete}` from `make_api_no_auth!` to `make_api!` so the OAuth bearer is actually sent.
- Add `apm_generate_metrics` to `default_scopes()`.
- Add an AUTHENTICATION section to the command's help text.

## Scope check

- `apm_read` (GET routes) is already in `default_scopes()` -- no change needed.
- `apm_generate_metrics` (POST/PATCH/DELETE routes) was not in `default_scopes()` or `read_only_scopes()`. Unlike scopes such as `user_access_manage` or `logs_delete_data` (deliberately excluded as broad/sensitive), this is a narrowly-scoped write permission comparable to `rum_generate_metrics`/`logs_generate_metrics`, both already requested by default -- so this PR adds it to `default_scopes()` rather than requiring `--extra-scopes`.

## Test plan

- [x] `cargo test traces` passes
- [x] CI passes
- [x] Manually verify `pup traces metrics list` works with OAuth login (default scopes)

Jira: DAL-744