### PR TITLE
feat(notebooks): add filtered content search

### DIFF
--- a/src/commands/notebooks.rs
+++ b/src/commands/notebooks.rs
@@ -16,11 +16,12 @@ const RATE_LIMIT_RETRIES: u32 = 3;
 fn compact_validation_details(content: &str) -> Option<String> {
     let parsed: serde_json::Value = serde_json::from_str(content).ok()?;
     let errors = parsed.get("errors")?.as_array()?;
+    let detail_pattern =
+        regex::Regex::new(r#"'detail': '((?:\\.|[^'])*)'"#).expect("static detail regex");
     let mut messages = Vec::new();
     for error in errors {
         let message = error.as_str()?;
-        let details = regex::Regex::new(r#"'detail': '((?:\\.|[^'])*)'"#)
-            .expect("static detail regex")
+        let details = detail_pattern
             .captures_iter(message)
             .filter_map(|capture| capture.get(1).map(|value| value.as_str()))
             .collect::<Vec<_>>();

--- a/src/commands/notebooks.rs
+++ b/src/commands/notebooks.rs
@@ -1,20 +1,179 @@
 use anyhow::Result;
-use datadog_api_client::datadogV1::api_notebooks::{ListNotebooksOptionalParams, NotebooksAPI};
+use datadog_api_client::datadog;
+use datadog_api_client::datadogV1::api_notebooks::NotebooksAPI;
 use datadog_api_client::datadogV1::model::{NotebookCreateRequest, NotebookUpdateRequest};
 
 use crate::config::Config;
-use crate::formatter;
+use crate::formatter::{self, Metadata};
 use crate::raw_client;
 use crate::util;
 use crate::util_ext;
 
-pub async fn list(cfg: &Config) -> Result<()> {
-    let api = crate::make_api!(NotebooksAPI, cfg);
-    let resp = api
-        .list_notebooks(ListNotebooksOptionalParams::default())
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to list notebooks: {e:?}"))?;
-    formatter::output(cfg, &resp)
+const SEARCH_PATH: &str = "/api/v2/notebooks/search";
+const MAX_RESULTS: usize = 1000;
+const RATE_LIMIT_RETRIES: u32 = 3;
+
+fn compact_validation_details(content: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(content).ok()?;
+    let errors = parsed.get("errors")?.as_array()?;
+    let mut messages = Vec::new();
+    for error in errors {
+        let message = error.as_str()?;
+        let details = regex::Regex::new(r#"'detail': '((?:\\.|[^'])*)'"#)
+            .expect("static detail regex")
+            .captures_iter(message)
+            .filter_map(|capture| capture.get(1).map(|value| value.as_str()))
+            .collect::<Vec<_>>();
+        if details.len() >= 4 && details.iter().all(|detail| detail.chars().count() == 1) {
+            messages.push(details.concat());
+        } else {
+            messages.push(message.to_string());
+        }
+    }
+    (!messages.is_empty()).then(|| messages.join("; "))
+}
+
+fn notebook_api_error<T: std::fmt::Debug>(
+    operation: &str,
+    error: datadog::Error<T>,
+) -> anyhow::Error {
+    match error {
+        datadog::Error::ResponseError(response) => {
+            let detail = compact_validation_details(&response.content)
+                .unwrap_or_else(|| response.content.trim().to_string());
+            anyhow::anyhow!(
+                "failed to {operation} notebook (HTTP {}): {detail}",
+                response.status
+            )
+        }
+        other => anyhow::anyhow!("failed to {operation} notebook: {other}"),
+    }
+}
+
+fn is_rate_limited(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<raw_client::HttpError>()
+        .is_some_and(|error| error.status == 429)
+}
+
+async fn get_search_page(cfg: &Config, params: &[(&str, &str)]) -> Result<serde_json::Value> {
+    let mut retry = 0;
+    loop {
+        match raw_client::raw_get(cfg, SEARCH_PATH, params).await {
+            Ok(response) => return Ok(response),
+            Err(error) if is_rate_limited(&error) && retry < RATE_LIMIT_RETRIES => {
+                let delay = 10 * 2_u64.pow(retry);
+                retry += 1;
+                eprintln!(
+                    "Notebook search was rate limited; retrying in {delay}s ({retry}/{RATE_LIMIT_RETRIES})"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+            }
+            Err(error) => return Err(anyhow::anyhow!("failed to search notebooks: {error}")),
+        }
+    }
+}
+
+fn parse_filters(filters: &[String]) -> Result<Vec<(String, String)>> {
+    filters
+        .iter()
+        .flat_map(|filter| filter.split_whitespace())
+        .map(|filter| {
+            let (field, value) = filter.split_once(':').ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid filter '{filter}': expected FIELD:VALUE (for example, tags:production)"
+                )
+            })?;
+            if field.is_empty() || value.is_empty() {
+                anyhow::bail!("invalid filter '{filter}': both FIELD and VALUE must be non-empty");
+            }
+            Ok((format!("filter[{field}]"), value.to_string()))
+        })
+        .collect()
+}
+
+async fn discover(
+    cfg: &Config,
+    query: &str,
+    filters: &[String],
+    sort: &str,
+    limit: usize,
+    command: &str,
+) -> Result<()> {
+    if !(1..=MAX_RESULTS).contains(&limit) {
+        anyhow::bail!("--limit must be between 1 and {MAX_RESULTS}, got {limit}");
+    }
+    let filters = parse_filters(filters)?;
+    let mut notebooks = Vec::new();
+
+    let page_size = limit.to_string();
+    let mut params = vec![
+        ("query", query),
+        ("sort", sort),
+        ("page[size]", page_size.as_str()),
+        ("page[number]", "0"),
+    ];
+    params.extend(
+        filters
+            .iter()
+            .map(|(field, value)| (field.as_str(), value.as_str())),
+    );
+
+    let response = get_search_page(cfg, &params).await?;
+    let page_data = response
+        .get("data")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("notebook search response did not contain data[]"))?;
+    let response_meta = response.get("meta").cloned();
+    notebooks.extend(page_data.iter().take(limit).cloned());
+
+    let count = notebooks.len();
+    let total = response_meta
+        .as_ref()
+        .and_then(|meta| meta.get("total"))
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|total| usize::try_from(total).ok());
+    let truncated = total.is_some_and(|total| count < total);
+    let mut meta = response_meta.unwrap_or_else(|| serde_json::json!({ "total": count }));
+    if let Some(meta) = meta.as_object_mut() {
+        meta.insert("returned".into(), count.into());
+        meta.insert("truncated".into(), truncated.into());
+    }
+    let payload = serde_json::json!({
+        "data": notebooks,
+        "meta": meta,
+    });
+    let metadata = Metadata {
+        count: Some(count),
+        truncated,
+        command: Some(command.to_string()),
+        next_action: None,
+    };
+    formatter::format_and_print(
+        &payload,
+        &cfg.output_format,
+        cfg.agent_mode,
+        Some(&metadata),
+        cfg.jq.as_deref(),
+    )
+}
+
+pub async fn search(
+    cfg: &Config,
+    query: Option<&str>,
+    filters: &[String],
+    sort: &str,
+    limit: usize,
+) -> Result<()> {
+    discover(
+        cfg,
+        query.unwrap_or_default(),
+        filters,
+        sort,
+        limit,
+        "notebooks search",
+    )
+    .await
 }
 
 pub async fn get(cfg: &Config, notebook_id: i64) -> Result<()> {
@@ -41,7 +200,7 @@ pub async fn create(cfg: &Config, file: &str) -> Result<()> {
     let resp = api
         .create_notebook(body)
         .await
-        .map_err(|e| anyhow::anyhow!("failed to create notebook: {e:?}"))?;
+        .map_err(|error| notebook_api_error("create", error))?;
     formatter::output(cfg, &resp)
 }
 
@@ -51,7 +210,7 @@ pub async fn update(cfg: &Config, notebook_id: i64, file: &str) -> Result<()> {
     let resp = api
         .update_notebook(notebook_id, body)
         .await
-        .map_err(|e| anyhow::anyhow!("failed to update notebook: {e:?}"))?;
+        .map_err(|error| notebook_api_error("update", error))?;
     formatter::output(cfg, &resp)
 }
 
@@ -121,22 +280,75 @@ pub async fn edit(cfg: &Config, notebook_id: i64, file: &str) -> Result<()> {
     let resp = api
         .update_notebook(notebook_id, update_body)
         .await
-        .map_err(|e| anyhow::anyhow!("failed to edit notebook: {e:?}"))?;
+        .map_err(|error| notebook_api_error("edit", error))?;
     formatter::output(cfg, &resp)
 }
 
 #[cfg(test)]
 mod tests {
-
     use crate::test_support::*;
+    use mockito::Matcher;
+
+    #[test]
+    fn test_compact_validation_details_reassembles_character_errors() {
+        let content = serde_json::json!({
+            "errors": [
+                "API input validation failed: {'cells': {3: {'errors': [\
+                 {'detail': 'b', 'source': {'pointer': '/data/attributes/definition/requests'}}, \
+                 {'detail': 'a', 'source': {'pointer': '/data/attributes/definition/requests'}}, \
+                 {'detail': 'd', 'source': {'pointer': '/data/attributes/definition/requests'}}, \
+                 {'detail': '!', 'source': {'pointer': '/data/attributes/definition/requests'}}]}}}"
+            ]
+        })
+        .to_string();
+
+        assert_eq!(
+            super::compact_validation_details(&content).as_deref(),
+            Some("bad!")
+        );
+    }
+
+    #[test]
+    fn test_compact_validation_details_preserves_normal_error() {
+        let content = serde_json::json!({"errors": ["Invalid notebook type"]}).to_string();
+
+        assert_eq!(
+            super::compact_validation_details(&content).as_deref(),
+            Some("Invalid notebook type")
+        );
+    }
 
     #[tokio::test]
-    async fn test_notebooks_list() {
+    async fn test_notebooks_search_without_query_sends_filters_sort_and_default_page_size() {
         let _lock = lock_env().await;
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
-        mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list(&cfg).await;
+        let mock = s
+            .mock("GET", super::SEARCH_PATH)
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("query".into(), "".into()),
+                Matcher::UrlEncoded("sort".into(), "-modified_at".into()),
+                Matcher::UrlEncoded("page[size]".into(), "20".into()),
+                Matcher::UrlEncoded("page[number]".into(), "0".into()),
+                Matcher::UrlEncoded("filter[tags]".into(), "production".into()),
+                Matcher::UrlEncoded("filter[deleted]".into(), "false".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[{"id":"123"}],"meta":{"total":1}}"#)
+            .create_async()
+            .await;
+
+        super::search(
+            &cfg,
+            None,
+            &["tags:production deleted:false".into()],
+            "-modified_at",
+            20,
+        )
+        .await
+        .unwrap();
+        mock.assert_async().await;
         cleanup_env();
     }
 
@@ -184,6 +396,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_notebooks_search_without_query_uses_requested_limit_as_page_size() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let response = serde_json::json!({
+            "data": (0..21)
+                .map(|id| serde_json::json!({ "id": id.to_string() }))
+                .collect::<Vec<_>>(),
+            "meta": { "total": 21 },
+        });
+        let mock = s
+            .mock("GET", super::SEARCH_PATH)
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("page[size]".into(), "21".into()),
+                Matcher::UrlEncoded("page[number]".into(), "0".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(response.to_string())
+            .create_async()
+            .await;
+
+        super::search(&cfg, None, &[], "name", 21).await.unwrap();
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
     async fn test_notebooks_diff_invalid_json() {
         let _lock = lock_env().await;
         let cfg = test_config("http://unused.local");
@@ -197,5 +437,65 @@ mod tests {
             .to_string()
             .contains("failed to parse JSON"));
         cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_notebooks_search_sends_content_query() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        let mock = s
+            .mock("GET", super::SEARCH_PATH)
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("query".into(), "unique cell text".into()),
+                Matcher::UrlEncoded(
+                    "filter[metadata.has_computational_cells]".into(),
+                    "false".into(),
+                ),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[{"id":"456"}],"meta":{"total":1}}"#)
+            .create_async()
+            .await;
+
+        super::search(
+            &cfg,
+            Some("unique cell text"),
+            &["metadata.has_computational_cells:false".into()],
+            "name",
+            20,
+        )
+        .await
+        .unwrap();
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[test]
+    fn test_parse_filters_rejects_missing_separator() {
+        let err = super::parse_filters(&["tags".into()]).unwrap_err();
+        assert!(err.to_string().contains("expected FIELD:VALUE"));
+    }
+
+    #[test]
+    fn test_parse_filters_preserves_colons_in_values() {
+        let filters = super::parse_filters(&["tags:pup-eval:abc".into()]).unwrap();
+        assert_eq!(
+            filters,
+            vec![("filter[tags]".into(), "pup-eval:abc".into())]
+        );
+    }
+
+    #[test]
+    fn test_is_rate_limited_only_matches_http_429() {
+        let error = anyhow::Error::new(crate::raw_client::HttpError {
+            status: 429,
+            method: "GET".into(),
+            url: "https://example.test".into(),
+            body: "rate limited".into(),
+        });
+        assert!(super::is_rate_limited(&error));
+        assert!(!super::is_rate_limited(&anyhow::anyhow!("other error")));
     }
 }

--- a/src/commands/notebooks.rs
+++ b/src/commands/notebooks.rs
@@ -11,7 +11,6 @@ use crate::util_ext;
 
 const SEARCH_PATH: &str = "/api/v2/notebooks/search";
 const MAX_RESULTS: usize = 1000;
-const RATE_LIMIT_RETRIES: u32 = 3;
 
 fn compact_validation_details(content: &str) -> Option<String> {
     let parsed: serde_json::Value = serde_json::from_str(content).ok()?;
@@ -48,30 +47,6 @@ fn notebook_api_error<T: std::fmt::Debug>(
             )
         }
         other => anyhow::anyhow!("failed to {operation} notebook: {other}"),
-    }
-}
-
-fn is_rate_limited(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<raw_client::HttpError>()
-        .is_some_and(|error| error.status == 429)
-}
-
-async fn get_search_page(cfg: &Config, params: &[(&str, &str)]) -> Result<serde_json::Value> {
-    let mut retry = 0;
-    loop {
-        match raw_client::raw_get(cfg, SEARCH_PATH, params).await {
-            Ok(response) => return Ok(response),
-            Err(error) if is_rate_limited(&error) && retry < RATE_LIMIT_RETRIES => {
-                let delay = 10 * 2_u64.pow(retry);
-                retry += 1;
-                eprintln!(
-                    "Notebook search was rate limited; retrying in {delay}s ({retry}/{RATE_LIMIT_RETRIES})"
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
-            }
-            Err(error) => return Err(anyhow::anyhow!("failed to search notebooks: {error}")),
-        }
     }
 }
 
@@ -120,7 +95,9 @@ async fn discover(
             .map(|(field, value)| (field.as_str(), value.as_str())),
     );
 
-    let response = get_search_page(cfg, &params).await?;
+    let response = raw_client::raw_get(cfg, SEARCH_PATH, &params)
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to search notebooks: {error}"))?;
     let page_data = response
         .get("data")
         .and_then(serde_json::Value::as_array)
@@ -486,17 +463,5 @@ mod tests {
             filters,
             vec![("filter[tags]".into(), "pup-eval:abc".into())]
         );
-    }
-
-    #[test]
-    fn test_is_rate_limited_only_matches_http_429() {
-        let error = anyhow::Error::new(crate::raw_client::HttpError {
-            status: 429,
-            method: "GET".into(),
-            url: "https://example.test".into(),
-            body: "rate limited".into(),
-        });
-        assert!(super::is_rate_limited(&error));
-        assert!(!super::is_rate_limited(&anyhow::anyhow!("other error")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2062,15 +2062,22 @@ enum Commands {
     /// investigations, share findings, and create runbooks.
     ///
     /// CAPABILITIES:
-    ///   • List notebooks
+    ///   • Search notebooks with optional text, structured filters, sorting, and bounded results
+    ///   • Search notebook names and cell contents
     ///   • Get notebook details
     ///   • Create new notebooks
-    ///   • Update notebooks
+    ///   • Replace notebooks or append cells
     ///   • Delete notebooks
     ///
     /// EXAMPLES:
-    ///   # List all notebooks
-    ///   pup notebooks list
+    ///   # Find all notebooks
+    ///   pup notebooks search
+    ///
+    ///   # Find filtered notebooks, newest first
+    ///   pup notebooks search --filter "tags:production deleted:false" --sort=-modified_at
+    ///
+    ///   # Search notebook names and cell contents
+    ///   pup notebooks search --query "deployment rollback" --limit 50
     ///
     ///   # Get notebook details
     ///   pup notebooks get notebook-id
@@ -6392,10 +6399,36 @@ enum UsageActions {
 }
 
 // ---- Notebooks ----
+#[derive(clap::Args)]
+struct NotebookDiscoveryOptions {
+    /// Filter results using FIELD:VALUE. Repeat the flag or separate filters with spaces.
+    ///
+    /// Supported fields: author.handle, author, type, tags,
+    /// metadata.has_computational_cells, modified_from, modified_to, id,
+    /// dataset_id, experience_type, deleted, and show_favorites.
+    #[arg(long = "filter", value_name = "FIELD:VALUE")]
+    filters: Vec<String>,
+    /// Sort field. Prefix with '-' for descending order.
+    ///
+    /// Supported fields: name, created_at, modified_at, deleted_at, and favorited_by.
+    #[arg(long, default_value = "name", value_name = "FIELD")]
+    sort: String,
+    /// Maximum number of results to return (default 20, maximum 1000)
+    #[arg(long, default_value_t = 20, value_name = "COUNT")]
+    limit: usize,
+}
+
 #[derive(Subcommand)]
 enum NotebookActions {
-    /// List notebooks
-    List,
+    /// Search notebooks by optional text and structured filters
+    #[command(alias = "list")]
+    Search {
+        /// Optional text to find in notebook names or cell contents
+        #[arg(long, value_name = "TEXT")]
+        query: Option<String>,
+        #[command(flatten)]
+        options: NotebookDiscoveryOptions,
+    },
     /// Get notebook details
     Get { notebook_id: i64 },
     /// Create a new notebook
@@ -14428,7 +14461,16 @@ async fn main_inner() -> anyhow::Result<()> {
             cfg.validate_auth()?;
             match action {
                 NotebookActions::Annotations { action } => run_annotations(&cfg, action).await?,
-                NotebookActions::List => commands::notebooks::list(&cfg).await?,
+                NotebookActions::Search { query, options } => {
+                    commands::notebooks::search(
+                        &cfg,
+                        query.as_deref(),
+                        &options.filters,
+                        &options.sort,
+                        options.limit,
+                    )
+                    .await?;
+                }
                 NotebookActions::Get { notebook_id } => {
                     commands::notebooks::get(&cfg, notebook_id).await?;
                 }

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -9,6 +9,59 @@
 use clap::CommandFactory;
 
 // -------------------------------------------------------------------------
+// Notebook discovery
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_notebooks_search_parses_without_query() {
+    use clap::Parser;
+
+    let cli =
+        crate::Cli::try_parse_from(["pup", "notebooks", "search", "--filter", "tags:production"])
+            .expect("notebooks search should not require --query");
+
+    let crate::Commands::Notebooks { action } = cli.command else {
+        panic!("expected Commands::Notebooks");
+    };
+    let crate::NotebookActions::Search { query, options } = action else {
+        panic!("expected NotebookActions::Search");
+    };
+    assert_eq!(query, None);
+    assert_eq!(options.filters, ["tags:production"]);
+    assert_eq!(options.limit, 20);
+}
+
+#[test]
+fn test_notebooks_list_is_a_hidden_search_alias() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from(["pup", "notebooks", "list"])
+        .expect("notebooks list should remain a compatibility alias");
+
+    let crate::Commands::Notebooks { action } = cli.command else {
+        panic!("expected Commands::Notebooks");
+    };
+    let crate::NotebookActions::Search { query, options } = action else {
+        panic!("expected the list alias to resolve to NotebookActions::Search");
+    };
+    assert_eq!(query, None);
+    assert!(options.filters.is_empty());
+    assert_eq!(options.sort, "name");
+    assert_eq!(options.limit, 20);
+
+    let help = crate::Cli::command()
+        .find_subcommand("notebooks")
+        .expect("notebooks command should exist")
+        .clone()
+        .render_long_help()
+        .to_string();
+    assert!(
+        !help.contains("list"),
+        "hidden alias leaked into help: {help}"
+    );
+}
+
+// -------------------------------------------------------------------------
 // Read-only mode
 // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- replace the unfiltered v1 notebook list implementation with v2 notebook search
- support optional text queries, structured API filters, sorting, and a default limit of 20
- preserve backend totals and report returned and truncated result metadata
- keep `pup notebooks list` as a hidden compatibility alias
- make notebook validation errors readable

## Testing

- `cargo fmt --check`
- `git diff --check`
- `cargo test commands::notebooks::tests -- --test-threads=1` — 9 passed
- `cargo clippy --all-targets -- -D warnings`