### PR TITLE
docs(logs): document trace ID remapping caveat

### DIFF
--- a/agents/logs.md
+++ b/agents/logs.md
@@ -140,6 +140,19 @@ Error: Invalid time format
 **No Results Found**:
 → Suggest broadening the query or checking time range
 
+**Trace IDs Missing from Log Results**:
+Logs may show a linked trace in the Datadog UI while the API result has no
+`dd.trace_id` / `dd.span_id` (queries like `@dd.trace_id:*` return zero hits).
+When a trace ID attribute is remapped for trace correlation (JSON preprocessing
+or a Trace Remapper processor), the source attribute is removed and stored as an
+internal attribute that the Logs Search API does not return.
+→ This is expected Datadog behavior, not a bug in pup, the query, or the user's
+instrumentation. Do NOT loop retrying queries or suggest instrumentation
+changes to "restore" the field. Explain the limitation (Datadog tracks the
+improvement as support reference FRLOGSS-4306) and offer alternatives: query a
+custom non-remapped attribute if the application emits one, or pivot to
+`pup traces search` using the log's service and time window.
+
 **Rate Limiting**:
 ```
 Error: Rate limit exceeded

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -233,6 +233,34 @@ pup --verbose monitors get 12345678
 pup --site=datadoghq.eu monitors get 12345678
 ```
 
+### Trace IDs Missing from Log Search Results
+
+**Symptoms:**
+- The Datadog UI shows a trace linked to a log, but `pup logs search` results
+  have no `dd.trace_id` / `dd.span_id` attribute
+- Queries like `@dd.trace_id:*` return zero hits for logs that are correlated
+  with traces in the UI
+
+**Cause:**
+
+This is Datadog Log Management behavior, not a pup issue. When a trace ID
+attribute is remapped for trace correlation (via JSON preprocessing or a Trace
+Remapper processor), the source attribute is removed from the log and the value
+is stored as an internal attribute. The Logs Search API does not return internal
+attributes, while the UI's trace link reads them - so the UI and API disagree.
+
+Datadog is tracking making these values queryable; contact
+support@datadoghq.com and reference "FRLOGSS-4306" for updates.
+
+**Workarounds:**
+- Emit the trace ID under an additional attribute that is not remapped (e.g.
+  `@custom.trace_id`) and query that instead
+- Pivot to trace search using the log's service and time window:
+
+```bash
+pup traces search --query="service:my-service" --from="1h"
+```
+
 ## Command Issues
 
 ### Command Not Found

--- a/skills/dd-logs/SKILL.md
+++ b/skills/dd-logs/SKILL.md
@@ -52,6 +52,27 @@ pup logs search --query="@http.status_code:>=500" --from="1h"
 | `service:api AND env:prod` | Boolean |
 | `@message:*timeout*` | Wildcard |
 
+### Trace IDs in Log Results
+
+Logs that show a linked trace in the Datadog UI may not include `dd.trace_id` /
+`dd.span_id` in API results. When a trace ID attribute is remapped for trace
+correlation (via JSON preprocessing or a Trace Remapper processor), the source
+attribute is removed and the value is stored as an internal attribute that the
+Logs Search API does not return. The UI's "trace" link reads that internal
+attribute, so UI and API results differ.
+
+**This is expected Datadog Log Management behavior, not a pup bug or an
+instrumentation problem.** Do not retry queries or change instrumentation to
+"fix" it. Datadog is tracking making these values queryable (support reference
+FRLOGSS-4306).
+
+Workarounds until then:
+
+- Emit the trace ID under a separate attribute that is not remapped (e.g.
+  `@custom.trace_id`) and query that.
+- Pivot the other way: search spans by the log's service/time window via
+  `pup traces search`, or use the trace link in the Datadog UI.
+
 ## Pipelines
 
 Process logs before indexing:
@@ -184,6 +205,7 @@ def sanitize_log(message: str) -> str:
 | High costs | Add exclusion filters |
 | Search slow | Narrow time range, use indexes |
 | Missing attributes | Check grok parser |
+| `dd.trace_id` missing but UI shows a trace | Expected: remapped trace IDs become internal attributes (see [Trace IDs in Log Results](#trace-ids-in-log-results)) |
 
 ## References/Documentation
 


### PR DESCRIPTION
## What does this PR do?

Documents that logs correlated with traces may not expose `dd.trace_id` / `dd.span_id` via the Logs Search API, even when the Datadog UI shows a linked trace. Three places updated:

- `skills/dd-logs/SKILL.md`: new "Trace IDs in Log Results" section plus a troubleshooting table row
- `agents/logs.md`: new error-handling entry telling agents this is expected behavior and to stop retrying / suggesting instrumentation changes
- `docs/TROUBLESHOOTING.md`: new symptom/cause/workaround entry under API Call Issues

## Motivation

Follow-up to #647. Per the Datadog Log Management team (see [comment](https://github.com/DataDog/pup/issues/647#issuecomment-5109332182)), trace ID attributes remapped for trace correlation are removed from the log and stored as internal attributes the Logs Search API does not return. Without this documented, agents using pup go in circles trying to "fix" the missing trace IDs. Maintainer approved the docs PR [here](https://github.com/DataDog/pup/issues/647#issuecomment-5167266601).

## Additional Notes

Docs-only change, no code touched. Ran `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -- --test-threads=1` locally: all pass (1709 tests). The Datadog-side improvement is tracked as support reference FRLOGSS-4306; docs can be simplified once that ships.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable) - N/A, docs only
- [x] Documentation has been updated (if applicable)
- [x] All CI checks pass
- [x] Code coverage is maintained or improved

## Related Issues

Closes #647