### PR TITLE
Implement cursor parameter for logs commands

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -33,6 +33,7 @@ pub struct SearchArgs {
     pub from: String,
     pub to: String,
     pub limit: i32,
+    pub cursor: Option<String>,
     pub sort: String,
     pub storage: Option<String>,
     pub index: Vec<String>,
@@ -210,6 +211,7 @@ pub async fn search(cfg: &Config, args: SearchArgs) -> Result<()> {
         from,
         to,
         limit,
+        cursor,
         sort,
         storage,
         index,
@@ -232,33 +234,37 @@ pub async fn search(cfg: &Config, args: SearchArgs) -> Result<()> {
         filter = filter.storage_tier(tier);
     }
 
+    let mut page = LogsListRequestPage::new().limit(limit);
+    if let Some(cursor) = cursor {
+        page = page.cursor(cursor);
+    }
+
     let body = LogsListRequest::new()
         .filter(filter)
-        .page(LogsListRequestPage::new().limit(limit))
+        .page(page)
         .sort(parse_logs_sort(&sort));
-
     let params = ListLogsOptionalParams::default().body(body);
-
     let resp = api
         .list_logs(params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to search logs: {:?}", e))?;
+    let next_cursor = resp
+        .meta
+        .as_ref()
+        .and_then(|m| m.page.as_ref())
+        .and_then(|p| p.after.clone())
+        .filter(|cursor| !cursor.is_empty());
 
     let meta = if cfg.agent_mode {
         let count = resp.data.as_ref().map(|d| d.len());
-        let truncated = count.is_some_and(|c| c as i32 >= limit);
+
         Some(formatter::Metadata {
             count,
-            truncated,
+            truncated: next_cursor.is_some(),
             command: Some("logs search".into()),
-            next_action: if truncated {
-                Some(format!(
-                    "Results may be truncated at {limit}. Use --limit={} or narrow the --query",
-                    limit + 1
-                ))
-            } else {
-                None
-            },
+            next_action: next_cursor.map(|c| {
+                format!("More results available. Use --cursor=\"{c}\" to page backwards through older logs, change the limit with --limit, or narrow the --query")
+            }),
         })
     } else {
         None
@@ -459,6 +465,7 @@ mod tests {
             from: "1h".into(),
             to: "now".into(),
             limit: 10,
+            cursor: None,
             sort: "-timestamp".into(),
             storage,
             index,
@@ -814,6 +821,34 @@ mod tests {
 
         let result = super::search(&cfg, search_args("status:error", None, vec![])).await;
         assert!(result.is_ok(), "logs search failed: {:?}", result.err());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_logs_search_with_cursor() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let _mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .match_query(mockito::Matcher::Any)
+            .match_body(mockito::Matcher::Regex(
+                r#""cursor":"cursor-abc""#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": [], "meta": {"page": {}}}"#)
+            .create_async()
+            .await;
+
+        let mut args = search_args("status:error", None, vec![]);
+        args.cursor = Some("cursor-abc".into());
+        let result = super::search(&cfg, args).await;
+        assert!(
+            result.is_ok(),
+            "logs search with cursor failed: {:?}",
+            result.err()
+        );
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3146,6 +3146,8 @@ enum LogActions {
         to: String,
         #[arg(long, default_value_t = 50, help = "Maximum number of logs (1-1000)")]
         limit: i32,
+        #[arg(long, help = "Pagination cursor from a previous response")]
+        cursor: Option<String>,
         #[arg(long, help = "Sort order: asc or desc", default_value = "desc")]
         sort: String,
         #[arg(
@@ -3175,6 +3177,8 @@ enum LogActions {
         to: String,
         #[arg(long, default_value_t = 10, help = "Number of logs")]
         limit: i32,
+        #[arg(long, help = "Pagination cursor from a previous response")]
+        cursor: Option<String>,
         #[arg(
             long,
             allow_hyphen_values = true,
@@ -3205,6 +3209,8 @@ enum LogActions {
         to: String,
         #[arg(long, default_value_t = 50, help = "Maximum results")]
         limit: i32,
+        #[arg(long, help = "Pagination cursor from a previous response")]
+        cursor: Option<String>,
         #[arg(
             long,
             allow_hyphen_values = true,
@@ -12411,6 +12417,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     from,
                     to,
                     limit,
+                    cursor,
                     sort,
                     index,
                     storage,
@@ -12422,6 +12429,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             from,
                             to,
                             limit,
+                            cursor,
                             sort,
                             storage,
                             index,
@@ -12434,6 +12442,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     from,
                     to,
                     limit,
+                    cursor,
                     sort,
                     storage,
                     index,
@@ -12445,6 +12454,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             from,
                             to,
                             limit,
+                            cursor,
                             sort,
                             storage,
                             index,
@@ -12457,6 +12467,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     from,
                     to,
                     limit,
+                    cursor,
                     sort,
                     storage,
                     index,
@@ -12469,6 +12480,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             from,
                             to,
                             limit,
+                            cursor,
                             sort,
                             storage,
                             index,

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -581,7 +581,9 @@ fn test_logs_search_and_aggregate_default_to_flex_storage() {
     match search.command {
         crate::Commands::Logs {
             action: crate::LogActions::Search { storage, .. },
-        } => assert_eq!(storage.as_deref(), Some("flex")),
+        } => {
+            assert_eq!(storage.as_deref(), Some("flex"));
+        }
         _ => panic!("expected LogActions::Search"),
     }
     match aggregate.command {
@@ -589,6 +591,62 @@ fn test_logs_search_and_aggregate_default_to_flex_storage() {
             action: crate::LogActions::Aggregate { storage, .. },
         } => assert_eq!(storage.as_deref(), Some("flex")),
         _ => panic!("expected LogActions::Aggregate"),
+    }
+}
+
+#[test]
+fn test_logs_search_cursor_parses() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "logs",
+        "search",
+        "--query",
+        "*",
+        "--cursor",
+        "cursor-abc",
+    ])
+    .expect("logs search --cursor should parse");
+
+    match cli.command {
+        crate::Commands::Logs {
+            action: crate::LogActions::Search { cursor, .. },
+        } => {
+            assert_eq!(cursor.as_deref(), Some("cursor-abc"));
+        }
+        _ => panic!("expected LogActions::Search"),
+    }
+}
+
+#[test]
+fn test_logs_list_and_query_cursor_parse() {
+    use clap::Parser;
+
+    let list = crate::Cli::try_parse_from(["pup", "logs", "list", "--cursor", "list-cursor"])
+        .expect("logs list --cursor should parse");
+    let query = crate::Cli::try_parse_from([
+        "pup",
+        "logs",
+        "query",
+        "--query",
+        "status:error",
+        "--cursor",
+        "query-cursor",
+    ])
+    .expect("logs query --cursor should parse");
+
+    match list.command {
+        crate::Commands::Logs {
+            action: crate::LogActions::List { cursor, .. },
+        } => assert_eq!(cursor.as_deref(), Some("list-cursor")),
+        _ => panic!("expected LogActions::List"),
+    }
+    match query.command {
+        crate::Commands::Logs {
+            action: crate::LogActions::Query { cursor, .. },
+        } => assert_eq!(cursor.as_deref(), Some("query-cursor")),
+        _ => panic!("expected LogActions::Query"),
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
it adds the --cursor option to the logs list, logs search and logs query commands, so multiple pages can be fetched. It also changes the agent mode metadata to indicate more pages are available with --cursor.

I briefly experimented with automated fetching of a predefined maximum number of pages. However, it is very easy to hit rate limits with that. As I do not know how these rate limits are configured, and no other part of pup currently implements that, I went back to just a single page fetch again.

## Motivation

<!-- What inspired you to submit this pull request? -->
We wanted to check logs for query patterns with an automated tool, to get an overview of how our services are used. For that, we need to fetch more than 5000 lines of logs, to not risk missing query patterns for busy services that also have a couple of lower traffic calls. That was not possible with the pup CLI, even though it is implemented for other commands in pup. So I added it

## Additional Notes

The link to the project conventions is broken in this pull request template. It points to https://github.com/DataDog/pup/blob/docs/CONTRIBUTING.md , but it should be https://github.com/DataDog/pup/blob/main/docs/CONTRIBUTING.md 

<!-- Anything else we should know when reviewing? -->

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->
