### PR TITLE
pup: remove stale OAuth-excluded endpoints for fleet, cost/billing, and CCM | DAL-1057

### DIFF
--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -870,13 +870,13 @@ mod tests {
         cleanup_env();
     }
 
-    /// OAuth-excluded endpoints (e.g. GET /api/v2/fleet/agents) must use API-key
+    /// OAuth-excluded endpoints (e.g. GET /profiling/api/v1/profiles/abc/info) must use API-key
     /// auth even when a bearer token is present. This exercises the reuse of
     /// raw_client::apply_auth's per-endpoint fallback table.
     ///
-    /// Fleet Automation is just today's example of a still-excluded endpoint,
+    /// Profiling is just today's example of a still-excluded endpoint,
     /// not a claim it's meant to stay that way -- update this test if/when
-    /// Fleet gets OAuth support too.
+    /// Profiling gets OAuth support too.
     #[tokio::test]
     async fn test_api_oauth_excluded_uses_api_keys() {
         let _lock = lock_env().await;
@@ -886,7 +886,7 @@ mod tests {
         // must prefer the API keys.
         cfg.access_token = Some("bearer-token".into());
         let _mock = server
-            .mock("GET", "/api/v2/fleet/agents")
+            .mock("GET", "/profiling/api/v1/profiles/abc/info")
             .match_query(mockito::Matcher::Any)
             .match_header("DD-API-KEY", "test-api-key")
             .match_header("DD-APPLICATION-KEY", "test-app-key")
@@ -899,7 +899,7 @@ mod tests {
 
         let result = super::run(
             &cfg,
-            "v2/fleet/agents",
+            "profiling/api/v1/profiles/abc/info",
             "GET",
             &[],
             &[],
@@ -927,7 +927,7 @@ mod tests {
         let mut cfg = test_config(&server.url());
         cfg.access_token = Some("bearer-token".into());
         let _mock = server
-            .mock("GET", "/api/v2/fleet/agents")
+            .mock("GET", "/profiling/api/v1/profiles/abc/info")
             .match_query(mockito::Matcher::Any)
             .match_header("DD-API-KEY", "test-api-key")
             .match_header("authorization", mockito::Matcher::Missing)
@@ -938,7 +938,7 @@ mod tests {
             .await;
 
         // Pass the fully-qualified URL, not a relative path.
-        let absolute = format!("{}/api/v2/fleet/agents", server.url());
+        let absolute = format!("{}/profiling/api/v1/profiles/abc/info", server.url());
         let result = super::run(
             &cfg,
             &absolute,

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -872,12 +872,12 @@ mod tests {
         cleanup_env();
     }
 
-    /// OAuth-excluded endpoints (e.g. GET /api/v2/test-oauth-excluded/some-id) must use API-key
+    /// OAuth-excluded endpoints (e.g. GET /api/unstable/fleet/some-id) must use API-key
     /// auth even when a bearer token is present. This exercises the reuse of
     /// raw_client::apply_auth's per-endpoint fallback table.
     ///
-    /// Uses a test fixture entry (permanently excluded) so this test doesn't
-    /// churn when real endpoints gain OAuth support.
+    /// Uses the unstable Fleet entry (DAL-509, not yet OAuth-capable
+    /// server-side) as the "still excluded" example.
     #[tokio::test]
     async fn test_api_oauth_excluded_uses_api_keys() {
         let _lock = lock_env().await;
@@ -887,7 +887,7 @@ mod tests {
         // must prefer the API keys.
         cfg.access_token = Some("bearer-token".into());
         let _mock = server
-            .mock("GET", "/api/v2/test-oauth-excluded/some-id")
+            .mock("GET", "/api/unstable/fleet/some-id")
             .match_query(mockito::Matcher::Any)
             .match_header("DD-API-KEY", "test-api-key")
             .match_header("DD-APPLICATION-KEY", "test-app-key")
@@ -900,7 +900,7 @@ mod tests {
 
         let result = super::run(
             &cfg,
-            "v2/test-oauth-excluded/some-id",
+            "unstable/fleet/some-id",
             "GET",
             &[],
             &[],
@@ -928,7 +928,7 @@ mod tests {
         let mut cfg = test_config(&server.url());
         cfg.access_token = Some("bearer-token".into());
         let _mock = server
-            .mock("GET", "/api/v2/test-oauth-excluded/some-id")
+            .mock("GET", "/api/unstable/fleet/some-id")
             .match_query(mockito::Matcher::Any)
             .match_header("DD-API-KEY", "test-api-key")
             .match_header("authorization", mockito::Matcher::Missing)
@@ -939,7 +939,7 @@ mod tests {
             .await;
 
         // Pass the fully-qualified URL, not a relative path.
-        let absolute = format!("{}/api/v2/test-oauth-excluded/some-id", server.url());
+        let absolute = format!("{}/api/unstable/fleet/some-id", server.url());
         let result = super::run(
             &cfg,
             &absolute,

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -876,8 +876,7 @@ mod tests {
     /// auth even when a bearer token is present. This exercises the reuse of
     /// raw_client::apply_auth's per-endpoint fallback table.
     ///
-    /// Uses the unstable Fleet entry (DAL-509, not yet OAuth-capable
-    /// server-side) as the "still excluded" example.
+    /// Uses the still-excluded unstable Fleet entry as the example.
     #[tokio::test]
     async fn test_api_oauth_excluded_uses_api_keys() {
         let _lock = lock_env().await;

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -870,13 +870,12 @@ mod tests {
         cleanup_env();
     }
 
-    /// OAuth-excluded endpoints (e.g. GET /profiling/api/v1/profiles/abc/info) must use API-key
+    /// OAuth-excluded endpoints (e.g. GET /api/v2/test-oauth-excluded/some-id) must use API-key
     /// auth even when a bearer token is present. This exercises the reuse of
     /// raw_client::apply_auth's per-endpoint fallback table.
     ///
-    /// Profiling is just today's example of a still-excluded endpoint,
-    /// not a claim it's meant to stay that way -- update this test if/when
-    /// Profiling gets OAuth support too.
+    /// Uses a test fixture entry (permanently excluded) so this test doesn't
+    /// churn when real endpoints gain OAuth support.
     #[tokio::test]
     async fn test_api_oauth_excluded_uses_api_keys() {
         let _lock = lock_env().await;
@@ -886,7 +885,7 @@ mod tests {
         // must prefer the API keys.
         cfg.access_token = Some("bearer-token".into());
         let _mock = server
-            .mock("GET", "/profiling/api/v1/profiles/abc/info")
+            .mock("GET", "/api/v2/test-oauth-excluded/some-id")
             .match_query(mockito::Matcher::Any)
             .match_header("DD-API-KEY", "test-api-key")
             .match_header("DD-APPLICATION-KEY", "test-app-key")
@@ -899,7 +898,7 @@ mod tests {
 
         let result = super::run(
             &cfg,
-            "profiling/api/v1/profiles/abc/info",
+            "v2/test-oauth-excluded/some-id",
             "GET",
             &[],
             &[],
@@ -927,7 +926,7 @@ mod tests {
         let mut cfg = test_config(&server.url());
         cfg.access_token = Some("bearer-token".into());
         let _mock = server
-            .mock("GET", "/profiling/api/v1/profiles/abc/info")
+            .mock("GET", "/api/v2/test-oauth-excluded/some-id")
             .match_query(mockito::Matcher::Any)
             .match_header("DD-API-KEY", "test-api-key")
             .match_header("authorization", mockito::Matcher::Missing)
@@ -938,7 +937,7 @@ mod tests {
             .await;
 
         // Pass the fully-qualified URL, not a relative path.
-        let absolute = format!("{}/profiling/api/v1/profiles/abc/info", server.url());
+        let absolute = format!("{}/api/v2/test-oauth-excluded/some-id", server.url());
         let result = super::run(
             &cfg,
             &absolute,

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -144,10 +144,18 @@ fn find_endpoint_requirement(method: &str, path: &str) -> Option<&'static Endpoi
 /// Endpoints that don't support OAuth.
 /// Trailing "/" means prefix match for ID-parameterized paths.
 static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
-    // Test fixture (1) — not a real API; exists only so tests that need a
-    // "still excluded" example don't churn when real endpoints gain OAuth.
+    // Fleet Automation unstable surface (DAL-509) — real API, currently
+    // doesn't support OAuth server-side. This is a status, not a contract:
+    // it's not expected to stay excluded forever, just not there yet. Used
+    // as the "still excluded" example in tests below because it's more
+    // durable than a v2 fleet path (those already flipped once, see
+    // `test_no_fallback_for_fleet`) -- but if/when DAL-509 ships, delete
+    // this entry (and update the tests that reference it) rather than
+    // patching it forward again. Only affects the raw `pup api` passthrough;
+    // `fleet.rs`'s typed commands go through a separate SDK client untouched
+    // by this table.
     EndpointRequirement {
-        path: "/api/v2/test-oauth-excluded/",
+        path: "/api/unstable/fleet/",
         method: "GET",
     },
     // DDSQL editor tools (3)
@@ -668,10 +676,10 @@ mod tests {
     #[test]
     fn test_prefix_matching_with_id() {
         // Trailing "/" in the pattern should match paths with IDs.
-        // Uses the test fixture entry (permanently excluded) as the example.
+        // Uses the unstable Fleet entry (DAL-509) as the example.
         assert!(requires_api_key_fallback(
             "GET",
-            "/api/v2/test-oauth-excluded/some-id"
+            "/api/unstable/fleet/some-id"
         ));
     }
 
@@ -996,15 +1004,15 @@ mod tests {
 
     #[test]
     fn test_other_oauth_excluded_endpoints_still_require_both_keys() {
-        // Uses the test fixture entry (permanently excluded) so this test
-        // doesn't churn when real endpoints gain OAuth support.
+        // Uses the unstable Fleet entry (DAL-509, see OAUTH_EXCLUDED_ENDPOINTS)
+        // as the "still excluded" example.
         let mut cfg = test_cfg();
         cfg.app_key = None;
-        let req = reqwest::Client::new()
-            .get("https://api.datadoghq.com/api/v2/test-oauth-excluded/some-id");
+        let req =
+            reqwest::Client::new().get("https://api.datadoghq.com/api/unstable/fleet/some-id");
 
-        let err = match apply_auth(req, &cfg, "GET", "/api/v2/test-oauth-excluded/some-id") {
-            Ok(_) => panic!("test fixture should require both keys"),
+        let err = match apply_auth(req, &cfg, "GET", "/api/unstable/fleet/some-id") {
+            Ok(_) => panic!("excluded endpoint should require both keys"),
             Err(err) => err,
         };
         assert!(err.to_string().contains("DD_API_KEY and DD_APP_KEY"));

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -662,10 +662,11 @@ mod tests {
 
     #[test]
     fn test_prefix_matching_with_id() {
-        // Trailing "/" in the pattern should match paths with IDs
+        // Trailing "/" in the pattern should match paths with IDs.
+        // Uses Profiling (still excluded) as the example.
         assert!(requires_api_key_fallback(
             "GET",
-            "/api/v2/fleet/agents/agent-123"
+            "/profiling/api/v1/profiles/abc/info"
         ));
     }
 

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -120,6 +120,12 @@ fn find_endpoint_requirement(method: &str, path: &str) -> Option<&'static Endpoi
 /// Endpoints that don't support OAuth.
 /// Trailing "/" means prefix match for ID-parameterized paths.
 static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
+    // Test fixture (1) — not a real API; exists only so tests that need a
+    // "still excluded" example don't churn when real endpoints gain OAuth.
+    EndpointRequirement {
+        path: "/api/v2/test-oauth-excluded/",
+        method: "GET",
+    },
     // DDSQL editor tools (3)
     EndpointRequirement {
         path: "/api/unstable/ddsql-editor/tools/ddsql-docs",
@@ -663,10 +669,10 @@ mod tests {
     #[test]
     fn test_prefix_matching_with_id() {
         // Trailing "/" in the pattern should match paths with IDs.
-        // Uses Profiling (still excluded) as the example.
+        // Uses the test fixture entry (permanently excluded) as the example.
         assert!(requires_api_key_fallback(
             "GET",
-            "/profiling/api/v1/profiles/abc/info"
+            "/api/v2/test-oauth-excluded/some-id"
         ));
     }
 
@@ -871,18 +877,15 @@ mod tests {
 
     #[test]
     fn test_other_oauth_excluded_endpoints_still_require_both_keys() {
-        // Uses Profiling as a currently-still-excluded example. This is
-        // just today's state of OAUTH_EXCLUDED_ENDPOINTS, not a claim that
-        // Profiling (or anything else in the table) is meant to stay that
-        // way -- update this example if/when its entries get OAuth support
-        // and are removed.
+        // Uses the test fixture entry (permanently excluded) so this test
+        // doesn't churn when real endpoints gain OAuth support.
         let mut cfg = test_cfg();
         cfg.app_key = None;
         let req = reqwest::Client::new()
-            .get("https://api.datadoghq.com/profiling/api/v1/profiles/abc/info");
+            .get("https://api.datadoghq.com/api/v2/test-oauth-excluded/some-id");
 
-        let err = match apply_auth(req, &cfg, "GET", "/profiling/api/v1/profiles/abc/info") {
-            Ok(_) => panic!("Profiling should require both keys"),
+        let err = match apply_auth(req, &cfg, "GET", "/api/v2/test-oauth-excluded/some-id") {
+            Ok(_) => panic!("test fixture should require both keys"),
             Err(err) => err,
         };
         assert!(err.to_string().contains("DD_API_KEY and DD_APP_KEY"));

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -144,16 +144,9 @@ fn find_endpoint_requirement(method: &str, path: &str) -> Option<&'static Endpoi
 /// Endpoints that don't support OAuth.
 /// Trailing "/" means prefix match for ID-parameterized paths.
 static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
-    // Fleet Automation unstable surface (DAL-509) — real API, currently
-    // doesn't support OAuth server-side. This is a status, not a contract:
-    // it's not expected to stay excluded forever, just not there yet. Used
-    // as the "still excluded" example in tests below because it's more
-    // durable than a v2 fleet path (those already flipped once, see
-    // `test_no_fallback_for_fleet`) -- but if/when DAL-509 ships, delete
-    // this entry (and update the tests that reference it) rather than
-    // patching it forward again. Only affects the raw `pup api` passthrough;
-    // `fleet.rs`'s typed commands go through a separate SDK client untouched
-    // by this table.
+    // Fleet Automation unstable surface — doesn't support OAuth server-side
+    // yet. Current status, not a permanent contract; delete this entry (and
+    // the tests referencing it) once it does, rather than patching forward.
     EndpointRequirement {
         path: "/api/unstable/fleet/",
         method: "GET",
@@ -676,7 +669,7 @@ mod tests {
     #[test]
     fn test_prefix_matching_with_id() {
         // Trailing "/" in the pattern should match paths with IDs.
-        // Uses the unstable Fleet entry (DAL-509) as the example.
+        // Uses the still-excluded unstable Fleet entry as the example.
         assert!(requires_api_key_fallback(
             "GET",
             "/api/unstable/fleet/some-id"
@@ -1004,8 +997,7 @@ mod tests {
 
     #[test]
     fn test_other_oauth_excluded_endpoints_still_require_both_keys() {
-        // Uses the unstable Fleet entry (DAL-509, see OAUTH_EXCLUDED_ENDPOINTS)
-        // as the "still excluded" example.
+        // Uses the still-excluded unstable Fleet entry as the example.
         let mut cfg = test_cfg();
         cfg.app_key = None;
         let req =

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -133,162 +133,6 @@ static OAUTH_EXCLUDED_ENDPOINTS: &[EndpointRequirement] = &[
         path: "/api/unstable/ddsql-editor/tools/table-data",
         method: "POST",
     },
-    // Fleet Automation (15)
-    EndpointRequirement {
-        path: "/api/v2/fleet/agents",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/agents/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/agents/versions",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/deployments",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/deployments/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/deployments/configure",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/deployments/upgrade",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/deployments/",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/deployments/",
-        method: "DELETE",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/schedules",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/schedules/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/schedules",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/schedules/",
-        method: "PATCH",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/schedules/",
-        method: "DELETE",
-    },
-    EndpointRequirement {
-        path: "/api/v2/fleet/schedules/",
-        method: "POST",
-    },
-    // Observability Pipelines (6) — API key only, no OAuth support
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/",
-        method: "PUT",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/",
-        method: "DELETE",
-    },
-    EndpointRequirement {
-        path: "/api/v2/obs-pipelines/pipelines/validate",
-        method: "POST",
-    },
-    // Cost / Billing (11) — API key only, no OAuth support
-    EndpointRequirement {
-        path: "/api/v2/usage/projected_cost",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/usage/cost_by_org",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost_by_tag/monthly_cost_attribution",
-        method: "GET",
-    },
-    // Cloud Cost Management config (12)
-    EndpointRequirement {
-        path: "/api/v2/cost/aws_cur_config",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/aws_cur_config",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/aws_cur_config/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/aws_cur_config/",
-        method: "DELETE",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/azure_uc_config",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/azure_uc_config",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/azure_uc_config/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/azure_uc_config/",
-        method: "DELETE",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/gcp_uc_config",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/gcp_uc_config",
-        method: "POST",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/gcp_uc_config/",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/gcp_uc_config/",
-        method: "DELETE",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/oci_config",
-        method: "GET",
-    },
-    EndpointRequirement {
-        path: "/api/v2/cost/anomalies",
-        method: "GET",
-    },
     // Profiling (4)
     // No OAuth scope is declared for Continuous Profiler endpoints; force API-key auth.
     EndpointRequirement {
@@ -835,11 +679,6 @@ mod tests {
     }
 
     #[test]
-    fn test_oauth_excluded_count() {
-        assert_eq!(OAUTH_EXCLUDED_ENDPOINTS.len(), 46);
-    }
-
-    #[test]
     fn test_no_fallback_for_notebooks() {
         assert!(!requires_api_key_fallback("GET", "/api/v1/notebooks"));
         assert!(!requires_api_key_fallback("GET", "/api/v1/notebooks/12345"));
@@ -847,11 +686,26 @@ mod tests {
     }
 
     #[test]
-    fn test_requires_api_key_fallback_fleet() {
-        assert!(requires_api_key_fallback("GET", "/api/v2/fleet/agents"));
-        assert!(requires_api_key_fallback(
+    fn test_no_fallback_for_fleet() {
+        // Fleet Automation v2 routes already accept OAuth server-side;
+        // the raw/generic `pup api` passthrough should use the OAuth bearer
+        // like the typed fleet commands do.
+        assert!(!requires_api_key_fallback("GET", "/api/v2/fleet/agents"));
+        assert!(!requires_api_key_fallback(
             "GET",
             "/api/v2/fleet/agents/agent-123"
+        ));
+        assert!(!requires_api_key_fallback(
+            "GET",
+            "/api/v2/fleet/deployments"
+        ));
+        assert!(!requires_api_key_fallback(
+            "POST",
+            "/api/v2/fleet/deployments/configure"
+        ));
+        assert!(!requires_api_key_fallback(
+            "POST",
+            "/api/v2/fleet/schedules/sched-123/trigger"
         ));
     }
 
@@ -1016,16 +870,18 @@ mod tests {
 
     #[test]
     fn test_other_oauth_excluded_endpoints_still_require_both_keys() {
-        // Uses Fleet Automation as a currently-still-excluded example. This is
-        // just today's state of OAUTH_EXCLUDED_ENDPOINTS, not a claim that Fleet
-        // (or anything else in the table) is meant to stay that way -- update
-        // this example if/when its entries get OAuth support and are removed.
+        // Uses Profiling as a currently-still-excluded example. This is
+        // just today's state of OAUTH_EXCLUDED_ENDPOINTS, not a claim that
+        // Profiling (or anything else in the table) is meant to stay that
+        // way -- update this example if/when its entries get OAuth support
+        // and are removed.
         let mut cfg = test_cfg();
         cfg.app_key = None;
-        let req = reqwest::Client::new().get("https://api.datadoghq.com/api/v2/fleet/agents");
+        let req = reqwest::Client::new()
+            .get("https://api.datadoghq.com/profiling/api/v1/profiles/abc/info");
 
-        let err = match apply_auth(req, &cfg, "GET", "/api/v2/fleet/agents") {
-            Ok(_) => panic!("Fleet Automation should require both keys"),
+        let err = match apply_auth(req, &cfg, "GET", "/profiling/api/v1/profiles/abc/info") {
+            Ok(_) => panic!("Profiling should require both keys"),
             Err(err) => err,
         };
         assert!(err.to_string().contains("DD_API_KEY and DD_APP_KEY"));

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -780,6 +780,62 @@ mod tests {
     }
 
     #[test]
+    fn test_no_fallback_for_cost_billing() {
+        // Cost/Billing routes already accept OAuth server-side (DAL-959); the
+        // raw/generic `pup api` passthrough should use the OAuth bearer
+        // instead of forcing API-key fallback.
+        assert!(!requires_api_key_fallback(
+            "GET",
+            "/api/v2/usage/projected_cost"
+        ));
+        assert!(!requires_api_key_fallback(
+            "GET",
+            "/api/v2/usage/cost_by_org"
+        ));
+        assert!(!requires_api_key_fallback(
+            "GET",
+            "/api/v2/cost_by_tag/monthly_cost_attribution"
+        ));
+    }
+
+    #[test]
+    fn test_no_fallback_for_ccm() {
+        // Cloud Cost Management config routes already accept OAuth
+        // server-side (DAL-959); the raw/generic `pup api` passthrough
+        // should use the OAuth bearer instead of forcing API-key fallback.
+        assert!(!requires_api_key_fallback(
+            "GET",
+            "/api/v2/cost/aws_cur_config"
+        ));
+        assert!(!requires_api_key_fallback(
+            "POST",
+            "/api/v2/cost/aws_cur_config"
+        ));
+        assert!(!requires_api_key_fallback(
+            "DELETE",
+            "/api/v2/cost/aws_cur_config/config-123"
+        ));
+        assert!(!requires_api_key_fallback(
+            "GET",
+            "/api/v2/cost/azure_uc_config"
+        ));
+        assert!(!requires_api_key_fallback(
+            "DELETE",
+            "/api/v2/cost/azure_uc_config/config-123"
+        ));
+        assert!(!requires_api_key_fallback(
+            "GET",
+            "/api/v2/cost/gcp_uc_config"
+        ));
+        assert!(!requires_api_key_fallback(
+            "DELETE",
+            "/api/v2/cost/gcp_uc_config/config-123"
+        ));
+        assert!(!requires_api_key_fallback("GET", "/api/v2/cost/oci_config"));
+        assert!(!requires_api_key_fallback("GET", "/api/v2/cost/anomalies"));
+    }
+
+    #[test]
     fn test_no_fallback_for_api_keys() {
         // /api/v2/api_keys and /api/v2/application_keys already accept OAuth
         // server-side (DAL-514); the raw/generic `pup api` passthrough should


### PR DESCRIPTION
## Summary

Remove 32 stale entries from `OAUTH_EXCLUDED_ENDPOINTS` (`src/raw_client.rs`) whose server-side routes already accept OAuth: Fleet Automation v2 routes (15, since 2026-06-04), Cost/Billing (3, DAL-959), Cloud Cost Management config (14, DAL-959). This table only affects `raw_get`/`raw_post` (`pup api` passthrough and hand-written commands) -- no live pup command uses `raw_get`/`raw_post` for any of these paths today, so this only changes `pup api` passthrough behavior.

Note: this doesn't close pup's fleet OAuth gap. `fleet.rs`'s commands call `/api/unstable/fleet/*`, not the `/api/v2/fleet/*` paths covered here, and that surface still deliberately excludes OAuth (DAL-509, separate issue).

Also removes the brittle `test_oauth_excluded_count` assertion.

## Remaining excluded entries (8)

- DDSQL editor (3) -- handled by #756
- Profiling (4) -- no OAuth support declared server-side (yet)
- Events intake (1) -- DD-API-KEY only by design
