### PR TITLE
workflows: send OAuth bearer token for action connections | DAL-751

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -56,6 +56,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "ci_visibility_read",
         "cloud_cost_management_read",
         "code_coverage_read",
+        "connections_read",
         "dora_metrics_read",
         "test_optimization_read",
         "dashboards_read",
@@ -398,6 +399,10 @@ mod tests {
         assert!(!ro.contains(&"teams_manage"));
         assert!(!ro.contains(&"monitors_write"));
         assert!(!ro.contains(&"logs_write_pipelines"));
+        // connections_read is a ReadOnly-tier permission; connections_write
+        // is intentionally opt-in (see --extra-scopes) and must not appear.
+        assert!(ro.contains(&"connections_read"));
+        assert!(!ro.contains(&"connections_write"));
     }
 
     #[test]

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -222,7 +222,7 @@ pub async fn instance_cancel(cfg: &Config, workflow_id: &str, instance_id: &str)
 // ---------------------------------------------------------------------------
 
 fn make_connection_api(cfg: &Config) -> ActionConnectionAPI {
-    crate::make_api_no_auth!(ActionConnectionAPI, cfg)
+    crate::make_api!(ActionConnectionAPI, cfg)
 }
 
 pub async fn connections_get(cfg: &Config, connection_id: &str) -> Result<()> {
@@ -279,6 +279,38 @@ mod tests {
         let _mock = mock_any(&mut server, "GET", r#"{}"#).await;
         let result = super::connections_get(&cfg, "conn-id").await;
         assert!(result.is_ok(), "connections get failed: {:?}", result.err());
+        cleanup_env();
+        std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_connections_get_accepts_oauth_bearer_token() {
+        let _lock = lock_env().await;
+        std::env::set_var("DD_TOKEN_STORAGE", "file");
+        let mut server = mockito::Server::new_async().await;
+        let mut cfg = test_config(&server.url());
+        // Simulate OAuth-only auth: bearer token configured, no API/APP keys.
+        cfg.api_key = None;
+        cfg.app_key = None;
+        cfg.access_token = Some("oauth-bearer-token".into());
+        std::env::remove_var("DD_API_KEY");
+        std::env::remove_var("DD_APP_KEY");
+
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .match_header("Authorization", "Bearer oauth-bearer-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{}"#)
+            .create_async()
+            .await;
+
+        let result = super::connections_get(&cfg, "conn-id").await;
+        assert!(
+            result.is_ok(),
+            "connections get with OAuth bearer failed: {:?}",
+            result.err()
+        );
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2923,11 +2923,13 @@ enum Commands {
     ///
     /// AUTHENTICATION:
     ///   Workflow CRUD (`workflows get/create/update/delete`),
-    ///   `workflows run`, and `workflows instances *` accept OAuth2
-    ///   (`pup auth login`) or DD_API_KEY + DD_APP_KEY.
-    ///   `workflows connections *` requires DD_API_KEY + DD_APP_KEY
-    ///   pending server-side OAuth enablement on the action-connections
-    ///   API.
+    ///   `workflows run`, `workflows instances *`, and `workflows
+    ///   connections *` accept OAuth2 (`pup auth login`) or DD_API_KEY +
+    ///   DD_APP_KEY.
+    ///   `workflows connections create/update/delete` require the
+    ///   connections_write scope, which is not requested by default --
+    ///   opt in with:
+    ///     pup auth login --extra-scopes connections_write
     #[command(verbatim_doc_comment)]
     Workflows {
         #[command(subcommand)]
@@ -4773,6 +4775,14 @@ enum WorkflowActions {
         action: WorkflowInstanceActions,
     },
     /// Manage action connections
+    ///
+    /// AUTHENTICATION:
+    ///   `get` accepts OAuth2 (`pup auth login`) or DD_API_KEY + DD_APP_KEY.
+    ///   `create`/`update`/`delete` additionally require the
+    ///   connections_write scope, which is not requested by default --
+    ///   opt in with:
+    ///     pup auth login --extra-scopes connections_write
+    #[command(verbatim_doc_comment)]
     Connections {
         #[command(subcommand)]
         action: WorkflowConnectionActions,


### PR DESCRIPTION
## Motivation
Expand support for OAuth, in particular for the pup CLI and other AI-agent/programmatic clients. OAuth is now a general-purpose auth method, and is preferred over API+App Keys because it's always scoped and credentials automatically expire.

## Changes

Send the OAuth bearer token for action-connections requests. `make_connection_api` was using `make_api_no_auth!`, which always sent API key auth even with a valid OAuth session; switched to `make_api!`. The action-connections API already accepts OAuth server-side, so this was the only client-side blocker.

Also adds `connections_read` to `read_only_scopes()` (it was already a default scope, just missing from the read-only subset) and documents `connections_write` as an opt-in `--extra-scopes` scope.

## Deliberately not changed

- `connections_write` is not added to `default_scopes()` — connection management is treated as sensitive and stays opt-in.

## Test plan

- [x] CI green
