### PR TITLE
feat(logs): default search storage to flex

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -178,10 +178,10 @@ pup logs search --query="service:api" --from="7d" --storage="flex"
 # Search online archives (long-term storage)
 pup logs search --query="status:error" --from="30d" --storage="online-archives"
 
-# Search standard indexes (default, fastest tier)
+# Search standard indexes (fastest tier)
 pup logs search --query="service:web-app" --from="1h" --storage="indexes"
 
-# Use Datadog's default storage behavior
+# Search Flex logs by default
 pup logs search --query="status:warn" --from="1h"
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1756,9 +1756,9 @@ enum Commands {
     ///
     /// STORAGE TIERS:
     ///   Datadog logs can be stored in different tiers with different performance and cost characteristics:
-    ///   • indexes - Standard indexed logs (default, real-time searchable)
+    ///   • indexes - Standard indexed logs (real-time searchable)
     ///   • online-archives - Rehydrated logs from archives (slower queries, lower cost)
-    ///   • flex - Flex logs (cost-optimized storage tier, balanced performance)
+    ///   • flex - Flex logs (default for search and aggregate, cost-optimized storage tier)
     ///
     /// LOG QUERY SYNTAX:
     ///   Logs use a query language similar to web search:
@@ -3154,7 +3154,11 @@ enum LogActions {
             help = "Log indexes to aggregate, comma-separated or repeated"
         )]
         index: Vec<String>,
-        #[arg(long, help = "Storage tier: indexes, online-archives, or flex")]
+        #[arg(
+            long,
+            default_value = "flex",
+            help = "Storage tier: indexes, online-archives, or flex"
+        )]
         storage: Option<String>,
     },
     /// List logs (v2 API)
@@ -3244,7 +3248,11 @@ enum LogActions {
         group_by: Option<String>,
         #[arg(long, default_value_t = 10, help = "Maximum groups per facet")]
         limit: i32,
-        #[arg(long, help = "Storage tier: indexes, online-archives, or flex")]
+        #[arg(
+            long,
+            default_value = "flex",
+            help = "Storage tier: indexes, online-archives, or flex"
+        )]
         storage: Option<String>,
         #[arg(
             long,

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -570,6 +570,61 @@ fn test_logs_list_sort_accepts_hyphen_timestamp() {
 }
 
 #[test]
+fn test_logs_search_and_aggregate_default_to_flex_storage() {
+    use clap::Parser;
+
+    let search = crate::Cli::try_parse_from(["pup", "logs", "search", "--query", "*"])
+        .expect("logs search should parse");
+    let aggregate = crate::Cli::try_parse_from(["pup", "logs", "aggregate"])
+        .expect("logs aggregate should parse");
+
+    match search.command {
+        crate::Commands::Logs {
+            action: crate::LogActions::Search { storage, .. },
+        } => assert_eq!(storage.as_deref(), Some("flex")),
+        _ => panic!("expected LogActions::Search"),
+    }
+    match aggregate.command {
+        crate::Commands::Logs {
+            action: crate::LogActions::Aggregate { storage, .. },
+        } => assert_eq!(storage.as_deref(), Some("flex")),
+        _ => panic!("expected LogActions::Aggregate"),
+    }
+}
+
+#[test]
+fn test_logs_search_and_aggregate_storage_overrides_are_preserved() {
+    use clap::Parser;
+
+    let search = crate::Cli::try_parse_from([
+        "pup",
+        "logs",
+        "search",
+        "--query",
+        "*",
+        "--storage",
+        "indexes",
+    ])
+    .expect("logs search --storage indexes should parse");
+    let aggregate =
+        crate::Cli::try_parse_from(["pup", "logs", "aggregate", "--storage", "online-archives"])
+            .expect("logs aggregate --storage online-archives should parse");
+
+    match search.command {
+        crate::Commands::Logs {
+            action: crate::LogActions::Search { storage, .. },
+        } => assert_eq!(storage.as_deref(), Some("indexes")),
+        _ => panic!("expected LogActions::Search"),
+    }
+    match aggregate.command {
+        crate::Commands::Logs {
+            action: crate::LogActions::Aggregate { storage, .. },
+        } => assert_eq!(storage.as_deref(), Some("online-archives")),
+        _ => panic!("expected LogActions::Aggregate"),
+    }
+}
+
+#[test]
 fn test_logs_saved_views_create_parses() {
     use clap::Parser;
 


### PR DESCRIPTION
## Summary

Default `--storage` to `flex` for `pup logs search` and `pup logs aggregate`, while preserving explicit storage-tier overrides. The generated `--help` output now advertises `[default: flex]`, and the storage-tier examples identify Flex as the default.

## Testing

- Added parser coverage for both defaults and explicit overrides
- Verified `logs search --help` and `logs aggregate --help` show the Flex default
- `cargo test test_logs_search_and_aggregate`

The full `cargo test` run passed 1,707 tests; six unrelated mock tests failed because they attempted DNS requests to `unused.local`.