### PR TITLE
feat(logs): add patterns subcommand

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -24,7 +24,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | acp | serve | src/commands/acp.rs | ✅ |
 | auth | login, logout, status, refresh | src/commands/auth.rs | ✅ |
 | metrics | query, list, search, timeseries, metadata, tags, submit | src/commands/metrics.rs | ✅ |
-| logs | search, list, aggregate, saved-views (list, get, create, delete) | src/commands/logs.rs | ✅ |
+| logs | search, list, aggregate, patterns, saved-views (list, get, create, delete) | src/commands/logs.rs | ✅ |
 | traces | metrics (list, get, create, update, delete) | src/commands/traces.rs | ✅ |
 | monitors | list, get, create, update, delete, search, diff | src/commands/monitors.rs | ✅ |
 | dashboards | list, get, delete, url, annotations (list, get-page, create, update, delete) | src/commands/dashboards.rs, src/commands/annotations.rs | ✅ |
@@ -111,6 +111,7 @@ pup slos get abc-123-def
 ```bash
 pup logs search --query="status:error" --from="1h"
 pup logs search --query="service:api" --from="7d" --storage="flex"
+pup logs patterns --query="status:error" --pattern-field="message" --from="1h"
 pup logs query --query="service:api" --index="main,security" --from="1h"
 pup logs saved-views create --file=saved-view.json
 pup dbm samples search --query="dbm_type:activity service:orders env:prod" --from="1h" --limit=10

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -139,10 +139,11 @@ pup logs patterns \
   --pattern-field="message" \
   --from="1h"
 
-# Analyze a specific index with larger sampling limits
+# Analyze a specific index with larger sampling limits and grouping fields
 pup logs patterns \
   --query="service:api" \
   --pattern-field="@request.path" \
+  --group-by="service,status" \
   --index="main" \
   --sample-limit=100 \
   --event-limit=20000 \

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -131,6 +131,26 @@ pup logs query --query="service:api" --index="main,security" --from="1h"
 pup logs query --query="service:api" --index="main" --index="security" --from="1h"
 ```
 
