### PR TITLE
feat(workflows): attribute API requests to pup

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -56,6 +56,52 @@ impl Middleware for UserAgentMiddleware {
     }
 }
 
+// Workflow Automation records this header as request-source metadata.
+pub(crate) const WORKFLOW_SOURCE_HEADER: &str = "x-datadog-workflow-automation-source";
+pub(crate) const WORKFLOW_SOURCE_VALUE: &str = "pup";
+const WORKFLOW_API_PATH: &str = "/api/v2/workflows";
+
+fn is_workflow_api_path(path: &str) -> bool {
+    path == WORKFLOW_API_PATH || path.starts_with("/api/v2/workflows/")
+}
+
+pub(crate) fn with_workflow_source_header(
+    req: reqwest::RequestBuilder,
+    path: &str,
+) -> reqwest::RequestBuilder {
+    if is_workflow_api_path(path) {
+        req.header(WORKFLOW_SOURCE_HEADER, WORKFLOW_SOURCE_VALUE)
+    } else {
+        req
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct WorkflowSourceMiddleware;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl Middleware for WorkflowSourceMiddleware {
+    async fn handle(
+        &self,
+        mut req: reqwest_middleware::reqwest::Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest_middleware::reqwest::Response> {
+        if is_workflow_api_path(req.url().path()) {
+            req.headers_mut().insert(
+                reqwest_middleware::reqwest::header::HeaderName::from_static(
+                    WORKFLOW_SOURCE_HEADER,
+                ),
+                reqwest_middleware::reqwest::header::HeaderValue::from_static(
+                    WORKFLOW_SOURCE_VALUE,
+                ),
+            );
+        }
+        next.run(req, extensions).await
+    }
+}
+
 // ---------------------------------------------------------------------------
 // DD Configuration builder
 // ---------------------------------------------------------------------------
@@ -116,10 +162,9 @@ pub fn make_dd_config(cfg: &Config) -> datadog_api_client::datadog::Configuratio
 }
 
 /// Builds a reqwest middleware client for SDK API calls. Always installs
-/// `UserAgentMiddleware` so requests carry pup's branded `User-Agent`
-/// instead of the SDK's `datadog-api-client-rust/...` default. When
-/// `send_bearer` is true and the config has an access token, also installs
-/// `BearerAuthMiddleware`. OAuth-incompatible endpoints (see
+/// middleware for pup's branded `User-Agent` and Workflow Automation source
+/// header. When `send_bearer` is true and the config has an access token, also
+/// installs `BearerAuthMiddleware`. OAuth-incompatible endpoints (see
 /// `raw_client::OAUTH_EXCLUDED_ENDPOINTS`) pass `false` so the SDK falls back
 /// to API key headers from the `Configuration`.
 ///
@@ -130,7 +175,9 @@ pub fn make_dd_client(cfg: &Config, send_bearer: bool) -> Option<ClientWithMiddl
         let reqwest_client = reqwest_middleware::reqwest::Client::builder()
             .build()
             .expect("failed to build reqwest client");
-        let mut builder = ClientBuilder::new(reqwest_client).with(UserAgentMiddleware);
+        let mut builder = ClientBuilder::new(reqwest_client)
+            .with(UserAgentMiddleware)
+            .with(WorkflowSourceMiddleware);
         if send_bearer {
             if let Some(token) = cfg.access_token.as_ref() {
                 builder = builder.with(BearerAuthMiddleware {
@@ -621,6 +668,52 @@ mod tests {
         std::env::remove_var("PUP_MOCK_SERVER");
         std::env::remove_var("DD_API_KEY");
         std::env::remove_var("DD_APP_KEY");
+    }
+
+    /// Verifies that source attribution is scoped to Workflow Automation routes.
+    #[tokio::test]
+    async fn test_make_dd_client_sends_workflow_source_header_only_for_workflows() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let workflow_mock = server
+            .mock("GET", "/api/v2/workflows/workflow-id")
+            .match_header(WORKFLOW_SOURCE_HEADER, WORKFLOW_SOURCE_VALUE)
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+        let non_workflow_mock = server
+            .mock("GET", "/api/v2/workflows-backup")
+            .match_header(WORKFLOW_SOURCE_HEADER, mockito::Matcher::Missing)
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let cfg = test_config(&server.url());
+        let client = make_dd_client(&cfg, true).expect("native builds use the middleware client");
+        let workflow_response = client
+            .get(format!("{}/api/v2/workflows/workflow-id", server.url()))
+            .send()
+            .await;
+        let non_workflow_response = client
+            .get(format!("{}/api/v2/workflows-backup", server.url()))
+            .send()
+            .await;
+
+        assert!(
+            workflow_response.is_ok(),
+            "workflow request did not carry source header: {:?}",
+            workflow_response.err()
+        );
+        assert!(
+            non_workflow_response.is_ok(),
+            "non-workflow request unexpectedly carried source header: {:?}",
+            non_workflow_response.err()
+        );
+        workflow_mock.assert_async().await;
+        non_workflow_mock.assert_async().await;
+        cleanup_env();
     }
 
     /// Verifies that requests built via `make_api!` carry pup's branded

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -588,6 +588,8 @@ pub fn apply_auth(
     method: &str,
     path: &str,
 ) -> anyhow::Result<reqwest::RequestBuilder> {
+    req = crate::client::with_workflow_source_header(req, path);
+
     // Events post is also in the broader OAuth-excluded table, so handle its
     // API-key-only requirement before the fallback branch that adds both keys.
     if requires_api_key_only(method, path) {
@@ -1107,6 +1109,46 @@ mod tests {
         ));
     }
 
+    /// Verifies that raw requests to Workflow Automation carry pup's source header.
+    #[tokio::test]
+    async fn test_raw_request_sends_workflow_source_header() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let mock = server
+            .mock("GET", "/api/v2/workflows/workflow-id")
+            .match_header(
+                crate::client::WORKFLOW_SOURCE_HEADER,
+                crate::client::WORKFLOW_SOURCE_VALUE,
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {"id": "workflow-id"}}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let response = super::raw_request(
+            &cfg,
+            "GET",
+            "/api/v2/workflows/workflow-id",
+            &[],
+            None,
+            None,
+            "application/json",
+            &[],
+        )
+        .await;
+
+        assert!(
+            response.is_ok(),
+            "raw workflow request failed: {:?}",
+            response.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
     /// Verifies that raw_request attaches query parameters and returns Ok when the
     /// server responds 200. Exercises the `!query.is_empty()` branch added to the function.
     #[tokio::test]
@@ -1117,6 +1159,10 @@ mod tests {
         let _mock = server
             .mock("GET", "/api/v2/monitors")
             .match_query(mockito::Matcher::Any)
+            .match_header(
+                crate::client::WORKFLOW_SOURCE_HEADER,
+                mockito::Matcher::Missing,
+            )
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body("[]")


### PR DESCRIPTION
## Summary

- send `X-Datadog-Workflow-Automation-Source: pup` on Workflow Automation API requests
- cover both generated SDK requests and raw requests used by the API passthrough and runbooks
- keep the attribution header off unrelated API routes

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1` (1,711 passed)