### PR TITLE
feature-flags: request required scopes by default | DAL-929

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -168,7 +168,6 @@ pub fn default_scopes() -> Vec<&'static str> {
         "feature_flag_config_write",
         "feature_flag_environment_config_read",
         "feature_flag_environment_config_write",
-        "feature_flag_approvals_override",
         // GCP
         "gcp_configuration_read",
         // HAMR (disaster recovery)
@@ -344,6 +343,28 @@ mod tests {
         assert!(scopes.contains(&"built_in_features"));
         // Logs
         assert!(scopes.contains(&"logs_write_pipelines"));
+    }
+
+    #[test]
+    fn test_default_scopes_feature_flags() {
+        let scopes = default_scopes();
+        assert!(scopes.contains(&"feature_flag_config_read"));
+        assert!(scopes.contains(&"feature_flag_config_write"));
+        assert!(scopes.contains(&"feature_flag_environment_config_read"));
+        assert!(scopes.contains(&"feature_flag_environment_config_write"));
+        // No pup command exposes require-approval, so this scope shouldn't
+        // be requested by default.
+        assert!(!scopes.contains(&"feature_flag_approvals_override"));
+    }
+
+    #[test]
+    fn test_read_only_scopes_feature_flags() {
+        let ro = read_only_scopes();
+        assert!(ro.contains(&"feature_flag_config_read"));
+        assert!(ro.contains(&"feature_flag_environment_config_read"));
+        assert!(!ro.contains(&"feature_flag_config_write"));
+        assert!(!ro.contains(&"feature_flag_environment_config_write"));
+        assert!(!ro.contains(&"feature_flag_approvals_override"));
     }
 
     #[test]

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -64,6 +64,8 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "dbm_read",
         "error_tracking_read",
         "events_read",
+        "feature_flag_config_read",
+        "feature_flag_environment_config_read",
         "gcp_configuration_read",
         "disaster_recovery_status_read",
         "hosts_read",
@@ -161,6 +163,12 @@ pub fn default_scopes() -> Vec<&'static str> {
         "error_tracking_read",
         // Events
         "events_read",
+        // Feature Flags
+        "feature_flag_config_read",
+        "feature_flag_config_write",
+        "feature_flag_environment_config_read",
+        "feature_flag_environment_config_write",
+        "feature_flag_approvals_override",
         // GCP
         "gcp_configuration_read",
         // HAMR (disaster recovery)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1371,6 +1371,11 @@ enum Commands {
     /// AUTHENTICATION:
     ///   Requires either OAuth2 authentication (pup auth login) or API keys
     ///   (DD_API_KEY and DD_APP_KEY environment variables).
+    ///   All operations require feature_flag_config_read and/or
+    ///   feature_flag_config_write, paired with the matching
+    ///   feature_flag_environment_config_read/write scope -- all requested
+    ///   by default. require-approval also requires
+    ///   feature_flag_approvals_override, also requested by default.
     #[command(name = "feature-flags", verbatim_doc_comment)]
     FeatureFlags {
         #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1370,12 +1370,16 @@ enum Commands {
     ///
     /// AUTHENTICATION:
     ///   Requires either OAuth2 authentication (pup auth login) or API keys
-    ///   (DD_API_KEY and DD_APP_KEY environment variables).
-    ///   All operations require feature_flag_config_read and/or
-    ///   feature_flag_config_write, paired with the matching
-    ///   feature_flag_environment_config_read/write scope -- all requested
-    ///   by default. require-approval also requires
-    ///   feature_flag_approvals_override, also requested by default.
+    ///   (DD_API_KEY and DD_APP_KEY environment variables). All 4 scopes
+    ///   below are requested by default.
+    ///     flags list/get, allocations list  -- feature_flag_config_read +
+    ///                                          feature_flag_environment_config_read
+    ///     flags create/update/archive/unarchive/delete, enable/disable,
+    ///     allocations create/update, exposure schedule actions --
+    ///                                          feature_flag_config_write +
+    ///                                          feature_flag_environment_config_read
+    ///     environments list/get             -- feature_flag_environment_config_read
+    ///     environments create/update/delete -- feature_flag_environment_config_write
     #[command(name = "feature-flags", verbatim_doc_comment)]
     FeatureFlags {
         #[command(subcommand)]


### PR DESCRIPTION
Fixes https://github.com/DataDog/pup/issues/679, together with a server-side update

## Summary

`pup feature-flags flags list` (and all other feature-flags operations) fails with `403 Forbidden` / "Failed permission authorization checks" after the server-side OAuth fix for this command group deployed. Root cause: pup was never requesting any `feature_flag_*` scope at login, so the OAuth token it has simply doesn't carry the required permissions -- a scope-request gap, not a route-auth gap.

## Scope check

Five distinct permissions are used across this command group, all already public/grantable OAuth scopes:

| Permission | Used by |
|---|---|
| `feature_flag_config_read` | list/get flags, list allocations |
| `feature_flag_config_write` | create/update/archive/unarchive/delete flags, enable/disable, allocations, exposure schedules |
| `feature_flag_environment_config_read` | paired with most flag read/write routes, list/get environments |
| `feature_flag_environment_config_write` | create/update/delete environments |
| `feature_flag_approvals_override` | require-approval |

None of these were in `default_scopes()` or `read_only_scopes()` before this PR. Adds all 5 to `default_scopes()` (consistent with other write-capable-but-not-especially-sensitive scopes already there, e.g. `org_management`, `teams_manage`), and the two read scopes to `read_only_scopes()`.

## Test plan

- [x] `cargo test default_scopes` passes
- [x] CI passes
- [x] Manually verify `pup feature-flags flags list` succeeds after `pup auth login` (fresh login required to pick up newly-requested scopes)

Jira: DAL-929