### PR TITLE
feat(rum): add Session Replay segments, playlist CRUD, and viewership

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ list of commands as built.
 | Metrics | ✅ | `metrics search`, `metrics query`, `metrics list`, `metrics get` | V1 and V2 APIs supported |
 | Logs | ✅ | `logs search`, `logs list`, `logs aggregate` | V1 and V2 APIs supported |
 | Events | ✅ | `events list`, `events search`, `events get` | Infrastructure event management |
-| RUM | ✅ | `rum apps`, `rum sessions`, `rum metrics`, `rum retention-filters`, `rum playlists`, `rum heatmaps` | Apps, sessions, metrics, retention filters, replay playlists, heatmaps |
+| RUM | ✅ | `rum apps`, `rum sessions`, `rum events`, `rum aggregate`, `rum metrics`, `rum retention-filters`, `rum playlists`, `rum replay`, `rum viewership`, `rum heatmaps` | Apps, sessions, events, metrics, retention filters, replay playlists/segments/viewership, heatmaps |
 | APM Services | ✅ | `apm services`, `apm entities`, `apm dependencies`, `apm flow-map` | Services stats, operations, resources; entity queries; dependencies; flow visualization |
 | Traces | ✅ | `traces search`, `traces aggregate`, `traces metrics` | Span search/aggregation and span-based metric definitions |
 | Profiling | ⏳ | `profiling` | Not supported in pup yet. Use the Datadog MCP server: https://docs.datadoghq.com/bits_ai/mcp_server. Enable with: https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core,profiling |
 | Database Monitoring | ✅ | `dbm samples search` | DBM query sample search |
-| Session Replay | ❌ | - | Not yet implemented |
+| Session Replay | ✅ | `rum replay segments`, `rum playlists`, `rum viewership`, `rum sessions search` | Segments, playlist CRUD, viewership; discover sessions via RUM (not logs) |
 
 </details>
 

--- a/agents/rum.md
+++ b/agents/rum.md
@@ -302,6 +302,14 @@ RUM Data Collection:
 - Session replay integration
 - Error stack traces and source maps
 
-Note: For detailed session replays and funnel analysis, use the Datadog RUM UI which provides visualizations and recordings.
+Session Replay via CLI:
+- Discover replay sessions: `pup rum sessions search --query='@session.has_replay:true' --from=1d`
+- Fetch replay segments: `pup rum replay segments get --session-id=<uuid> --view-id=<uuid>`
+- Manage playlists: `pup rum playlists list|create|update|delete` and `pup rum playlists sessions add|remove|list`
+- Viewership: `pup rum viewership history list --from=7d` and `pup rum viewership watchers list --session-id=<uuid>`
+
+Note: Session Replay metadata is in the RUM API, not the logs index. Use `pup rum` for discovery; use `pup logs search --query='@session.id:<uuid>'` only to correlate application logs once you have a session ID from RUM.
+
+For visual replay playback and funnel analysis, use the Datadog RUM UI.
 
 For RUM-based alerting, use the monitors agent to create alerts for error rates, performance degradation, or user experience issues.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -33,7 +33,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | debugger | probes (list, get, create, delete, watch) | src/commands/debugger.rs | ✅ |
 | slos | list, get, create, update, diff, delete, status | src/commands/slos.rs | ✅ |
 | incidents | list, get, attachments, settings, handles, postmortem-templates | src/commands/incidents.rs | ✅ |
-| rum | apps, metrics, retention-filters, sessions, playlists, heatmaps | src/commands/rum.rs | ✅ |
+| rum | apps, metrics, retention-filters, sessions, events, aggregate, playlists, replay, viewership, heatmaps | src/commands/rum.rs | ✅ |
 | cicd | pipelines, events, tests, dora, flaky-tests | src/commands/cicd.rs | ✅ |
 | static-analysis | custom-rulesets (get, update, delete), custom-rules (get, create, delete, revisions, revision) | src/commands/static_analysis.rs | ✅ |
 | downtime | list, get, cancel | src/commands/downtime.rs | ✅ |
