### PR TITLE
Add core resource diff commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -27,11 +27,11 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | logs | search, list, aggregate, saved-views (list, get, create, delete) | src/commands/logs.rs | ✅ |
 | traces | metrics (list, get, create, update, delete) | src/commands/traces.rs | ✅ |
 | monitors | list, get, create, update, delete, search, diff | src/commands/monitors.rs | ✅ |
-| dashboards | list, get, delete, url, annotations (list, get-page, create, update, delete) | src/commands/dashboards.rs, src/commands/annotations.rs | ✅ |
+| dashboards | list, get, create, update, diff, delete, url, annotations (list, get-page, create, update, delete) | src/commands/dashboards.rs, src/commands/annotations.rs | ✅ |
 | dbm | samples (search) | src/commands/dbm.rs | ✅ |
 | ddsql | table, time-series, spec, schema (tables, columns) | src/commands/ddsql.rs | ✅ |
 | debugger | probes (list, get, create, delete, watch) | src/commands/debugger.rs | ✅ |
-| slos | list, get, delete, status | src/commands/slos.rs | ✅ |
+| slos | list, get, create, update, diff, delete, status | src/commands/slos.rs | ✅ |
 | incidents | list, get, attachments, settings, handles, postmortem-templates | src/commands/incidents.rs | ✅ |
 | rum | apps, metrics, retention-filters, sessions, playlists, heatmaps | src/commands/rum.rs | ✅ |
 | cicd | pipelines, events, tests, dora, flaky-tests | src/commands/cicd.rs | ✅ |
@@ -49,7 +49,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | logs-restriction | list, get, create, update, delete, roles (list, add) | src/commands/logs_restriction.rs | ✅ |
 | processes | list | src/commands/processes.rs | ✅ |
 | users | list, get, roles, service-accounts (create, app-keys CRUD) | src/commands/users.rs | ✅ |
-| notebooks | list, get, delete, annotations (list, get-page, create, update, delete) | src/commands/notebooks.rs, src/commands/annotations.rs | ✅ |
+| notebooks | list, get, create, update, diff, delete, annotations (list, get-page, create, update, delete) | src/commands/notebooks.rs, src/commands/annotations.rs | ✅ |
 | security | rules, signals, findings, content-packs, risk-scores | src/commands/security.rs | ✅ |
 | organizations | get, list | src/commands/organizations.rs | ✅ |
 | service-catalog | list, get | src/commands/service_catalog.rs | ✅ |
@@ -65,7 +65,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | datasets | list, get, create, update, delete | src/commands/datasets.rs | ✅ |
 | data-deletion | requests (list, create, cancel) | src/commands/data_deletion.rs | ✅ |
 | data-governance | scanner-rules (list) | src/commands/data_governance.rs | ✅ |
-| obs-pipelines | list, get, create, update, delete, validate | src/commands/obs_pipelines.rs | ✅ |
+| obs-pipelines | list, get, create, update, diff, delete, validate | src/commands/obs_pipelines.rs | ✅ |
 | llm-obs | projects (create, list), experiments (create, list, update, delete, summary, events (list, get, submit), metric-values, dimension-values), datasets (create, list, batch-update, clone, restore, records, records-add, records-all, records-full), spans (search), patterns (configs (list, get), runs (list, status), topics, topics-with-points, points), agent-insights (list, get, update-status, submit-feedback), model-pricing | src/commands/llm_obs.rs | ✅ |
 | reference-tables | list, get, create, batch-query | src/commands/reference_tables.rs | ✅ |
 | network | flows list, devices (list, get, interfaces, tags), interfaces (list, update) | src/commands/network.rs | ✅ |
@@ -209,7 +209,7 @@ pup infrastructure hosts list
 - **costs** - Cost management: `datadog` subgroup (projected, attribution, by-org, aws-config, azure-config, gcp-config), `ccm` subgroup (custom-costs, tag-descriptions, tag-metadata, tags, tag-keys, budgets, commitments), `oci-configs` subgroup (list), and `anomalies` subgroup (list)
 
 ### Configuration & Data Management
