### PR TITLE
fix(logs): clarify retention risk on storage fallback

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -1878,7 +1878,7 @@ mod tests {
     }
 
     #[test]
-    fn test_flex_fallback_warning_mentions_retention() {
+    fn test_flex_fallback_warning_mentions_indexed_log_retention() {
         // Verify the fallback warning explicitly communicates retention risk
         assert!(
             FLEX_FALLBACK_WARNING.contains("Results may be incomplete"),

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -42,7 +42,7 @@ pub struct SearchArgs {
     pub auto_storage: bool,
 }
 
-const FLEX_FALLBACK_WARNING: &str = "Flex log storage is unavailable for this account or credentials; retried with indexed logs. Use --storage indexes to skip this retry or --storage flex to require Flex.";
+const FLEX_FALLBACK_WARNING: &str = "Flex log storage is unavailable for this account or credentials; retried with indexed logs. Results may be incomplete if the requested time range exceeds indexed-log retention (often 7-15 days). Use --storage indexes to skip this retry or --storage flex to require Flex.";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum StorageSelection {
@@ -1875,5 +1875,23 @@ mod tests {
             result.err()
         );
         cleanup_env();
+    }
+
+    #[test]
+    fn test_flex_fallback_warning_mentions_retention() {
+        // Verify the fallback warning explicitly communicates retention risk
+        assert!(
+            FLEX_FALLBACK_WARNING.contains("Results may be incomplete"),
+            "Warning should mention potential incompleteness"
+        );
+        assert!(
+            FLEX_FALLBACK_WARNING.contains("retention"),
+            "Warning should mention retention limits"
+        );
+        assert!(
+            FLEX_FALLBACK_WARNING.contains("--storage indexes")
+                || FLEX_FALLBACK_WARNING.contains("--storage flex"),
+            "Warning should mention explicit storage options"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3161,7 +3161,7 @@ enum LogActions {
         index: Vec<String>,
         #[arg(
             long,
-            help = "Storage tier: auto, indexes, online-archives, or flex (default: auto)"
+            help = "Storage tier: auto, indexes, online-archives, or flex (default: auto). Long lookback queries may require flex or online-archives for full retention."
         )]
         storage: Option<String>,
     },
@@ -3188,7 +3188,10 @@ enum LogActions {
             help = "Sort order"
         )]
         sort: String,
-        #[arg(long, help = "Storage tier: auto, indexes, online-archives, or flex")]
+        #[arg(
+            long,
+            help = "Storage tier: auto, indexes, online-archives, or flex. Long lookback queries may require flex or online-archives for full retention."
+        )]
         storage: Option<String>,
         #[arg(
             long,
@@ -3220,7 +3223,10 @@ enum LogActions {
             help = "Sort order"
         )]
         sort: String,
-        #[arg(long, help = "Storage tier: auto, indexes, online-archives, or flex")]
+        #[arg(
+            long,
+            help = "Storage tier: auto, indexes, online-archives, or flex. Long lookback queries may require flex or online-archives for full retention."
+        )]
         storage: Option<String>,
         #[arg(
             long,
@@ -3293,7 +3299,7 @@ enum LogActions {
         limit: i32,
         #[arg(
             long,
-            help = "Storage tier: auto, indexes, online-archives, or flex (default: auto)"
+            help = "Storage tier: auto, indexes, online-archives, or flex (default: auto). Long lookback queries may require flex or online-archives for full retention."
         )]
         storage: Option<String>,
         #[arg(

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -790,6 +790,94 @@ fn test_logs_saved_views_create_parses() {
 }
 
 #[test]
