### PR TITLE
feat(logs): add --interval for timeseries aggregation

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -22,6 +22,7 @@ pub struct AggregateArgs {
     pub index: Vec<String>,
     pub storage: Option<String>,
     pub sort: String,
+    pub interval: Option<String>,
 }
 
 pub struct SearchArgs {
@@ -134,8 +135,13 @@ fn build_aggregate_body(
     index: Vec<String>,
     storage: Option<String>,
     sort: &str,
+    interval: Option<String>,
 ) -> Result<serde_json::Value> {
     let storage_tier = normalize_storage_tier(storage)?;
+    let interval = match interval {
+        Some(iv) => Some(util_ext::parse_duration_to_millis(&iv)?.to_string()),
+        None => None,
+    };
 
     let mut filter = serde_json::json!({
         "query": query,
@@ -156,6 +162,10 @@ fn build_aggregate_body(
             let mut obj = serde_json::json!({ "aggregation": aggregation });
             if let Some(m) = metric {
                 obj["metric"] = serde_json::Value::String(m);
+            }
+            if let Some(iv) = &interval {
+                obj["type"] = serde_json::Value::String("timeseries".into());
+                obj["interval"] = serde_json::Value::String(iv.clone());
             }
             Ok(obj)
         })
@@ -281,6 +291,7 @@ pub async fn aggregate(cfg: &Config, args: AggregateArgs) -> Result<()> {
         index,
         storage,
         sort,
+        interval,
     } = args;
     if compute.is_empty() {
         compute.push("count".into());
@@ -288,7 +299,7 @@ pub async fn aggregate(cfg: &Config, args: AggregateArgs) -> Result<()> {
     let from_ms = util_ext::parse_time_to_unix_millis(&from)?;
     let to_ms = util_ext::parse_time_to_unix_millis(&to)?;
     let body = build_aggregate_body(
-        query, from_ms, to_ms, compute, group_by, limit, index, storage, &sort,
+        query, from_ms, to_ms, compute, group_by, limit, index, storage, &sort, interval,
     )?;
     let data = raw_client::raw_post(cfg, "/api/v2/logs/analytics/aggregate", body).await?;
     formatter::output(cfg, &data)?;
@@ -441,6 +452,7 @@ mod tests {
             vec![],
             Some("flex".into()),
             "count",
+            None,
         )
         .unwrap();
 
@@ -482,6 +494,7 @@ mod tests {
             vec![],
             None,
             "count",
+            None,
         )
         .unwrap();
 
@@ -516,6 +529,7 @@ mod tests {
             vec![],
             None,
             "count",
+            None,
         )
         .unwrap();
 
@@ -548,6 +562,7 @@ mod tests {
             vec![],
             None,
             "count",
+            None,
         )
         .unwrap();
 
@@ -608,6 +623,7 @@ mod tests {
             vec![],
             None,
             "pc95",
+            None,
         )
         .unwrap();
 
@@ -633,6 +649,7 @@ mod tests {
             vec![],
             None,
             "pc95",
+            None,
         )
         .unwrap();
 
@@ -651,6 +668,7 @@ mod tests {
             vec![],
             None,
             "count",
+            None,
         )
         .unwrap();
 
@@ -669,6 +687,7 @@ mod tests {
             vec!["main".into(), "web".into()],
             None,
             "count",
+            None,
         )
         .unwrap();
 
@@ -676,6 +695,49 @@ mod tests {
             body["filter"]["indexes"],
             serde_json::json!(["main", "web"])
         );
+    }
+
+    #[test]
+    fn test_build_aggregate_body_timeseries_interval() {
+        let body = build_aggregate_body(
+            "*".into(),
+            1,
+            2,
+            vec!["count".into(), "avg(@duration)".into()],
+            vec![],
+            10,
+            vec![],
+            None,
+            "count",
+            Some("5m".into()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["compute"],
+            serde_json::json!([
+                { "aggregation": "count", "type": "timeseries", "interval": "300000" },
+                { "aggregation": "avg", "metric": "@duration", "type": "timeseries", "interval": "300000" }
+            ])
+        );
+    }
+
+    #[test]
+    fn test_build_aggregate_body_invalid_interval() {
+        let err = build_aggregate_body(
+            "*".into(),
+            1,
+            2,
+            vec!["count".into()],
+            vec![],
+            10,
+            vec![],
+            None,
+            "count",
+            Some("bogus".into()),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unable to parse duration"));
     }
 
     #[test]
@@ -800,6 +862,7 @@ mod tests {
                 index: vec![],
                 storage: None,
                 sort: "count".into(),
+                interval: None,
             },
         )
         .await;
@@ -828,6 +891,7 @@ mod tests {
                 index: vec![],
                 storage: None,
                 sort: "count".into(),
+                interval: None,
             },
         )
         .await;
@@ -916,6 +980,7 @@ mod tests {
                 index: vec![],
                 storage: Some("flex".into()),
                 sort: "count".into(),
+                interval: None,
             },
         )
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3216,6 +3216,11 @@ enum LogActions {
             help = "Sort groups by aggregation (count,cardinality,pc75,pc90,pc95,pc98,pc99,sum,min,max)"
         )]
         sort: String,
+        #[arg(
+            long,
+            help = "Return a timeseries with this bucket size (e.g. 60s, 5m, 1h); enables timeseries mode"
+        )]
+        interval: Option<String>,
     },
     /// Manage log archives
     Archives {
@@ -12280,6 +12285,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     storage,
                     index,
                     sort,
+                    interval,
                 } => {
                     commands::logs::aggregate(
                         &cfg,
@@ -12300,6 +12306,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             index,
                             storage,
                             sort,
+                            interval,
                         },
                     )
                     .await?;


### PR DESCRIPTION
## Summary
Adds an `--interval` flag to `pup logs aggregate` that switches the compute to timeseries mode with the given bucket size (e.g. `60s`, `5m`, `1h`).

## Example
Without `--interval`, `logs aggregate` collapses the whole range into a single total:
```bash
pup logs aggregate --query="status:error" --from=1h --compute="count"
```

With `--interval`, the same query returns a timeseries instead — one value per bucket:
```bash
pup logs aggregate --query="status:error" --from=1h --compute="count" --interval=10m
```
```json
{
  "computes": {
    "c0": [
      { "time": "2026-07-29T12:20:00.000Z", "value": ... },
      { "time": "2026-07-29T12:30:00.000Z", "value": ... },
      ...
    ]
  }
}
```
Note: bucket count is approximately `range / interval`, but the API aligns buckets to clock boundaries, so you may see one extra partial bucket at the edges of the range.

## Changes
- `src/commands/logs.rs`: `AggregateArgs.interval` parsed via `util_ext::parse_duration_to_millis`; when set, each compute entry gets `type: "timeseries"` and `interval` in milliseconds.
- `src/main.rs`: new `--interval` flag on `pup logs aggregate`, threaded through to the command.

## Testing
- Added `test_build_aggregate_body_timeseries_interval` (happy path) and `test_build_aggregate_body_invalid_interval` (bad duration string).
- `cargo test`, `cargo fmt --check`, `cargo clippy -- -D warnings` all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)