-- **obs-pipelines** - Observability pipelines (list, get, create, update, delete, validate)
+- **obs-pipelines** - Observability pipelines (list, get, create, update, diff, delete, validate)
 - **llm-obs** - LLM Observability (projects, experiments, datasets, spans, agent insights, model pricing)
 - **reference-tables** - Reference tables for log enrichment (list, get, create, batch-query)
 - **misc** - Miscellaneous (ip-ranges, status)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -208,6 +208,16 @@ pup dashboards url "abc-123-def"
 pup dashboards url "abc-123-def" --from=now-1w --to=now --live=true
 ```
 
+### Diff Dashboard
+```bash
+# Compare a candidate JSON file against the live dashboard
+pup dashboards diff "abc-123-def" dashboard.json
+
+# Scope or suppress specific field paths
+pup dashboards diff "abc-123-def" dashboard.json --only widgets
+pup dashboards diff "abc-123-def" dashboard.json --ignore modified_at
+```
+
 ### Delete Dashboard
 ```bash
 pup dashboards delete "abc-123-def" --yes
@@ -285,6 +295,16 @@ pup slos list --metrics-query="sum:requests.error{service:api}" --limit=25 --off
 ### Get SLO
 ```bash
 pup slos get "abc-123-def"
+```
+
+### Diff SLO
+```bash
+# Compare a candidate JSON file against the live SLO
+pup slos diff "abc-123-def" slo.json
+
+# Scope or suppress specific field paths
+pup slos diff "abc-123-def" slo.json --only thresholds
+pup slos diff "abc-123-def" slo.json --ignore overall_status
 ```
 
 ### Create SLO
@@ -754,6 +774,30 @@ pup synthetics tests get "test-id"
 ### List Synthetic Locations
 ```bash
 pup synthetics locations list
+```
+
+## Notebooks
+
+### Diff Notebook
+```bash
+# Compare a candidate JSON file against the live notebook
+pup notebooks diff 12345 notebook.json
+
+# Scope or suppress specific field paths
+pup notebooks diff 12345 notebook.json --only data.attributes.cells
+pup notebooks diff 12345 notebook.json --ignore data.attributes.modified
+```
+
+## Observability Pipelines
+
+### Diff Pipeline
+```bash
+# Compare a candidate JSON file against the live pipeline
+pup obs-pipelines diff <pipeline-id> pipeline.json
+
+# Scope or suppress specific field paths
+pup obs-pipelines diff <pipeline-id> pipeline.json --only data.attributes.config
+pup obs-pipelines diff <pipeline-id> pipeline.json --ignore data.attributes.updated_at
 ```
 
 ## Workflows

--- a/src/commands/dashboards.rs
+++ b/src/commands/dashboards.rs
@@ -6,7 +6,9 @@ use url::Url;
 
 use crate::config::Config;
 use crate::formatter::{self, Metadata};
+use crate::raw_client;
 use crate::util;
