### PR TITLE
fix(cli): reset SIGPIPE to default so piping to head/tail exits quietly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ dependencies = [
  "js-sys",
  "jsonschema",
  "keyring",
+ "libc",
  "mockito",
  "open",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,5 +172,9 @@ jaq-json = { version = "2.0.1", features = ["serde"] }
 reqwest = { version = ">=0.13, <0.13.3", features = ["stream"] }
 gethostname = "1"
 
+# SIGPIPE reset so piping output to `head`/`tail` exits quietly instead of panicking
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 mockito = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11791,9 +11791,44 @@ mod test_agent_schema {
 
 // ---- Main ----
 
+#[cfg(unix)]
+fn reset_sigpipe() {
+    // Rust ignores SIGPIPE by default, which turns a closed stdout pipe (e.g. `| head`)
+    // into an EPIPE error that println!/print! then panic on. Restore the default Unix
+    // behavior so the process just exits quietly instead.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
+#[cfg(all(test, unix))]
+mod reset_sigpipe_tests {
+    use super::reset_sigpipe;
+
+    #[test]
+    fn sets_default_disposition() {
+        // Force a non-default disposition first so the assertion below can't
+        // pass merely because SIGPIPE happened to already be SIG_DFL.
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+        }
+
+        reset_sigpipe();
+
+        // libc::signal returns the *previous* disposition, so calling it again
+        // reveals what reset_sigpipe() actually installed.
+        let previous = unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL) };
+        assert_eq!(previous, libc::SIG_DFL);
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    reset_sigpipe();
     main_inner().await
 }
 


### PR DESCRIPTION
## Summary
- Piping `pup` output into `head`/`tail` (e.g. `pup logs search --query='*' | head -n 20`) panicked with `failed printing to stdout: Broken pipe (os error 32)`. Rust ignores `SIGPIPE` by default, so a closed pipe surfaces as an `EPIPE` error, which `println!`/`print!` turn into a panic instead of a clean exit.
- Reset `SIGPIPE` to `SIG_DFL` at process start — the standard fix used by `ripgrep`, `fd`, and other Unix CLI tools — so the process now exits quietly via the signal instead of panicking.

## Changes
- `src/main.rs`: add `reset_sigpipe()`, called at the top of `main()` (native target), plus a unit test (`reset_sigpipe_tests::sets_default_disposition`)
- `Cargo.toml`/`Cargo.lock`: add `libc` as a `cfg(unix)`-only target dependency (already a transitive dependency at the pinned version, no new crate introduced)

## Testing
- Built both the pre-fix and post-fix binaries and ran `pup completions bash | head -n 1`:
  - Before: panics with `thread 'main' panicked ... failed to write completion file: Broken pipe`, exit code 101
  - After: exits cleanly via SIGPIPE, exit code 141
- `cargo test reset_sigpipe` passes
- `cargo fmt --check` passes
- `cargo clippy --all-targets -- -D warnings` passes

## Related Issues
Fixes the broken pipe panic reported when piping `pup` output to `head`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)