@@ -312,6 +312,12 @@ Constraints worth knowing before relying on these:
 - `--output` and agent mode have no effect under `--markdown`: the document is
   printed as-is, with no envelope and no format conversion. This matches
   `skills remote get`, the other command that emits raw Markdown.
+
+### v1.13.x — Session Replay API Support (#182)
+
+- **rum replay segments get** — fetch replay recording segments for a session view (`--session-id`, `--view-id`, optional paging/source flags)
+- **rum playlists** — extended with create, update, delete, and `sessions list|add|remove|bulk-remove`
+- **rum viewership** — new subgroup: `history list`, `watch create|delete`, `watchers list`
 
 ### v0.64.x — Error Tracking Issue Filters (SDK PRs #1568, #1480)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -518,7 +518,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 188);
+        assert_eq!(UNSTABLE_OPS.len(), 187);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -377,6 +377,8 @@ static UNSTABLE_OPS: &[&str] = &[
     "v2.get_tag_rule_score",
     "v2.list_tag_rules",
     "v2.update_tag_rule",
+    // RUM Session Replay (1)
+    "v2.get_segments",
     // Model Lab (16)
     "v2.delete_model_lab_run",
     "v2.get_model_lab_artifact_content",
@@ -516,7 +518,7 @@ mod tests {
 
     #[test]
     fn test_unstable_ops_count() {
-        assert_eq!(UNSTABLE_OPS.len(), 186);
+        assert_eq!(UNSTABLE_OPS.len(), 188);
     }
 
     #[test]

--- a/src/commands/rum.rs
+++ b/src/commands/rum.rs
@@ -5,14 +5,23 @@ use datadog_api_client::datadogV2::api_rum_replay_heatmaps::{
     ListReplayHeatmapSnapshotsOptionalParams, RumReplayHeatmapsAPI,
 };
 use datadog_api_client::datadogV2::api_rum_replay_playlists::{
+    AddRumReplaySessionToPlaylistOptionalParams, ListRumReplayPlaylistSessionsOptionalParams,
     ListRumReplayPlaylistsOptionalParams, RumReplayPlaylistsAPI,
+};
+use datadog_api_client::datadogV2::api_rum_replay_sessions::{
+    GetSegmentsOptionalParams, RumReplaySessionsAPI,
+};
+use datadog_api_client::datadogV2::api_rum_replay_viewership::{
+    ListRumReplaySessionWatchersOptionalParams,
+    ListRumReplayViewershipHistorySessionsOptionalParams, RumReplayViewershipAPI,
 };
 use datadog_api_client::datadogV2::api_rum_retention_filters::RumRetentionFiltersAPI;
 use datadog_api_client::datadogV2::model::{
-    RUMApplicationCreate, RUMApplicationCreateAttributes, RUMApplicationCreateRequest,
+    Playlist, RUMApplicationCreate, RUMApplicationCreateAttributes, RUMApplicationCreateRequest,
     RUMApplicationCreateType, RUMApplicationUpdateRequest, RUMQueryFilter, RUMQueryPageOptions,
     RUMSearchEventsRequest, RUMSort, RumMetricCreateRequest, RumMetricUpdateRequest,
-    RumRetentionFilterCreateRequest, RumRetentionFilterUpdateRequest,
+    RumRetentionFilterCreateRequest, RumRetentionFilterUpdateRequest, SessionIdArray, Watch,
+    WatchData, WatchDataType,
 };
 
 use crate::config::Config;
@@ -288,6 +297,248 @@ pub async fn playlists_get(cfg: &Config, playlist_id: i32) -> Result<()> {
     formatter::output(cfg, &resp)
 }
 
+pub async fn playlists_create(cfg: &Config, file: &str) -> Result<()> {
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
+    let body: Playlist = crate::util::read_json_file(file)?;
+    let resp = api
+        .create_rum_replay_playlist(body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create RUM playlist: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn playlists_update(cfg: &Config, playlist_id: i32, file: &str) -> Result<()> {
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
+    let body: Playlist = crate::util::read_json_file(file)?;
+    let resp = api
+        .update_rum_replay_playlist(playlist_id as i64, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update RUM playlist: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn playlists_delete(cfg: &Config, playlist_id: i32) -> Result<()> {
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
+    api.delete_rum_replay_playlist(playlist_id as i64)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete RUM playlist: {e:?}"))?;
+    println!("RUM playlist {playlist_id} deleted.");
+    Ok(())
+}
+
+pub async fn playlists_sessions_list(
+    cfg: &Config,
+    playlist_id: i32,
+    page_number: Option<i64>,
+    page_size: i64,
+) -> Result<()> {
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
+    let mut params = ListRumReplayPlaylistSessionsOptionalParams::default().page_size(page_size);
+    if let Some(page_number) = page_number {
+        params = params.page_number(page_number);
+    }
+    let resp = api
+        .list_rum_replay_playlist_sessions(playlist_id as i64, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list RUM playlist sessions: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn playlists_sessions_add(
+    cfg: &Config,
+    playlist_id: i32,
+    session_id: String,
+    ts: Option<i64>,
+    data_source: Option<String>,
+) -> Result<()> {
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
+    let ts = ts.unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+    let mut params = AddRumReplaySessionToPlaylistOptionalParams::default();
+    if let Some(data_source) = data_source {
+        params = params.data_source(data_source);
+    }
+    let resp = api
+        .add_rum_replay_session_to_playlist(ts, playlist_id as i64, session_id, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to add session to RUM playlist: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn playlists_sessions_remove(
+    cfg: &Config,
+    playlist_id: i32,
+    session_id: String,
+) -> Result<()> {
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
+    api.remove_rum_replay_session_from_playlist(playlist_id as i64, session_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to remove session from RUM playlist: {e:?}"))?;
+    println!("Session removed from RUM playlist {playlist_id}.");
+    Ok(())
+}
+
+pub async fn playlists_sessions_bulk_remove(
+    cfg: &Config,
+    playlist_id: i32,
+    file: &str,
+) -> Result<()> {
+    let api = crate::make_api!(RumReplayPlaylistsAPI, cfg);
+    let body: SessionIdArray = crate::util::read_json_file(file)?;
+    api.bulk_remove_rum_replay_playlist_sessions(playlist_id as i64, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to bulk-remove RUM playlist sessions: {e:?}"))?;
+    println!("Sessions removed from RUM playlist {playlist_id}.");
+    Ok(())
+}
+
+// ---- RUM Replay Segments ----
+
+pub struct ReplaySegmentsGetArgs {
+    pub session_id: String,
+    pub view_id: String,
+    pub source: Option<String>,
+    pub ts: Option<i64>,
+    pub max_list_size: Option<i64>,
+    pub paging: Option<String>,
+}
+
+fn output_response_content(cfg: &Config, content: &str) -> Result<()> {
+    if content.trim().is_empty() {
+        formatter::output(cfg, &serde_json::Value::Null)?;
+        return Ok(());
+    }
+    let value: serde_json::Value = serde_json::from_str(content)
+        .map_err(|e| anyhow::anyhow!("failed to parse API response JSON: {e}"))?;
+    formatter::output(cfg, &value)
+}
+
+pub async fn replay_segments_get(cfg: &Config, args: ReplaySegmentsGetArgs) -> Result<()> {
+    let api = crate::make_api!(RumReplaySessionsAPI, cfg);
+    let ReplaySegmentsGetArgs {
+        session_id,
+        view_id,
+        source,
+        ts,
+        max_list_size,
+        paging,
+    } = args;
+
+    let mut params = GetSegmentsOptionalParams::default();
+    if let Some(source) = source {
+        params = params.source(source);
+    }
+    if let Some(ts) = ts {
+        params = params.ts(ts);
+    }
+    if let Some(max_list_size) = max_list_size {
+        params = params.max_list_size(max_list_size);
+    }
+    if let Some(paging) = paging {
+        params = params.paging(paging);
+    }
+
+    let resp = api
+        .get_segments_with_http_info(view_id, session_id, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get RUM replay segments: {e:?}"))?;
+    output_response_content(cfg, &resp.content)
+}
+
+// ---- RUM Viewership ----
+
+pub struct ViewershipHistoryListArgs {
+    pub from: String,
+    pub to: String,
+    pub page_number: Option<i64>,
+    pub page_size: i64,
+    pub session_ids: Option<String>,
+    pub application_id: Option<String>,
+    pub created_by: Option<String>,
+}
+
+pub async fn viewership_history_list(cfg: &Config, args: ViewershipHistoryListArgs) -> Result<()> {
+    let api = crate::make_api!(RumReplayViewershipAPI, cfg);
+    let ViewershipHistoryListArgs {
+        from,
+        to,
+        page_number,
+        page_size,
+        session_ids,
+        application_id,
+        created_by,
+    } = args;
+    let from_ms = util_ext::parse_time_to_unix_millis(&from)?;
+    let to_ms = util_ext::parse_time_to_unix_millis(&to)?;
+
+    let mut params = ListRumReplayViewershipHistorySessionsOptionalParams::default()
+        .filter_watched_at_start(from_ms)
+        .filter_watched_at_end(to_ms)
+        .page_size(page_size);
+    if let Some(page_number) = page_number {
+        params = params.page_number(page_number);
+    }
+    if let Some(session_ids) = session_ids {
+        params = params.filter_session_ids(session_ids);
+    }
+    if let Some(application_id) = application_id {
+        params = params.filter_application_id(application_id);
+    }
+    if let Some(created_by) = created_by {
+        params = params.filter_created_by(created_by);
+    }
+
+    let resp = api
+        .list_rum_replay_viewership_history_sessions(params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list RUM viewership history: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn viewership_watch_create(
+    cfg: &Config,
+    session_id: String,
+    file: Option<String>,
+) -> Result<()> {
+    let api = crate::make_api!(RumReplayViewershipAPI, cfg);
+    let body: Watch = if let Some(file) = file {
+        crate::util::read_json_file(&file)?
+    } else {
+        Watch::new(WatchData::new(WatchDataType::RUM_REPLAY_WATCH))
+    };
+    let resp = api
+        .create_rum_replay_session_watch(session_id, body)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create RUM replay watch: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
+pub async fn viewership_watch_delete(cfg: &Config, session_id: String) -> Result<()> {
+    let api = crate::make_api!(RumReplayViewershipAPI, cfg);
+    api.delete_rum_replay_session_watch(session_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to delete RUM replay watch: {e:?}"))?;
+    println!("RUM replay watch deleted.");
+    Ok(())
+}
+
+pub async fn viewership_watchers_list(
+    cfg: &Config,
+    session_id: String,
+    page_number: Option<i64>,
+    page_size: i64,
+) -> Result<()> {
+    let api = crate::make_api!(RumReplayViewershipAPI, cfg);
+    let mut params = ListRumReplaySessionWatchersOptionalParams::default().page_size(page_size);
+    if let Some(page_number) = page_number {
+        params = params.page_number(page_number);
+    }
+    let resp = api
+        .list_rum_replay_session_watchers(session_id, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list RUM replay watchers: {e:?}"))?;
+    formatter::output(cfg, &resp)
+}
+
 // ---- RUM Heatmaps ----
 
 pub async fn heatmaps_query(cfg: &Config, view_name: &str) -> Result<()> {
@@ -539,6 +790,138 @@ mod tests {
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
         let _ = super::playlists_list(&cfg).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_playlists_create() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(
+            &mut s,
+            r#"{"data": {"id": "1", "type": "rum_replay_playlist"}}"#,
+        )
+        .await;
+        let path =
+            std::env::temp_dir().join(format!("pup-rum-playlist-{}.json", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"{"data":{"type":"rum_replay_playlist","attributes":{"name":"test"}}}"#,
+        )
+        .unwrap();
+        let _ = super::playlists_create(&cfg, path.to_str().unwrap()).await;
+        let _ = std::fs::remove_file(path);
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_playlists_delete() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{}"#).await;
+        let _ = super::playlists_delete(&cfg, 123).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_playlists_sessions_list() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let _ = super::playlists_sessions_list(&cfg, 123, None, 100).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_replay_segments_get() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let result = super::replay_segments_get(
+            &cfg,
+            super::ReplaySegmentsGetArgs {
+                session_id: "sess-1".into(),
+                view_id: "view-1".into(),
+                source: None,
+                ts: None,
+                max_list_size: None,
+                paging: None,
+            },
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "replay segments get failed: {:?}",
+            result.err()
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_viewership_history_list() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let _ = super::viewership_history_list(
+            &cfg,
+            super::ViewershipHistoryListArgs {
+                from: "1h".into(),
+                to: "now".into(),
+                page_number: None,
+                page_size: 100,
+                session_ids: None,
+                application_id: None,
+                created_by: None,
+            },
+        )
+        .await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_viewership_watch_create() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(
+            &mut s,
+            r#"{"data": {"id": "watch-1", "type": "rum_replay_watch"}}"#,
+        )
+        .await;
+        let _ = super::viewership_watch_create(&cfg, "sess-1".into(), None).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_rum_viewership_watchers_list() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let _ = super::viewership_watchers_list(&cfg, "sess-1".into(), None, 100).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_output_response_content_parses_json() {
+        let _lock = lock_env().await;
+        let cfg = test_config("https://example.com");
+        let result = super::output_response_content(&cfg, r#"{"ok":true}"#);
+        assert!(result.is_ok());
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_output_response_content_rejects_invalid_json() {
+        let _lock = lock_env().await;
+        let cfg = test_config("https://example.com");
+        let result = super::output_response_content(&cfg, "not-json");
+        assert!(result.is_err());
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2311,6 +2311,7 @@ enum Commands {
     ///   • Configure RUM metrics and custom metrics
     ///   • Set up retention filters for session replay and data
     ///   • Query session replay data and playlists
+    ///   • Fetch replay recording segments and viewership data
     ///   • Analyze user interaction heatmaps
     ///
     /// RUM DATA TYPES:
@@ -2345,6 +2346,13 @@ enum Commands {
     ///
     ///   # Query session replay data
     ///   pup rum sessions list --from="1h"
+    ///
+    ///   # Get replay segments for a session view
+    ///   pup rum replay segments get --session-id="..." --view-id="..."
+    ///
+    ///   # Manage replay playlists
+    ///   pup rum playlists list
+    ///   pup rum playlists create --file=playlist.json
     ///
     /// AUTHENTICATION:
     ///   Requires either OAuth2 authentication (pup auth login) or API keys
@@ -6612,6 +6620,16 @@ enum RumActions {
         #[command(subcommand)]
         action: RumPlaylistActions,
     },
+    /// Session replay recording segments
+    Replay {
+        #[command(subcommand)]
+        action: RumReplayActions,
+    },
+    /// Session replay viewership
+    Viewership {
+        #[command(subcommand)]
+        action: RumViewershipActions,
+    },
     /// Query RUM interaction heatmaps
     Heatmaps {
         #[command(subcommand)]
@@ -6727,6 +6745,156 @@ enum RumPlaylistActions {
     List,
     /// Get playlist details
     Get { playlist_id: i32 },
+    /// Create a session replay playlist
+    Create {
+        #[arg(long)]
+        file: String,
+    },
+    /// Update a session replay playlist
+    Update {
+        playlist_id: i32,
+        #[arg(long)]
+        file: String,
+    },
+    /// Delete a session replay playlist
+    Delete { playlist_id: i32 },
+    /// Manage sessions in a playlist
+    Sessions {
+        #[command(subcommand)]
+        action: RumPlaylistSessionActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum RumPlaylistSessionActions {
+    /// List sessions in a playlist
+    List {
+        playlist_id: i32,
+        #[arg(long)]
+        page_number: Option<i64>,
+        #[arg(long, default_value_t = 100)]
+        page_size: i64,
+    },
+    /// Add a session to a playlist
+    Add {
+        playlist_id: i32,
+        #[arg(long)]
+        session_id: String,
+        #[arg(long, help = "Session timestamp in milliseconds (defaults to now)")]
+        ts: Option<i64>,
+        #[arg(long, help = "Data source: rum or product_analytics")]
+        data_source: Option<String>,
+    },
+    /// Remove a session from a playlist
+    Remove {
+        playlist_id: i32,
+        #[arg(long)]
+        session_id: String,
+    },
+    /// Bulk-remove sessions from a playlist
+    #[command(name = "bulk-remove")]
+    BulkRemove {
+        playlist_id: i32,
+        #[arg(long)]
+        file: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum RumReplayActions {
+    /// Session replay segment data
+    Segments {
+        #[command(subcommand)]
+        action: RumReplaySegmentActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum RumReplaySegmentActions {
+    /// Get replay segments for a session view
+    Get {
+        #[arg(long)]
+        session_id: String,
+        #[arg(long)]
+        view_id: String,
+        #[arg(long, help = "Storage source: event_platform or blob")]
+        source: Option<String>,
+        #[arg(long, help = "Server-side timestamp in milliseconds")]
+        ts: Option<i64>,
+        #[arg(long, help = "Maximum segment list size in bytes")]
+        max_list_size: Option<i64>,
+        #[arg(long, help = "Paging token for pagination")]
+        paging: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum RumViewershipActions {
+    /// Viewership history
+    History {
+        #[command(subcommand)]
+        action: RumViewershipHistoryActions,
+    },
+    /// Watch a replay session
+    Watch {
+        #[command(subcommand)]
+        action: RumViewershipWatchActions,
+    },
+    /// Session replay watchers
+    Watchers {
+        #[command(subcommand)]
+        action: RumViewershipWatchersActions,
+    },
+}
+
+#[derive(Subcommand)]
+enum RumViewershipHistoryActions {
+    /// List viewership history sessions
+    List {
+        #[arg(long, default_value = "1h")]
+        from: String,
+        #[arg(long, default_value = "now")]
+        to: String,
+        #[arg(long)]
+        page_number: Option<i64>,
+        #[arg(long, default_value_t = 100)]
+        page_size: i64,
+        #[arg(long, help = "Comma-separated session IDs")]
+        session_ids: Option<String>,
+        #[arg(long)]
+        application_id: Option<String>,
+        #[arg(long, help = "Filter by user UUID")]
+        created_by: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum RumViewershipWatchActions {
+    /// Create a replay session watch
+    Create {
+        #[arg(long)]
+        session_id: String,
+        #[arg(long, help = "Optional JSON body (defaults to empty watch)")]
+        file: Option<String>,
+    },
+    /// Delete a replay session watch
+    Delete {
+        #[arg(long)]
+        session_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum RumViewershipWatchersActions {
+    /// List watchers for a replay session
+    List {
+        #[arg(long)]
+        session_id: String,
+        #[arg(long)]
+        page_number: Option<i64>,
+        #[arg(long, default_value_t = 100)]
+        page_size: i64,
+    },
 }
 
 #[derive(Subcommand)]
@@ -14749,6 +14917,142 @@ async fn main_inner() -> anyhow::Result<()> {
                     RumPlaylistActions::Get { playlist_id } => {
                         commands::rum::playlists_get(&cfg, playlist_id).await?;
                     }
+                    RumPlaylistActions::Create { file } => {
+                        commands::rum::playlists_create(&cfg, &file).await?;
+                    }
+                    RumPlaylistActions::Update { playlist_id, file } => {
+                        commands::rum::playlists_update(&cfg, playlist_id, &file).await?;
+                    }
+                    RumPlaylistActions::Delete { playlist_id } => {
+                        if !cfg.auto_approve {
+                            eprint!(
+                                "Permanently delete RUM playlist {playlist_id}? Type 'yes' to confirm: "
+                            );
+                            let mut input = String::new();
+                            std::io::stdin().read_line(&mut input)?;
+                            if input.trim() != "yes" {
+                                println!("Operation cancelled.");
+                                return Ok(());
+                            }
+                        }
+                        commands::rum::playlists_delete(&cfg, playlist_id).await?;
+                    }
+                    RumPlaylistActions::Sessions { action } => match action {
+                        RumPlaylistSessionActions::List {
+                            playlist_id,
+                            page_number,
+                            page_size,
+                        } => {
+                            commands::rum::playlists_sessions_list(
+                                &cfg,
+                                playlist_id,
+                                page_number,
+                                page_size,
+                            )
+                            .await?;
+                        }
+                        RumPlaylistSessionActions::Add {
+                            playlist_id,
+                            session_id,
+                            ts,
+                            data_source,
+                        } => {
+                            commands::rum::playlists_sessions_add(
+                                &cfg,
+                                playlist_id,
+                                session_id,
+                                ts,
+                                data_source,
+                            )
+                            .await?;
+                        }
+                        RumPlaylistSessionActions::Remove {
+                            playlist_id,
+                            session_id,
+                        } => {
+                            commands::rum::playlists_sessions_remove(&cfg, playlist_id, session_id)
+                                .await?;
+                        }
+                        RumPlaylistSessionActions::BulkRemove { playlist_id, file } => {
+                            commands::rum::playlists_sessions_bulk_remove(&cfg, playlist_id, &file)
+                                .await?;
+                        }
+                    },
+                },
+                RumActions::Replay { action } => match action {
+                    RumReplayActions::Segments { action } => match action {
+                        RumReplaySegmentActions::Get {
+                            session_id,
+                            view_id,
+                            source,
+                            ts,
+                            max_list_size,
+                            paging,
+                        } => {
+                            commands::rum::replay_segments_get(
+                                &cfg,
+                                commands::rum::ReplaySegmentsGetArgs {
+                                    session_id,
+                                    view_id,
+                                    source,
+                                    ts,
+                                    max_list_size,
+                                    paging,
+                                },
+                            )
+                            .await?;
+                        }
+                    },
+                },
+                RumActions::Viewership { action } => match action {
+                    RumViewershipActions::History { action } => match action {
+                        RumViewershipHistoryActions::List {
+                            from,
+                            to,
+                            page_number,
+                            page_size,
+                            session_ids,
+                            application_id,
+                            created_by,
+                        } => {
+                            commands::rum::viewership_history_list(
+                                &cfg,
+                                commands::rum::ViewershipHistoryListArgs {
+                                    from,
+                                    to,
+                                    page_number,
+                                    page_size,
+                                    session_ids,
+                                    application_id,
+                                    created_by,
+                                },
+                            )
+                            .await?;
+                        }
+                    },
+                    RumViewershipActions::Watch { action } => match action {
+                        RumViewershipWatchActions::Create { session_id, file } => {
+                            commands::rum::viewership_watch_create(&cfg, session_id, file).await?;
+                        }
+                        RumViewershipWatchActions::Delete { session_id } => {
+                            commands::rum::viewership_watch_delete(&cfg, session_id).await?;
+                        }
+                    },
+                    RumViewershipActions::Watchers { action } => match action {
+                        RumViewershipWatchersActions::List {
+                            session_id,
+                            page_number,
+                            page_size,
+                        } => {
+                            commands::rum::viewership_watchers_list(
+                                &cfg,
+                                session_id,
+                                page_number,
+                                page_size,
+                            )
+                            .await?;
+                        }
+                    },
                 },
                 RumActions::Heatmaps { action } => match action {
                     RumHeatmapActions::Query { view_name, .. } => {


### PR DESCRIPTION
## Summary
- Wire Session Replay segments, full playlist management, and viewership APIs
- SDK clients already exist at the pinned rev; no dependency bump
- Session Replay metadata is discovered via `pup rum`, not `pup logs`

## Changes
- `src/commands/rum.rs` — replay segments, playlist CRUD/sessions, viewership handlers + unit tests
- `src/main.rs` — CLI enums and dispatch for `rum replay`, extended `playlists`, and `rum viewership`
- `src/client.rs` — enable unstable op `v2.get_segments`
- `README.md`, `docs/COMMANDS.md`, `agents/rum.md` — document Session Replay coverage

## Testing
- [x] `cargo test commands::rum`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual smoke against datadoghq.com (`playlists list`, `viewership history list`)

Closes #182

Made with [Cursor](https://cursor.com)