+use crate::util_ext;
 
 pub async fn list(cfg: &Config) -> Result<()> {
     let api = crate::make_api!(DashboardsAPI, cfg);
@@ -44,6 +46,31 @@ pub async fn update(cfg: &Config, id: &str, file: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to update dashboard: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+pub async fn diff(
+    cfg: &Config,
+    id: &str,
+    file: &str,
+    only: &[String],
+    ignore: &[String],
+) -> Result<()> {
+    let candidate: serde_json::Value = util::read_json_file(file)?;
+    let live = raw_client::raw_get(cfg, &format!("/api/v1/dashboard/{id}"), &[])
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get dashboard: {e:?}"))?;
+
+    let mut options = util_ext::ResourceDiffOptions::new(
+        "dashboards diff",
+        "pup dashboards update",
+        "dashboard",
+        id,
+    );
+    options.readonly_paths = util_ext::READONLY_DASHBOARD_FIELDS;
+    options.only = only;
+    options.ignore = ignore;
+    options.no_changes_message = Some(format!("No changes - dashboard {id} is in sync."));
+    util_ext::format_resource_diff(cfg, &live, &candidate, &options)
 }
 
 pub async fn delete(cfg: &Config, id: &str) -> Result<()> {
@@ -1146,6 +1173,58 @@ mod tests {
 
         let result = super::get(&cfg, "abc-123").await;
         assert!(result.is_ok(), "dashboards get failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_dashboards_diff_detects_changes() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let mock = server
+            .mock("GET", "/api/v1/dashboard/abc-123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                    "id": "abc-123",
+                    "title": "Old Dashboard",
+                    "layout_type": "ordered",
+                    "widgets": [],
+                    "modified_at": "2024-01-01T00:00:00Z"
+                }"#,
+            )
+            .create_async()
+            .await;
+        let path = write_temp_json(
+            "pup_dashboard_diff_detects_changes.json",
+            r#"{
+                "title": "New Dashboard",
+                "layout_type": "ordered",
+                "widgets": []
+            }"#,
+        );
+
+        let result = super::diff(&cfg, "abc-123", path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_ok(), "dashboards diff failed: {:?}", result.err());
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_dashboards_diff_invalid_json() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let path = write_temp_json("pup_dashboard_diff_invalid_json.json", "not valid json {{{");
+
+        let result = super::diff(&cfg, "abc-123", path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to parse JSON"));
         cleanup_env();
     }
 

--- a/src/commands/notebooks.rs
+++ b/src/commands/notebooks.rs
@@ -4,7 +4,9 @@ use datadog_api_client::datadogV1::model::{NotebookCreateRequest, NotebookUpdate
 
 use crate::config::Config;
 use crate::formatter;
+use crate::raw_client;
 use crate::util;
+use crate::util_ext;
 
 pub async fn list(cfg: &Config) -> Result<()> {
     let api = crate::make_api!(NotebooksAPI, cfg);
@@ -51,6 +53,32 @@ pub async fn update(cfg: &Config, notebook_id: i64, file: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to update notebook: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+pub async fn diff(
+    cfg: &Config,
+    notebook_id: i64,
+    file: &str,
+    only: &[String],
+    ignore: &[String],
+) -> Result<()> {
+    let candidate: serde_json::Value = util::read_json_file(file)?;
+    let live = raw_client::raw_get(cfg, &format!("/api/v1/notebooks/{notebook_id}"), &[])
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get notebook: {e:?}"))?;
+
+    let resource_id = notebook_id.to_string();
+    let mut options = util_ext::ResourceDiffOptions::new(
+        "notebooks diff",
+        "pup notebooks update",
+        "notebook",
+        &resource_id,
+    );
+    options.readonly_paths = util_ext::READONLY_NOTEBOOK_FIELDS;
+    options.only = only;
+    options.ignore = ignore;
+    options.no_changes_message = Some(format!("No changes - notebook {notebook_id} is in sync."));
+    util_ext::format_resource_diff(cfg, &live, &candidate, &options)
 }
 
 /// Append-only update: fetches the current notebook, appends cells from
@@ -109,6 +137,65 @@ mod tests {
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
         let _ = super::list(&cfg).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_notebooks_diff_detects_changes() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let mock = server
+            .mock("GET", "/api/v1/notebooks/12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                    "data": {
+                        "id": "12345",
+                        "type": "notebooks",
+                        "attributes": {
+                            "name": "Old Notebook",
+                            "cells": [],
+                            "modified": "2024-01-01T00:00:00Z"
+                        }
+                    }
+                }"#,
+            )
+            .create_async()
+            .await;
+        let path = write_temp_json(
+            "pup_notebook_diff_detects_changes.json",
+            r#"{
+                "data": {
+                    "attributes": {
+                        "name": "New Notebook",
+                        "cells": []
+                    }
+                }
+            }"#,
+        );
+
+        let result = super::diff(&cfg, 12345, path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_ok(), "notebooks diff failed: {:?}", result.err());
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_notebooks_diff_invalid_json() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let path = write_temp_json("pup_notebook_diff_invalid_json.json", "not valid json {{{");
+
+        let result = super::diff(&cfg, 12345, path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to parse JSON"));
         cleanup_env();
     }
 }

--- a/src/commands/obs_pipelines.rs
+++ b/src/commands/obs_pipelines.rs
@@ -6,7 +6,9 @@ use datadog_api_client::datadogV2::model::{ObservabilityPipeline, ObservabilityP
 
 use crate::config::Config;
 use crate::formatter;
+use crate::raw_client;
 use crate::util;
+use crate::util_ext;
 
 fn make_api(cfg: &Config) -> ObservabilityPipelinesAPI {
     crate::make_api!(ObservabilityPipelinesAPI, cfg)
@@ -51,6 +53,35 @@ pub async fn update(cfg: &Config, pipeline_id: &str, file: &str) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
+pub async fn diff(
+    cfg: &Config,
+    pipeline_id: &str,
+    file: &str,
+    only: &[String],
+    ignore: &[String],
+) -> Result<()> {
+    let candidate: serde_json::Value = util::read_json_file(file)?;
+    let live = raw_client::raw_get(
+        cfg,
+        &format!("/api/v2/obs-pipelines/pipelines/{pipeline_id}"),
+        &[],
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to get pipeline: {e:?}"))?;
+
+    let mut options = util_ext::ResourceDiffOptions::new(
+        "obs-pipelines diff",
+        "pup obs-pipelines update",
+        "pipeline",
+        pipeline_id,
+    );
+    options.readonly_paths = util_ext::READONLY_OBS_PIPELINE_FIELDS;
+    options.only = only;
+    options.ignore = ignore;
+    options.no_changes_message = Some(format!("No changes - pipeline {pipeline_id} is in sync."));
+    util_ext::format_resource_diff(cfg, &live, &candidate, &options)
+}
+
 pub async fn delete(cfg: &Config, pipeline_id: &str) -> Result<()> {
     let api = make_api(cfg);
     api.delete_pipeline(pipeline_id.to_string())
@@ -68,4 +99,75 @@ pub async fn validate(cfg: &Config, file: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to validate pipeline: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_support::*;
+
+    #[tokio::test]
+    async fn test_obs_pipelines_diff_detects_changes() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let mock = server
+            .mock("GET", "/api/v2/obs-pipelines/pipelines/pipeline-123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                    "data": {
+                        "id": "pipeline-123",
+                        "type": "pipelines",
+                        "attributes": {
+                            "name": "Old Pipeline",
+                            "config": {"sources": [{"id": "source", "type": "datadog_agent"}]},
+                            "updated_at": "2024-01-01T00:00:00Z"
+                        }
+                    }
+                }"#,
+            )
+            .create_async()
+            .await;
+        let path = write_temp_json(
+            "pup_obs_pipeline_diff_detects_changes.json",
+            r#"{
+                "data": {
+                    "attributes": {
+                        "name": "New Pipeline",
+                        "config": {"sources": [{"id": "source", "type": "datadog_agent"}]}
+                    }
+                }
+            }"#,
+        );
+
+        let result = super::diff(&cfg, "pipeline-123", path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(
+            result.is_ok(),
+            "obs-pipelines diff failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_obs_pipelines_diff_invalid_json() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let path = write_temp_json(
+            "pup_obs_pipeline_diff_invalid_json.json",
+            "not valid json {{{",
+        );
+
+        let result = super::diff(&cfg, "pipeline-123", path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to parse JSON"));
+        cleanup_env();
+    }
 }

--- a/src/commands/slos.rs
+++ b/src/commands/slos.rs
@@ -10,7 +10,9 @@ use datadog_api_client::datadogV2::model::RawErrorBudgetRemaining;
 
 use crate::config::Config;
 use crate::formatter;
+use crate::raw_client;
 use crate::util;
+use crate::util_ext;
 
 pub async fn list(
     cfg: &Config,
@@ -71,6 +73,26 @@ pub async fn update(cfg: &Config, id: &str, file: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to update SLO: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+pub async fn diff(
+    cfg: &Config,
+    id: &str,
+    file: &str,
+    only: &[String],
+    ignore: &[String],
+) -> Result<()> {
+    let candidate: serde_json::Value = util::read_json_file(file)?;
+    let live = raw_client::raw_get(cfg, &format!("/api/v1/slo/{id}"), &[])
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get SLO: {e:?}"))?;
+
+    let mut options = util_ext::ResourceDiffOptions::new("slos diff", "pup slos update", "SLO", id);
+    options.readonly_paths = util_ext::READONLY_SLO_FIELDS;
+    options.only = only;
+    options.ignore = ignore;
+    options.no_changes_message = Some(format!("No changes - SLO {id} is in sync."));
+    util_ext::format_resource_diff(cfg, &live, &candidate, &options)
 }
 
 pub async fn delete(cfg: &Config, id: &str) -> Result<()> {
@@ -387,6 +409,66 @@ mod tests {
 
         let result = super::get(&cfg, "abc123").await;
         assert!(result.is_ok(), "slos get failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_slos_diff_detects_changes() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let mock = server
+            .mock("GET", "/api/v1/slo/slo-123")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                    "id": "slo-123",
+                    "name": "Old SLO",
+                    "type": "metric",
+                    "query": {
+                        "numerator": "sum:requests.good{*}.as_count()",
+                        "denominator": "sum:requests.total{*}.as_count()"
+                    },
+                    "thresholds": [{"timeframe": "7d", "target": 99.9}],
+                    "overall_status": [{"status": "ok"}]
+                }"#,
+            )
+            .create_async()
+            .await;
+        let path = write_temp_json(
+            "pup_slo_diff_detects_changes.json",
+            r#"{
+                "name": "New SLO",
+                "type": "metric",
+                "query": {
+                    "numerator": "sum:requests.good{*}.as_count()",
+                    "denominator": "sum:requests.total{*}.as_count()"
+                },
+                "thresholds": [{"timeframe": "7d", "target": 99.95}]
+            }"#,
+        );
+
+        let result = super::diff(&cfg, "slo-123", path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_ok(), "slos diff failed: {:?}", result.err());
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_slos_diff_invalid_json() {
+        let _lock = lock_env().await;
+        let cfg = test_config("http://unused.local");
+        let path = write_temp_json("pup_slo_diff_invalid_json.json", "not valid json {{{");
+
+        let result = super::diff(&cfg, "slo-123", path.to_str().unwrap(), &[], &[]).await;
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to parse JSON"));
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3486,6 +3486,23 @@ enum DashboardActions {
         #[arg(long)]
         file: String,
     },
+    /// Diff a candidate JSON definition against the live dashboard
+    Diff {
+        id: String,
+        file: String,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Restrict the diff to these field paths (dot-notation, comma-separated or repeated)"
+        )]
+        only: Vec<String>,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Exclude these field paths from the diff (dot-notation, comma-separated or repeated)"
+        )]
+        ignore: Vec<String>,
+    },
     /// Delete a dashboard
     Delete { id: String },
     /// Edit widgets embedded in a dashboard, and discover widget schemas
@@ -3859,6 +3876,23 @@ enum SloActions {
         id: String,
         #[arg(long)]
         file: String,
+    },
+    /// Diff a candidate JSON definition against the live SLO
+    Diff {
+        id: String,
+        file: String,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Restrict the diff to these field paths (dot-notation, comma-separated or repeated)"
+        )]
+        only: Vec<String>,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Exclude these field paths from the diff (dot-notation, comma-separated or repeated)"
+        )]
+        ignore: Vec<String>,
     },
     /// Delete an SLO
     Delete { id: String },
