### PR TITLE
cloud-auth: document opt-in OAuth scopes for persona-mappings | DAL-981

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -401,6 +401,23 @@ mod tests {
     }
 
     #[test]
+    fn test_default_scopes_excludes_workload_identity_federation() {
+        let scopes = default_scopes();
+        // workload_identity_federation_read/write are only ever granted to
+        // admins, so they're opt-in only (see 'pup cloud-auth' AUTHENTICATION
+        // doc) rather than requested by default.
+        assert!(!scopes.contains(&"workload_identity_federation_read"));
+        assert!(!scopes.contains(&"workload_identity_federation_write"));
+    }
+
+    #[test]
+    fn test_read_only_scopes_excludes_workload_identity_federation() {
+        let ro = read_only_scopes();
+        assert!(!ro.contains(&"workload_identity_federation_read"));
+        assert!(!ro.contains(&"workload_identity_federation_write"));
+    }
+
+    #[test]
     fn test_read_only_scopes_subset_of_default() {
         let default: std::collections::HashSet<&str> = default_scopes().into_iter().collect();
         for scope in read_only_scopes() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7902,7 +7902,13 @@ enum IntegrationActions {
 #[derive(Subcommand)]
 enum IntegrationAwsActions {
     /// Manage AWS cloud authentication
-    #[command(name = "cloud-auth")]
+    ///
+    /// AUTHENTICATION:
+    ///   Requires OAuth2 (via 'pup auth login') or API + Application keys.
+    ///   OAuth2 requires the workload_identity_federation_read/write scopes,
+    ///   which are not requested by default -- opt in with:
+    ///     pup auth login --extra-scopes workload_identity_federation_read,workload_identity_federation_write
+    #[command(name = "cloud-auth", verbatim_doc_comment)]
     CloudAuth {
         #[command(subcommand)]
         action: CloudAuthActions,


### PR DESCRIPTION
pup's `cloud-auth persona-mappings` commands already send the OAuth bearer token automatically (no command-logic change needed). The server-side routes now accept OAuth, gated by scopes `workload_identity_federation_read`/`write`.

These two permissions are only ever granted to admins, so -- per direction from the team -- they're documented as opt-in via `--extra-scopes` rather than added to `default_scopes()`, matching the existing precedent for other admin-only scopes (`api_keys_*`, `app_keys_*`, `service_account_write`, see #702).

## Changes
- Add an AUTHENTICATION doc block to the `cloud-auth` command noting the required scopes and the opt-in invocation.
- Add regression tests asserting `workload_identity_federation_read`/`write` are excluded from both `default_scopes()` and `read_only_scopes()`.

## Test plan
- [x] CI green
- [x] E2e tested against staging with server-side OAuth support already in place: `--extra-scopes workload_identity_federation_read,workload_identity_federation_write` logs in successfully, `list`/`get` return real data over the bearer token, and `create` reaches business-logic validation (not an auth error), confirming the OAuth path works end-to-end for both read and write.
