### PR TITLE
chore(ci): add stale bot workflow for issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
-          days-before-stale: 60
+          days-before-stale: 30
           days-before-close: 14
           exempt-issue-labels: "no-stale,enhancement,bug"
           exempt-pr-labels: "no-stale,enhancement,bug"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-issue-labels: "no-stale,enhancement,bug"
+          exempt-pr-labels: "no-stale,enhancement,bug"
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            Remove the stale label or comment to keep it open.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            Remove the stale label or comment to keep it open.
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. Feel free to
+            reopen if it is still relevant.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity. Feel free to
+            reopen if it is still relevant.


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically marks inactive issues and PRs as stale and closes them after a grace period.

## Changes
- New `.github/workflows/stale.yml` using `actions/stale@v11.0.0` (pinned by SHA)
- Marks issues/PRs stale after 30 days of inactivity, closes them 14 days after that if untouched
- Labels `no-stale`, `enhancement`, and `bug` exempt items from being marked stale (on both issues and PRs)
- Runs daily via cron, with `workflow_dispatch` for manual runs

## Testing
- `actionlint` run against the workflow file with no errors
- No `run:` steps or untrusted input interpolation, so no injection surface

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)