@@ -6318,6 +6352,23 @@ enum NotebookActions {
         notebook_id: i64,
         #[arg(long, help = "JSON file with notebook data (required)")]
         file: String,
+    },
+    /// Diff a candidate JSON definition against the live notebook
+    Diff {
+        notebook_id: i64,
+        file: String,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Restrict the diff to these field paths (dot-notation, comma-separated or repeated)"
+        )]
+        only: Vec<String>,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Exclude these field paths from the diff (dot-notation, comma-separated or repeated)"
+        )]
+        ignore: Vec<String>,
     },
     /// Append cells to an existing notebook (reads current notebook first, then appends)
     Edit {
@@ -9229,6 +9280,23 @@ enum ObsPipelinesActions {
         pipeline_id: String,
         #[arg(long, help = "JSON file with pipeline body (required)")]
         file: String,
+    },
+    /// Diff a candidate JSON definition against the live pipeline
+    Diff {
+        pipeline_id: String,
+        file: String,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Restrict the diff to these field paths (dot-notation, comma-separated or repeated)"
+        )]
+        only: Vec<String>,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Exclude these field paths from the diff (dot-notation, comma-separated or repeated)"
+        )]
+        ignore: Vec<String>,
     },
     /// Delete a pipeline
     Delete { pipeline_id: String },