+fn test_logs_search_help_mentions_retention() {
+    let cmd = crate::Cli::command();
+    let logs_cmd = cmd
+        .find_subcommand("logs")
+        .expect("logs subcommand should exist");
+    let mut search_cmd = logs_cmd
+        .find_subcommand("search")
+        .expect("logs search subcommand should exist")
+        .clone();
+
+    let help = search_cmd.render_help().to_string();
+
+    // Verify help text mentions retention considerations for storage flag
+    assert!(
+        help.contains(
+            "Long lookback queries may require flex or online-archives for full retention"
+        ),
+        "logs search help should mention retention considerations for --storage flag"
+    );
+}
+
+#[test]
+fn test_logs_aggregate_help_mentions_retention() {
+    let cmd = crate::Cli::command();
+    let logs_cmd = cmd
+        .find_subcommand("logs")
+        .expect("logs subcommand should exist");
+    let mut aggregate_cmd = logs_cmd
+        .find_subcommand("aggregate")
+        .expect("logs aggregate subcommand should exist")
+        .clone();
+
+    let help = aggregate_cmd.render_help().to_string();
+
+    // Verify help text mentions retention considerations for storage flag
+    assert!(
+        help.contains(
+            "Long lookback queries may require flex or online-archives for full retention"
+        ),
+        "logs aggregate help should mention retention considerations for --storage flag"
+    );
+}
+
+#[test]
+fn test_logs_list_help_mentions_retention() {
+    let cmd = crate::Cli::command();
+    let logs_cmd = cmd
+        .find_subcommand("logs")
+        .expect("logs subcommand should exist");
+    let mut list_cmd = logs_cmd
+        .find_subcommand("list")
+        .expect("logs list subcommand should exist")
+        .clone();
+
+    let help = list_cmd.render_help().to_string();
+
+    // Verify help text mentions retention considerations for storage flag
+    assert!(
+        help.contains(
+            "Long lookback queries may require flex or online-archives for full retention"
+        ),
+        "logs list help should mention retention considerations for --storage flag"
+    );
+}
+
+#[test]
+fn test_logs_query_help_mentions_retention() {
+    let cmd = crate::Cli::command();
+    let logs_cmd = cmd
+        .find_subcommand("logs")
+        .expect("logs subcommand should exist");
+    let mut query_cmd = logs_cmd
+        .find_subcommand("query")
+        .expect("logs query subcommand should exist")
+        .clone();
+
+    let help = query_cmd.render_help().to_string();
+
+    // Verify help text mentions retention considerations for storage flag
+    assert!(
+        help.contains(
+            "Long lookback queries may require flex or online-archives for full retention"
+        ),
+        "logs query help should mention retention considerations for --storage flag"
+    );
+}
+
+#[test]
 fn test_traces_search_sort_accepts_hyphen_timestamp() {
     use clap::Parser;
 

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -790,91 +790,26 @@ fn test_logs_saved_views_create_parses() {
 }
 
 #[test]
-fn test_logs_search_help_mentions_retention() {
+fn test_logs_storage_help_mentions_long_lookback_storage() {
     let cmd = crate::Cli::command();
     let logs_cmd = cmd
         .find_subcommand("logs")
         .expect("logs subcommand should exist");
-    let mut search_cmd = logs_cmd
-        .find_subcommand("search")
-        .expect("logs search subcommand should exist")
-        .clone();
 
-    let help = search_cmd.render_help().to_string();
+    for subcommand in ["search", "aggregate", "list", "query"] {
+        let mut command = logs_cmd
+            .find_subcommand(subcommand)
+            .unwrap_or_else(|| panic!("logs {subcommand} subcommand should exist"))
+            .clone();
+        let help = command.render_help().to_string();
 
-    // Verify help text mentions retention considerations for storage flag
-    assert!(
-        help.contains(
-            "Long lookback queries may require flex or online-archives for full retention"
-        ),
-        "logs search help should mention retention considerations for --storage flag"
-    );
-}
-
-#[test]
-fn test_logs_aggregate_help_mentions_retention() {
-    let cmd = crate::Cli::command();
-    let logs_cmd = cmd
-        .find_subcommand("logs")
-        .expect("logs subcommand should exist");
-    let mut aggregate_cmd = logs_cmd
-        .find_subcommand("aggregate")
-        .expect("logs aggregate subcommand should exist")
-        .clone();
-
-    let help = aggregate_cmd.render_help().to_string();
-
-    // Verify help text mentions retention considerations for storage flag
-    assert!(
-        help.contains(
-            "Long lookback queries may require flex or online-archives for full retention"
-        ),
-        "logs aggregate help should mention retention considerations for --storage flag"
-    );
-}
-
-#[test]
-fn test_logs_list_help_mentions_retention() {
-    let cmd = crate::Cli::command();
-    let logs_cmd = cmd
-        .find_subcommand("logs")
-        .expect("logs subcommand should exist");
-    let mut list_cmd = logs_cmd
-        .find_subcommand("list")
-        .expect("logs list subcommand should exist")
-        .clone();
-
-    let help = list_cmd.render_help().to_string();
-
-    // Verify help text mentions retention considerations for storage flag
-    assert!(
-        help.contains(
-            "Long lookback queries may require flex or online-archives for full retention"
-        ),
-        "logs list help should mention retention considerations for --storage flag"
-    );
-}
-
-#[test]
-fn test_logs_query_help_mentions_retention() {
-    let cmd = crate::Cli::command();
-    let logs_cmd = cmd
-        .find_subcommand("logs")
-        .expect("logs subcommand should exist");
-    let mut query_cmd = logs_cmd
-        .find_subcommand("query")
-        .expect("logs query subcommand should exist")
-        .clone();
-
-    let help = query_cmd.render_help().to_string();
-
-    // Verify help text mentions retention considerations for storage flag
-    assert!(
-        help.contains(
-            "Long lookback queries may require flex or online-archives for full retention"
-        ),
-        "logs query help should mention retention considerations for --storage flag"
-    );
+        assert!(
+            help.contains(
+                "Long lookback queries may require flex or online-archives for full retention"
+            ),
+            "logs {subcommand} help should mention long-lookback storage guidance"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?

 Clarifies logs storage retention behavior for long lookback queries.

This updates the Flex-to-indexed fallback warning so `logs search` and `logs aggregate` tell users that results may be incomplete if indexed-log retention does not cover the requested time range. It also updates logs `--storage` help text to mention that long lookback queries may require Flex or online archives for full retention.

  ## Motivation

Was messing around w the cli for a project where I was using `pup logs aggregate --from=30d` to summarize service errors over a month. The count looked too low, and rerunning with `--storage=flex` returned the expected higher number. The original output looked complete, but it had only covered indexed-log retention.

  ## Additional Notes

This PR intentionally stays scoped to warning/help-text clarity. It does not implement retention discovery, retention-aware storage selection, or structured `retention_limited` response metadata, but it makes the current fallback behavior explicit and gives users a clear `--storage` path to act on. That should also make a future retention-aware `auto` mode easier to evaluate, since the user-facing storage guidance is no longer fully implicit.

  Validated with:

  ```sh
  cargo fmt --check
  cargo test retention -- --nocapture
  cargo test logs_search_auto_storage_falls_back_after_flex_403 -- --nocapture
  cargo test logs_aggregate_auto_storage_falls_back_after_flex_403 -- --nocapture

  ## Checklist

  - [x] The code change follows the project conventions (see ../docs/CONTRIBUTING.md)
  - [x] Tests have been added/updated (if applicable)
  - [x] Documentation has been updated (if applicable)
  - [ ] All CI checks pass #need to wait on Actions, local equivs pass tho
  - [x] Code coverage is maintained or improved
 ```
  ## Related Issues

  Addresses the low-risk warning/help-text portion of #717, i.e. bullets 1 & 4.