### PR TITLE
pup: enable OAuth for ASM WAF, DDSQL editor, and Observability Pipelines commands

### DIFF
--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -47,6 +47,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "apm_remote_configuration_read",
         "apm_service_catalog_read",
         "apm_service_ingest_read",
+        "appsec_protect_read",
         "apps_run",
         "audit_logs_read",
         "aws_configuration_read",
@@ -119,6 +120,9 @@ pub fn default_scopes() -> Vec<&'static str> {
         "apm_service_ingest_read",
         "apm_service_ingest_write",
         "apm_service_renaming_write",
+        // AppSec
+        "appsec_protect_read",
+        "appsec_protect_write",
         // App Builder
         "apps_run",
         "apps_write",

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -588,7 +588,7 @@ pub async fn suppressions_validate(cfg: &Config, file: &str) -> Result<()> {
 // ---- ASM WAF Custom Rules ----
 
 pub async fn asm_custom_rules_list(cfg: &Config) -> Result<()> {
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .list_application_security_waf_custom_rules()
         .await
@@ -597,7 +597,7 @@ pub async fn asm_custom_rules_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn asm_custom_rules_get(cfg: &Config, custom_rule_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .get_application_security_waf_custom_rule(custom_rule_id.to_string())
         .await
@@ -607,7 +607,7 @@ pub async fn asm_custom_rules_get(cfg: &Config, custom_rule_id: &str) -> Result<
 
 pub async fn asm_custom_rules_create(cfg: &Config, file: &str) -> Result<()> {
     let body: ApplicationSecurityWafCustomRuleCreateRequest = util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .create_application_security_waf_custom_rule(body)
         .await
@@ -617,7 +617,7 @@ pub async fn asm_custom_rules_create(cfg: &Config, file: &str) -> Result<()> {
 
 pub async fn asm_custom_rules_update(cfg: &Config, custom_rule_id: &str, file: &str) -> Result<()> {
     let body: ApplicationSecurityWafCustomRuleUpdateRequest = util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .update_application_security_waf_custom_rule(custom_rule_id.to_string(), body)
         .await
@@ -626,7 +626,7 @@ pub async fn asm_custom_rules_update(cfg: &Config, custom_rule_id: &str, file: &
 }
 
 pub async fn asm_custom_rules_delete(cfg: &Config, custom_rule_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     api.delete_application_security_waf_custom_rule(custom_rule_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete ASM WAF custom rule: {e:?}"))?;
@@ -637,7 +637,7 @@ pub async fn asm_custom_rules_delete(cfg: &Config, custom_rule_id: &str) -> Resu
 // ---- ASM WAF Exclusion Filters ----
 
 pub async fn asm_exclusions_list(cfg: &Config) -> Result<()> {
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .list_application_security_waf_exclusion_filters()
         .await
@@ -646,7 +646,7 @@ pub async fn asm_exclusions_list(cfg: &Config) -> Result<()> {
 }
 
 pub async fn asm_exclusions_get(cfg: &Config, exclusion_filter_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .get_application_security_waf_exclusion_filter(exclusion_filter_id.to_string())
         .await
@@ -656,7 +656,7 @@ pub async fn asm_exclusions_get(cfg: &Config, exclusion_filter_id: &str) -> Resu
 
 pub async fn asm_exclusions_create(cfg: &Config, file: &str) -> Result<()> {
     let body: ApplicationSecurityWafExclusionFilterCreateRequest = util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .create_application_security_waf_exclusion_filter(body)
         .await
@@ -670,7 +670,7 @@ pub async fn asm_exclusions_update(
     file: &str,
 ) -> Result<()> {
     let body: ApplicationSecurityWafExclusionFilterUpdateRequest = util::read_json_file(file)?;
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     let resp = api
         .update_application_security_waf_exclusion_filter(exclusion_filter_id.to_string(), body)
         .await
@@ -679,7 +679,7 @@ pub async fn asm_exclusions_update(
 }
 
 pub async fn asm_exclusions_delete(cfg: &Config, exclusion_filter_id: &str) -> Result<()> {
-    let api = crate::make_api_no_auth!(ApplicationSecurityAPI, cfg);
+    let api = crate::make_api!(ApplicationSecurityAPI, cfg);
     api.delete_application_security_waf_exclusion_filter(exclusion_filter_id.to_string())
         .await
         .map_err(|e| anyhow::anyhow!("failed to delete ASM WAF exclusion filter: {e:?}"))?;

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -120,19 +120,6 @@ fn find_endpoint_requirement(method: &str, path: &str) -> Option<&'static Endpoi
 /// Endpoints that don't support OAuth.
 /// Trailing "/" means prefix match for ID-parameterized paths.
 static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
-    // DDSQL editor tools (3)
-    EndpointRequirement {
-        path: "/api/unstable/ddsql-editor/tools/ddsql-docs",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/unstable/ddsql-editor/tools/table-names",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/unstable/ddsql-editor/tools/table-data",
-        method: "POST",
-    },
     // Fleet Automation (15)
     EndpointRequirement {
         path: "/api/v2/fleet/agents",
@@ -192,31 +179,6 @@ static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
     },
     EndpointRequirement {
         path: "/api/v2/fleet/schedules/",
-        method: "POST",
-    },
-    // Observability Pipelines (6) — API key only, no OAuth support
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/",
-        method: "PUT",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/",
-        method: "DELETE",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/validate",
         method: "POST",
     },
     // Cost / Billing (11) — API key only, no OAuth support
@@ -836,7 +798,7 @@ mod tests {
 
     #[test]
     fn test_oauth_excluded_count() {
-        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 46);
+        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 37);
     }
 
     #[test]
@@ -878,22 +840,6 @@ mod tests {
         assert!(!requires_api_key_fallback(
             "PATCH",
             "/api/v2/application_keys/key-123"
-        ));
-    }
-
-    #[test]
-    fn test_requires_api_key_fallback_ddsql_editor_tools() {
-        assert!(requires_api_key_fallback(
-            "GET",
-            "/api/unstable/ddsql-editor/tools/ddsql-docs"
-        ));
-        assert!(requires_api_key_fallback(
-            "GET",
-            "/api/unstable/ddsql-editor/tools/table-names"
-        ));
-        assert!(requires_api_key_fallback(
-            "POST",
-            "/api/unstable/ddsql-editor/tools/table-data"
         ));
     }
 


### PR DESCRIPTION
## Summary

Enable OAuth bearer auth for three groups of pup commands that previously fell back to API-key-only auth:

- **ASM WAF** (10 commands): `asm_custom_rules_*` (5) and `asm_exclusions_*` (5) in `security.rs` -- switched from `make_api_no_auth!` to `make_api!`
- **DDSQL editor** (3 commands): `ddsql::spec`, `ddsql::schema_tables`, `ddsql::schema_columns` -- removed 3 endpoints from `OAUTH_EXCLUDED_ENDPOINTS` so `raw_get`/`raw_post` send the bearer
- **Observability Pipelines** (7 commands): `obs_pipelines::diff` and all other obs-pipelines commands -- removed 6 endpoints from `OAUTH_EXCLUDED_ENDPOINTS` (server already accepts OAuth)

## Changes

- `src/commands/security.rs`: 10 `make_api_no_auth!` -> `make_api!` swaps for ASM WAF functions
- `src/raw_client.rs`: Removed 3 DDSQL editor + 6 obs-pipelines entries from `OAUTH_EXCLUDED_ENDPOINTS` (46 -> 37), updated count test, removed obsolete ddsql-editor test
- `src/auth/types.rs`: Added `appsec_protect_read` and `appsec_protect_write` to the OAuth scope list

## Server-side PRs

- DDSQL editor: [dd-source#66615](https://github.com/ddoghq/dd-source/pull/66615) adds `ValidOAuthAccessToken` to the 3 ddsql-editor routes
- ASM WAF: server routes are in dd-go's rc-api (chi router, JWT-based auth) -- server-side gap is at the gateway level, not a per-route code change
- Observability Pipelines: server already accepts OAuth (no server PR needed)
- Billing seats: [dd-source#66599](https://github.com/ddoghq/dd-source/pull/66599) adds OAuth to `/api/v2/seats/users` routes

## FAQ

See [Info & FAQ: Expanding OAuth support](https://datadoghq.atlassian.net/wiki/spaces/~880408511/pages/7114163387/Info+FAQ+Expanding+OAuth+support)