@@ -12649,6 +12717,14 @@ async fn main_inner() -> anyhow::Result<()> {
                 DashboardActions::Update { id, file } => {
                     commands::dashboards::update(&cfg, &id, &file).await?;
                 }
+                DashboardActions::Diff {
+                    id,
+                    file,
+                    only,
+                    ignore,
+                } => {
+                    commands::dashboards::diff(&cfg, &id, &file, &only, &ignore).await?;
+                }
                 DashboardActions::Delete { id } => commands::dashboards::delete(&cfg, &id).await?,
                 DashboardActions::Widgets { action } => match action {
                     DashboardWidgetActions::List { dash_id } => {
@@ -12852,6 +12928,14 @@ async fn main_inner() -> anyhow::Result<()> {
                 SloActions::Create { file } => commands::slos::create(&cfg, &file).await?,
                 SloActions::Update { id, file } => {
                     commands::slos::update(&cfg, &id, &file).await?;
+                }
+                SloActions::Diff {
+                    id,
+                    file,
+                    only,
+                    ignore,
+                } => {
+                    commands::slos::diff(&cfg, &id, &file, &only, &ignore).await?;
                 }
                 SloActions::Delete { id } => commands::slos::delete(&cfg, &id).await?,
                 SloActions::Status { id, from, to } => {
@@ -14177,6 +14261,14 @@ async fn main_inner() -> anyhow::Result<()> {
                 }
                 NotebookActions::Update { notebook_id, file } => {
                     commands::notebooks::update(&cfg, notebook_id, &file).await?;
+                }
+                NotebookActions::Diff {
+                    notebook_id,
+                    file,
+                    only,
+                    ignore,
+                } => {
+                    commands::notebooks::diff(&cfg, notebook_id, &file, &only, &ignore).await?;
                 }
                 NotebookActions::Edit { notebook_id, file } => {
                     commands::notebooks::edit(&cfg, notebook_id, &file).await?;
@@ -16145,6 +16237,15 @@ async fn main_inner() -> anyhow::Result<()> {
                 }
                 ObsPipelinesActions::Update { pipeline_id, file } => {
                     commands::obs_pipelines::update(&cfg, &pipeline_id, &file).await?;
+                }
+                ObsPipelinesActions::Diff {
+                    pipeline_id,
+                    file,
+                    only,
+                    ignore,
+                } => {
+                    commands::obs_pipelines::diff(&cfg, &pipeline_id, &file, &only, &ignore)
+                        .await?;
                 }
                 ObsPipelinesActions::Delete { pipeline_id } => {
                     commands::obs_pipelines::delete(&cfg, &pipeline_id).await?;

--- a/src/util_ext.rs
+++ b/src/util_ext.rs
@@ -205,6 +205,52 @@ pub const READONLY_WORKFLOW_FIELDS: &[&str] = &[
     "data.attributes.updatedBy",
 ];
 
+/// Read-only server-managed fields that are stripped before diffing a dashboard.
+pub const READONLY_DASHBOARD_FIELDS: &[&str] = &[
+    "id",
+    "url",
+    "author_handle",
+    "author_name",
+    "created_at",
+    "modified_at",
+    "deleted",
+];
+
+/// Read-only server-managed fields that are stripped before diffing an SLO.
+pub const READONLY_SLO_FIELDS: &[&str] = &[
+    "id",
+    "created_at",
+    "modified_at",
+    "creator",
+    "overall_status",
+    "overall_status_modified",
+];
+
+/// Read-only server-managed fields that are stripped before diffing a notebook.
+pub const READONLY_NOTEBOOK_FIELDS: &[&str] = &[
+    "data.id",
+    "data.type",
+    "data.attributes.author",
+    "data.attributes.created",
+    "data.attributes.modified",
+];
+
+/// Read-only server-managed fields that are stripped before diffing an observability pipeline.
+pub const READONLY_OBS_PIPELINE_FIELDS: &[&str] = &[
+    "data.id",
+    "data.type",
+    "data.attributes.created_at",
+    "data.attributes.createdAt",
+    "data.attributes.created_by",
+    "data.attributes.createdBy",
+    "data.attributes.modified_at",
+    "data.attributes.modifiedAt",
+    "data.attributes.updated_at",
+    "data.attributes.updatedAt",
+    "data.attributes.updated_by",
+    "data.attributes.updatedBy",
+];
+
 /// Options for diffing a live resource against a candidate JSON value.
 pub struct ResourceDiffOptions<'a> {
     pub command: &'a str,


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0db39936-be9d-4da3-8fe5-f4e863cd42a7","source":"chat","resourceId":"db4d45fe-bbb9-4a7f-89ed-f89ab55013bb","workflowId":"097269d7-bc69-42a6-97cf-ff7dfcbb4b59","codeChangeId":"097269d7-bc69-42a6-97cf-ff7dfcbb4b59","sourceType":"chat"} -->
## What does this PR do?

Adds monitor-style JSON diff commands for dashboards, SLOs, notebooks, and observability pipelines. Each command compares a candidate JSON file against the live resource and supports the same `--only` and `--ignore` field filters as the existing monitor and workflow diff commands.

## Motivation

Issue #634 asks for diff support beyond monitors, especially for resources that can be exported or managed as JSON. The workflow diff PR established the shared helper; this PR applies it to the next set of high-value configuration resources with stable `get` and file-backed `update` paths.

## Changes

- Added read-only field normalization lists for dashboards, SLOs, notebooks, and observability pipelines in `src/util_ext.rs`.
- Added `diff` implementations in `src/commands/dashboards.rs`, `src/commands/slos.rs`, `src/commands/notebooks.rs`, and `src/commands/obs_pipelines.rs`.
- Wired `diff <id> <file> --only --ignore` into the clap command enums and dispatch paths in `src/main.rs`.
- Added positive diff tests and invalid JSON tests for all four new resource diff commands.
- Documented the new commands in `docs/COMMANDS.md` and added usage examples in `docs/EXAMPLES.md`.

## Testing

- `cargo +stable fmt --check`
- `git diff --check`
- Attempted `timeout 300 cargo +stable test diff_detects_changes`, but Cargo could not fetch the pinned `datadog-api-client-rust` git dependency from GitHub in this sandbox (`403` / allowlist block), so the Rust test run did not complete locally.

## Additional Notes

The new diff commands fetch live resources through the raw JSON client before diffing. That keeps diff output tied to the API payload and avoids typed SDK defaults or deserialization requirements changing the comparison surface.

## Checklist

- [x] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

Related to #634

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/db4d45fe-bbb9-4a7f-89ed-f89ab55013bb)

Comment @datadog to request changes