### PR TITLE
feat(service-catalog): add --page-size and --page-number to list

### DIFF
--- a/src/commands/service_catalog.rs
+++ b/src/commands/service_catalog.rs
@@ -6,10 +6,14 @@ use datadog_api_client::datadogV2::api_service_definition::{
 use crate::config::Config;
 use crate::formatter;
 
-pub async fn list(cfg: &Config) -> Result<()> {
+pub async fn list(cfg: &Config, page_size: i64, page_number: i64) -> Result<()> {
     let api = crate::make_api!(ServiceDefinitionAPI, cfg);
     let resp = api
-        .list_service_definitions(ListServiceDefinitionsOptionalParams::default())
+        .list_service_definitions(
+            ListServiceDefinitionsOptionalParams::default()
+                .page_size(page_size)
+                .page_number(page_number),
+        )
         .await
         .map_err(|e| anyhow::anyhow!("failed to list services: {e:?}"))?;
     formatter::output(cfg, &resp)
@@ -38,7 +42,17 @@ mod tests {
         let mut s = mockito::Server::new_async().await;
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
-        let _ = super::list(&cfg).await;
+        let _ = super::list(&cfg, 10, 0).await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_service_catalog_list_with_pagination() {
+        let _lock = lock_env().await;
+        let mut s = mockito::Server::new_async().await;
+        let cfg = test_config(&s.url());
+        mock_all(&mut s, r#"{"data": []}"#).await;
+        let _ = super::list(&cfg, 50, 2).await;
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6212,7 +6212,12 @@ enum CaseNotificationRuleActions {
 #[derive(Subcommand)]
 enum ServiceCatalogActions {
     /// List services
-    List,
+    List {
+        #[arg(long, default_value_t = 10, help = "Results per page (max 100)")]
+        page_size: i64,
+        #[arg(long, default_value_t = 0, help = "Page number (0-indexed)")]
+        page_number: i64,
+    },
     /// Get service details
     Get { service_name: String },
 }
@@ -14682,7 +14687,10 @@ async fn main_inner() -> anyhow::Result<()> {
         Commands::ServiceCatalog { action } => {
             cfg.validate_auth()?;
             match action {
-                ServiceCatalogActions::List => commands::service_catalog::list(&cfg).await?,
+                ServiceCatalogActions::List {
+                    page_size,
+                    page_number,
+                } => commands::service_catalog::list(&cfg, page_size, page_number).await?,
                 ServiceCatalogActions::Get { service_name } => {
                     commands::service_catalog::get(&cfg, &service_name).await?;
                 }


### PR DESCRIPTION
## Summary
`service-catalog list` was the one list command with no pagination controls — the underlying `ListServiceDefinitionsOptionalParams` (datadog-api-client-rust) already supports `page_size`/`page_number`, they just weren't wired up. This adds them, following the same per-command pattern used in #449 (users list) and #663 (security rules list).

## Changes
- `src/main.rs` — `ServiceCatalogActions::List` gains `--page-size` (default 10) and `--page-number` (default 0)
- `src/commands/service_catalog.rs` — `list()` now takes `page_size`/`page_number` and passes them to `ListServiceDefinitionsOptionalParams`

## Testing
- `cargo test service_catalog` — 3/3 pass (existing test updated with default args, new test covers non-default page size/number)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean

## A note on pagination architecture, for what it's worth

While digging into this we found `origin/janis.kirsteins/pagination`, an unmerged branch (`4607e03` + `2561c7b`, 2026-03-31) implementing pagination as a *unified* mechanism — a shared `PaginationInfo`/`extract_pagination()` in `formatter.rs` normalizing cursor/offset/page-number styles across ~22 commands in one pass, with `docs/PAGINATION.md` documenting the result. It has no PR history (never opened, best we can tell), and is now 1000+ commits stale.

In the roughly five months since, pagination has instead landed via five separate PRs (#449, #458, #663, #732, #761), each adding flags to one command at a time — this PR continues that pattern rather than reviving the unified branch, since that seemed like the pragmatic call at this point.

Just flagging it in case it's useful signal: the unified approach looks like the right shape for this problem in general (one envelope format instead of five-plus bespoke wire-ups, agent-mode pagination metadata for free), and if there's appetite to revisit it, doing so sooner rather than after more piecemeal PRs land would mean less to reconcile. No opinion asserted on priority — just surfacing what we found.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)