+### Find Similar Log Patterns
+```bash
+# Cluster similar message values instead of grouping exact values
+pup logs patterns \
+  --query="status:error" \
+  --pattern-field="message" \
+  --from="1h"
+
+# Analyze a specific index with larger sampling limits
+pup logs patterns \
+  --query="service:api" \
+  --pattern-field="@request.path" \
+  --index="main" \
+  --sample-limit=100 \
+  --event-limit=20000 \
+  --from="24h"
+```
+
+Pattern clustering returns similar-value groups. Use `logs aggregate --group-by` when exact-value buckets are required.
+
 ### Aggregate Logs
 ```bash
 # Count logs by status

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -14,6 +14,7 @@ use crate::util;
 use crate::util_ext;
 
 const SAVED_VIEWS_PATH: &str = "/api/v1/logs/views";
+const PATTERNS_PATH: &str = "/api/v1/logs-analytics/cluster?type=logs";
 
 pub struct AggregateArgs {
     pub query: String,
@@ -35,6 +36,16 @@ pub struct SearchArgs {
     pub limit: i32,
     pub sort: String,
     pub storage: Option<String>,
+    pub index: Vec<String>,
+}
+
+pub struct PatternArgs {
+    pub query: String,
+    pub pattern_field: String,
+    pub from: String,
+    pub to: String,
+    pub sample_limit: i32,
+    pub event_limit: i32,
     pub index: Vec<String>,
 }
 
@@ -283,6 +294,80 @@ pub async fn query(cfg: &Config, args: SearchArgs) -> Result<()> {
     search(cfg, args).await
 }
 
+fn build_patterns_body(
+    query: String,
+    pattern_field: String,
+    from_ms: i64,
+    to_ms: i64,
+    sample_limit: i32,
+    event_limit: i32,
+    index: Vec<String>,
+) -> Result<serde_json::Value> {
+    if pattern_field.trim().is_empty() {
+        bail!("--pattern-field must not be empty");
+    }
+    if sample_limit <= 0 {
+        bail!("--sample-limit must be greater than zero");
+    }
+    if event_limit <= 0 {
+        bail!("--event-limit must be greater than zero");
+    }
+    if from_ms > to_ms {
+        bail!("--from must not be after --to");
+    }
+
+    Ok(serde_json::json!({
+        "cluster": {
+            "time": {
+                "from": from_ms.to_string(),
+                "to": to_ms.to_string(),
+            },
+            "search": { "query": query },
+            "sampleLimit": sample_limit,
+            "eventLimit": event_limit,
+            "computeGrokParser": true,
+            "indexes": if index.is_empty() {
+                vec!["*".to_string()]
+            } else {
+                index
+            },
+            "clusteringFieldPaths": [],
+            "clusteringPatternFieldPath": pattern_field,
+            "ignoreDocumentsWithEmptyText": true,
+            "executionInfo": {},
+            "includeWildcardSummaries": false,
+        },
+        "querySourceId": "logs_explorer",
+    }))
+}
+
+pub async fn patterns(cfg: &Config, args: PatternArgs) -> Result<()> {
+    let PatternArgs {
+        query,
+        pattern_field,
+        from,
+        to,
+        sample_limit,
+        event_limit,
+        index,
+    } = args;
+    let from_ms = util_ext::parse_time_to_unix_millis(&from)?;
+    let to_ms = util_ext::parse_time_to_unix_millis(&to)?;
+    let body = build_patterns_body(
+        query,
+        pattern_field,
+        from_ms,
+        to_ms,
+        sample_limit,
+        event_limit,
+        index,
+    )?;
+    let data = raw_client::raw_post(cfg, PATTERNS_PATH, body)
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to cluster log patterns: {error}"))?;
+    formatter::output(cfg, &data)
+}
+
 pub async fn aggregate(cfg: &Config, args: AggregateArgs) -> Result<()> {
     let AggregateArgs {
         query,
@@ -469,6 +554,69 @@ mod tests {
     fn test_normalize_storage_tier_alias() {
         let tier = normalize_storage_tier(Some("online_archives".into())).unwrap();
         assert_eq!(tier.unwrap(), "online-archives");
+    }
+
+    #[test]
+    fn test_build_patterns_body_uses_defaults_and_all_indexes() {
+        let body = build_patterns_body(
+            "status:error".into(),
+            "message".into(),
+            1,
+            2,
+            50,
+            100,
+            vec![],
+        )
+        .unwrap();
+
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "cluster": {
+                    "time": { "from": "1", "to": "2" },
+                    "search": { "query": "status:error" },
+                    "sampleLimit": 50,
+                    "eventLimit": 100,
+                    "computeGrokParser": true,
+                    "indexes": ["*"],
+                    "clusteringFieldPaths": [],
+                    "clusteringPatternFieldPath": "message",
+                    "ignoreDocumentsWithEmptyText": true,
+                    "executionInfo": {},
+                    "includeWildcardSummaries": false,
+                },
+                "querySourceId": "logs_explorer",
+            })
+        );
+    }
+
+    #[test]
+    fn test_build_patterns_body_preserves_indexes() {
+        let body = build_patterns_body(
+            "*".into(),
+            "@request.path".into(),
+            1,
+            2,
+            50,
+            100,
+            vec!["main".into(), "security".into()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["cluster"]["indexes"],
+            serde_json::json!(["main", "security"])
+        );
+    }
+
+    #[test]
+    fn test_build_patterns_body_rejects_invalid_input() {
+        let valid = || build_patterns_body("*".into(), "message".into(), 1, 2, 50, 100, vec![]);
+        assert!(valid().is_ok());
+        assert!(build_patterns_body("*".into(), " ".into(), 1, 2, 50, 100, vec![]).is_err());
+        assert!(build_patterns_body("*".into(), "message".into(), 1, 2, 0, 100, vec![]).is_err());
+        assert!(build_patterns_body("*".into(), "message".into(), 1, 2, 50, 0, vec![]).is_err());
+        assert!(build_patterns_body("*".into(), "message".into(), 2, 1, 50, 100, vec![]).is_err());
     }
 
     #[test]
@@ -972,6 +1120,148 @@ mod tests {
 
         let result = super::search(&cfg, search_args("status:error", None, vec![])).await;
         assert!(result.is_ok(), "logs search should work with OAuth");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_logs_patterns() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", "/api/v1/logs-analytics/cluster")
+            .match_query(mockito::Matcher::UrlEncoded("type".into(), "logs".into()))
+            .match_header("dd-api-key", "test-api-key")
+            .match_header("dd-application-key", "test-app-key")
+            .match_body(mockito::Matcher::Regex(
+                r#""clusteringPatternFieldPath":"message""#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"clusters": []}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns(
+            &cfg,
+            super::PatternArgs {
+                query: "status:error".into(),
+                pattern_field: "message".into(),
+                from: "1h".into(),
+                to: "now".into(),
+                sample_limit: 50,
+                event_limit: 100,
+                index: vec![],
+            },
+        )
+        .await;
+        assert!(result.is_ok(), "logs patterns failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_logs_patterns_with_oauth() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        std::env::set_var("PUP_MOCK_SERVER", server.url());
+        let cfg = Config {
+            api_key: None,
+            app_key: None,
+            access_token: Some("token".into()),
+            site: "datadoghq.com".into(),
+            site_explicit: false,
+            org: None,
+            output_format: OutputFormat::Json,
+            auto_approve: false,
+            agent_mode: false,
+            read_only: false,
+            jq: None,
+        };
+        let _mock = server
+            .mock("POST", "/api/v1/logs-analytics/cluster")
+            .match_query(mockito::Matcher::UrlEncoded("type".into(), "logs".into()))
+            .match_header("authorization", "Bearer token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"clusters": []}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns(
+            &cfg,
+            super::PatternArgs {
+                query: "*".into(),
+                pattern_field: "message".into(),
+                from: "1h".into(),
+                to: "now".into(),
+                sample_limit: 50,
+                event_limit: 100,
+                index: vec![],
+            },
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "logs patterns with OAuth failed: {result:?}"
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_logs_patterns_returns_endpoint_error() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", "/api/v1/logs-analytics/cluster")
+            .match_query(mockito::Matcher::UrlEncoded("type".into(), "logs".into()))
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors": ["forbidden"]}"#)
+            .create_async()
+            .await;
+
+        let result = super::patterns(
+            &cfg,
+            super::PatternArgs {
+                query: "*".into(),
+                pattern_field: "message".into(),
+                from: "1h".into(),
+                to: "now".into(),
+                sample_limit: 50,
+                event_limit: 100,
+                index: vec![],
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to cluster log patterns"));
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_logs_patterns_rejects_invalid_time() {
+        let _lock = lock_env().await;
+        let server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let result = super::patterns(
+            &cfg,
+            super::PatternArgs {
+                query: "*".into(),
+                pattern_field: "message".into(),
+                from: "not-a-time".into(),
+                to: "now".into(),
+                sample_limit: 50,
+                event_limit: 100,
+                index: vec![],
+            },
+        )
+        .await;
+        assert!(result.is_err());
         cleanup_env();
     }
 

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -47,6 +47,7 @@ pub struct PatternArgs {
     pub sample_limit: i32,
     pub event_limit: i32,
     pub index: Vec<String>,
+    pub group_by: Vec<String>,
 }
 
 fn normalize_storage_tier(storage: Option<String>) -> Result<Option<String>> {
@@ -294,6 +295,7 @@ pub async fn query(cfg: &Config, args: SearchArgs) -> Result<()> {
     search(cfg, args).await
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_patterns_body(
     query: String,
     pattern_field: String,
@@ -302,6 +304,7 @@ fn build_patterns_body(
     sample_limit: i32,
     event_limit: i32,
     index: Vec<String>,
+    group_by: Vec<String>,
 ) -> Result<serde_json::Value> {
     if pattern_field.trim().is_empty() {
         bail!("--pattern-field must not be empty");
@@ -331,7 +334,7 @@ fn build_patterns_body(
             } else {
                 index
             },
-            "clusteringFieldPaths": [],
+            "clusteringFieldPaths": group_by,
             "clusteringPatternFieldPath": pattern_field,
             "ignoreDocumentsWithEmptyText": true,
             "executionInfo": {},
@@ -350,6 +353,7 @@ pub async fn patterns(cfg: &Config, args: PatternArgs) -> Result<()> {
         sample_limit,
         event_limit,
         index,
+        group_by,
     } = args;
     let from_ms = util_ext::parse_time_to_unix_millis(&from)?;
     let to_ms = util_ext::parse_time_to_unix_millis(&to)?;
@@ -361,6 +365,7 @@ pub async fn patterns(cfg: &Config, args: PatternArgs) -> Result<()> {
         sample_limit,
         event_limit,
         index,
+        group_by,
     )?;
     let data = raw_client::raw_post(cfg, PATTERNS_PATH, body)
         .await
@@ -566,6 +571,7 @@ mod tests {
             50,
             100,
             vec![],
+            vec![],
         )
         .unwrap();
 
@@ -600,6 +606,7 @@ mod tests {
             50,
             100,
             vec!["main".into(), "security".into()],
+            vec!["service".into(), "status".into()],
         )
         .unwrap();
 
@@ -607,16 +614,31 @@ mod tests {
             body["cluster"]["indexes"],
             serde_json::json!(["main", "security"])
         );
+        assert_eq!(
+            body["cluster"]["clusteringFieldPaths"],
+            serde_json::json!(["service", "status"])
+        );
     }
 
     #[test]
     fn test_build_patterns_body_rejects_invalid_input() {
-        let valid = || build_patterns_body("*".into(), "message".into(), 1, 2, 50, 100, vec![]);
+        let valid =
+            || build_patterns_body("*".into(), "message".into(), 1, 2, 50, 100, vec![], vec![]);
         assert!(valid().is_ok());
-        assert!(build_patterns_body("*".into(), " ".into(), 1, 2, 50, 100, vec![]).is_err());
-        assert!(build_patterns_body("*".into(), "message".into(), 1, 2, 0, 100, vec![]).is_err());
-        assert!(build_patterns_body("*".into(), "message".into(), 1, 2, 50, 0, vec![]).is_err());
-        assert!(build_patterns_body("*".into(), "message".into(), 2, 1, 50, 100, vec![]).is_err());
+        assert!(
+            build_patterns_body("*".into(), " ".into(), 1, 2, 50, 100, vec![], vec![]).is_err()
+        );
+        assert!(
+            build_patterns_body("*".into(), "message".into(), 1, 2, 0, 100, vec![], vec![])
+                .is_err()
+        );
+        assert!(
+            build_patterns_body("*".into(), "message".into(), 1, 2, 50, 0, vec![], vec![]).is_err()
+        );
+        assert!(
+            build_patterns_body("*".into(), "message".into(), 2, 1, 50, 100, vec![], vec![])
+                .is_err()
+        );
     }
 
     #[test]
@@ -1152,6 +1174,7 @@ mod tests {
                 sample_limit: 50,
                 event_limit: 100,
                 index: vec![],
+                group_by: vec![],
             },
         )
         .await;
@@ -1197,6 +1220,7 @@ mod tests {
                 sample_limit: 50,
                 event_limit: 100,
                 index: vec![],
+                group_by: vec![],
             },
         )
         .await;
@@ -1231,6 +1255,7 @@ mod tests {
                 sample_limit: 50,
                 event_limit: 100,
                 index: vec![],
+                group_by: vec![],
             },
         )
         .await;
@@ -1258,6 +1283,7 @@ mod tests {
                 sample_limit: 50,
                 event_limit: 100,
                 index: vec![],
+                group_by: vec![],
             },
         )
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3223,6 +3223,35 @@ enum LogActions {
         #[arg(long, help = "Timezone for timestamps")]
         timezone: Option<String>,
     },
+    /// Find similar log-message patterns (v1 API)
+    Patterns {
+        #[arg(long, help = "Log query (required)")]
+        query: String,
+        #[arg(long, help = "Field whose similar values are clustered (required)")]
+        pattern_field: String,
+        #[arg(
+            long,
+            default_value = "1h",
+            help = "Start time: 1h, 5min, 2hours, '5 minutes', RFC3339, Unix timestamp, or 'now'"
+        )]
+        from: String,
+        #[arg(long, default_value = "now", help = "End time")]
+        to: String,
+        #[arg(
+            long,
+            default_value_t = 50,
+            help = "Maximum representative samples per pattern"
+        )]
+        sample_limit: i32,
+        #[arg(long, default_value_t = 10_000, help = "Maximum events to analyze")]
+        event_limit: i32,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Log indexes to search, comma-separated or repeated (all indexes by default)"
+        )]
+        index: Vec<String>,
+    },
     /// Aggregate logs (v2 API)
     Aggregate {
         #[arg(long, help = "Log query (required)")]
@@ -12521,6 +12550,29 @@ async fn main_inner() -> anyhow::Result<()> {
                             limit,
                             sort,
                             storage,
+                            index,
+                        },
+                    )
+                    .await?;
+                }
+                LogActions::Patterns {
+                    query,
+                    pattern_field,
+                    from,
+                    to,
+                    sample_limit,
+                    event_limit,
+                    index,
+                } => {
+                    commands::logs::patterns(
+                        &cfg,
+                        commands::logs::PatternArgs {
+                            query,
+                            pattern_field,
+                            from,
+                            to,
+                            sample_limit,
+                            event_limit,
                             index,
                         },
                     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -3251,6 +3251,12 @@ enum LogActions {
             help = "Log indexes to search, comma-separated or repeated (all indexes by default)"
         )]
         index: Vec<String>,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Fields to group patterns by, comma-separated or repeated"
+        )]
+        group_by: Vec<String>,
     },
     /// Aggregate logs (v2 API)
     Aggregate {
@@ -12563,6 +12569,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     sample_limit,
                     event_limit,
                     index,
+                    group_by,
                 } => {
                     commands::logs::patterns(
                         &cfg,
@@ -12574,6 +12581,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             sample_limit,
                             event_limit,
                             index,
+                            group_by,
                         },
                     )
                     .await?;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -583,6 +583,8 @@ fn test_logs_patterns_parses_and_is_read_only() {
         "message",
         "--index",
         "main,security",
+        "--group-by",
+        "service,status",
     ])
     .expect("logs patterns should parse");
 
@@ -594,6 +596,7 @@ fn test_logs_patterns_parses_and_is_read_only() {
                     sample_limit,
                     event_limit,
                     index,
+                    group_by,
                     ..
                 },
         } => {
@@ -601,6 +604,7 @@ fn test_logs_patterns_parses_and_is_read_only() {
             assert_eq!(sample_limit, 50);
             assert_eq!(event_limit, 10_000);
             assert_eq!(index, vec!["main", "security"]);
+            assert_eq!(group_by, vec!["service", "status"]);
         }
         _ => panic!("expected LogActions::Patterns"),
     }

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -570,6 +570,59 @@ fn test_logs_list_sort_accepts_hyphen_timestamp() {
 }
 
 #[test]
+fn test_logs_patterns_parses_and_is_read_only() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "logs",
+        "patterns",
+        "--query",
+        "status:error",
+        "--pattern-field",
+        "message",
+        "--index",
+        "main,security",
+    ])
+    .expect("logs patterns should parse");
+
+    match cli.command {
+        crate::Commands::Logs {
+            action:
+                crate::LogActions::Patterns {
+                    pattern_field,
+                    sample_limit,
+                    event_limit,
+                    index,
+                    ..
+                },
+        } => {
+            assert_eq!(pattern_field, "message");
+            assert_eq!(sample_limit, 50);
+            assert_eq!(event_limit, 10_000);
+            assert_eq!(index, vec!["main", "security"]);
+        }
+        _ => panic!("expected LogActions::Patterns"),
+    }
+
+    let command = crate::Cli::command();
+    let schema = crate::build_agent_schema(&command);
+    let logs = schema["commands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|command| command["name"] == "logs")
+        .expect("logs must be present in the agent schema");
+    let patterns = logs["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|command| command["name"] == "patterns")
+        .expect("logs patterns must be present in the agent schema");
+    assert_eq!(patterns["read_only"], true);
+}
+
+#[test]
 fn test_logs_search_and_aggregate_default_to_flex_storage() {
     use clap::Parser;
 


### PR DESCRIPTION
## What does this PR do?

This adds the subcommand `pup logs pattern`, which can be used to find patterns in logs as documented here: https://docs.datadoghq.com/logs/explorer/analytics/patterns/

It's using the same API as the webui uses.

## Motivation

I needed an agent to find patterns in logs, instead of downloading all logs and finding the patterns locally.

## Additional Notes

I haven't found official API documentation. This was based on what the webui requests.

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

-
