### PR TITLE
fix(synthetics): tolerate null in downtime list

### DIFF
--- a/src/commands/synthetics.rs
+++ b/src/commands/synthetics.rs
@@ -556,17 +556,36 @@ pub async fn downtime_list(
 ) -> Result<()> {
     let api = crate::make_api!(SyntheticsV2API, cfg);
     let mut params = ListSyntheticsDowntimesOptionalParams::default();
-    if let Some(ids) = filter_test_ids {
+    if let Some(ids) = filter_test_ids.clone() {
         params = params.filter_test_ids(ids);
     }
-    if let Some(active) = filter_active {
+    if let Some(active) = filter_active.clone() {
         params = params.filter_active(active);
     }
-    let resp = api
-        .list_synthetics_downtimes(params)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to list synthetics downtimes: {e:?}"))?;
-    formatter::output(cfg, &resp)
+    match api.list_synthetics_downtimes(params).await {
+        Ok(resp) => formatter::output(cfg, &resp),
+        // Issue #722: the typed V2 model rejects downtime payloads that contain
+        // `null` where it expects an array ("invalid type: null, expected a
+        // sequence"). This deserialization failure only happens on a successful
+        // (2xx) response, so fall back to emitting the raw JSON:API body, which
+        // tolerates nulls. Genuine HTTP errors surface through the arm below.
+        Err(datadog_api_client::datadog::Error::Serde(_)) => {
+            let mut query: Vec<(&str, &str)> = Vec::new();
+            if let Some(ids) = filter_test_ids.as_deref() {
+                query.push(("filter[test_ids]", ids));
+            }
+            if let Some(active) = filter_active.as_deref() {
+                query.push(("filter[active]", active));
+            }
+            let resp = crate::raw_client::raw_get(cfg, "/api/v2/synthetics/downtimes", &query)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to list synthetics downtimes: {e}"))?;
+            formatter::output(cfg, &resp)
+        }
+        Err(e) => Err(anyhow::anyhow!(
+            "failed to list synthetics downtimes: {e:?}"
+        )),
+    }
 }
 
 pub async fn downtime_create(cfg: &Config, file: &str) -> Result<()> {
@@ -914,6 +933,46 @@ mod tests {
             .await;
         let result = super::downtime_list(&cfg, None, None).await;
         assert!(result.is_err(), "expected 403 error from downtime_list");
+        cleanup_env();
+    }
+
+    // Issue #722: a successful (2xx) response whose shape the typed V2 model
+    // cannot deserialize (here `data` is an object where a sequence is
+    // expected, mirroring the reported "invalid type: null, expected a
+    // sequence") must fall back to the raw JSON:API body instead of erroring.
+    #[tokio::test]
+    async fn test_synthetics_downtime_list_falls_back_on_deserialize_error() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let _mock = mock_any(&mut s, "GET", r#"{"data":{}}"#).await;
+        let result = super::downtime_list(&cfg, None, None).await;
+        assert!(
+            result.is_ok(),
+            "downtime_list should fall back to raw output on deserialize error: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    // The raw fallback must still forward the test-id and active filters.
+    #[tokio::test]
+    async fn test_synthetics_downtime_list_fallback_with_filters() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let _mock = mock_any(&mut s, "GET", r#"{"data":{}}"#).await;
+        let result = super::downtime_list(
+            &cfg,
+            Some("abc-def-ghi".to_string()),
+            Some("true".to_string()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "downtime_list fallback with filters failed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"20cbf2e5-830e-4801-a1fd-5db643c7d07f","source":"chat","resourceId":"c3a386e1-87d6-4182-93c9-fe3722b21c1b","workflowId":"9fede921-3003-4c42-a09d-ee5bfbeaba05","codeChangeId":"9fede921-3003-4c42-a09d-ee5bfbeaba05","sourceType":"chat"} -->
## What does this PR do?

Fixes `pup synthetics downtime list` failing on a **successful** API response with:

```
Error: failed to list synthetics downtimes: Serde(Error("invalid type: null, expected a sequence", ...))
```

The typed `datadog-api-client` V2 model deserializes downtime responses strictly, so a `null` where it expects a JSON array aborts the whole listing. This change adds a targeted fallback in `downtime_list` (`src/commands/synthetics.rs`):

- Keep the existing typed `list_synthetics_downtimes` call for the happy path (unchanged output, zero regression risk).
- Only when it fails with a `datadog::Error::Serde(_)` — the exact failure mode in #722, which per the reporter occurs solely on 2xx responses — re-fetch via the existing null-tolerant `raw_client::raw_get` against `/api/v2/synthetics/downtimes` and emit the raw JSON:API body.
- The `--filter-test-ids` / `--filter-active` filters are forwarded on the fallback path (`filter[test_ids]` / `filter[active]`, matching the repo's existing V2 filter convention in `apm.rs`).
- Genuine HTTP errors (e.g. 403) keep their original error handling.

## Motivation

`synthetics downtime list` is completely unusable against any org whose downtime payload contains a null array field: the strict typed model turns an otherwise-valid 2xx response into a hard error. Reusing the project's existing `raw_client` (rather than patching the pinned SDK crate) restores the command while leaving healthy responses and real error responses untouched.

## Additional Notes

- Reuses `raw_client::raw_get` (same pattern as `apm.rs` / `change_stories.rs`) instead of introducing new HTTP plumbing; no new imports or dependencies.
- The fallback is scoped strictly to the `Serde` deserialization variant, so it can never mask legitimate API errors.
- Sandbox limitation: the pinned `datadog-api-client` git dependency could not be fetched through the environment's proxy allowlist, so `cargo build`/`cargo test` could not be run here. Verified with `cargo fmt --check` (passes) plus manual review. CI will run the full build/clippy/test matrix.

## Testing

Added two unit tests in the existing `mockito`-based harness:

- `test_synthetics_downtime_list_falls_back_on_deserialize_error` — a 2xx body the typed model can't deserialize now yields output via the raw fallback instead of an error.
- `test_synthetics_downtime_list_fallback_with_filters` — the fallback path with both filters set.

Existing tests remain valid: `test_synthetics_downtime_list` (healthy `{"data":[]}` → typed path) and `test_synthetics_downtime_list_error` (403 → error) are unaffected.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable) — not applicable (no user-facing behavior/flags changed)
- [ ] All CI checks pass — could not be run in the sandbox; pending CI
- [x] Code coverage is maintained or improved

## Related Issues

Closes #722

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c3a386e1-87d6-4182-93c9-fe3722b21c1b)

Comment @datadog to request changes