### PR TITLE
feat(idp): add entity graph discovery and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,19 @@ pup incidents list
 pup incidents get abc-123-def
 ```
 
+### IDP Entity Graph
+
+```bash
+# Discover available entity kinds and their query schema
+pup idp kinds list
+pup idp kinds describe service
+
+# Query services and walk ownership and system relations
+pup idp entities query 'kind:service AND owner:payments' \
+  --field name,owner,contacts \
+  --include owner_teams,systems
+```
+
 ## Global Flags
 
 - `-o, --output`: Output format (json, table, yaml) - default: json

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -53,7 +53,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | security | rules, signals, findings, content-packs, risk-scores | src/commands/security.rs | ✅ |
 | organizations | get, list | src/commands/organizations.rs | ✅ |
 | service-catalog | list, get | src/commands/service_catalog.rs | ✅ |
-| idp | assist, find, owner, deps, register | src/commands/idp.rs | ✅ |
+| idp | kinds (list, describe), entities (query), assist, find, owner, deps, register, migrate-schema | src/commands/idp/ | ✅ |
 | error-tracking | issues (search, get) | src/commands/error_tracking.rs | ✅ |
 | scorecards | rules (list, create, update, delete), outcomes (list, batch-create) | src/commands/scorecards.rs | ✅ |
 | usage | summary, hourly | src/commands/usage.rs | ✅ |
@@ -122,6 +122,34 @@ pup metrics tags list system.cpu.user --window-seconds=3600
 pup metrics timeseries --file=request.json
 pup events search --query="@user.id:12345"
 ```
+
+### IDP Entity Graph
+
+Use kind discovery before writing flexible cross-entity queries:
+
+```bash
+# Curated kind index; add --all for the filtered live server inventory.
+pup idp kinds list
+pup idp kinds list --all --include-custom
+
+# Live fields, relations, operators, examples, and caveats for one kind.
+pup idp kinds describe service
+
+# Query one result kind and optionally expand relations.
+pup idp entities query 'kind:service AND owner:payments' \
+  --field name,owner,contacts,service_health_status \
+  --include owner_teams,systems
+
+# Continue an explicitly paginated query.
+pup idp entities query 'kind:service' --cursor '<next_cursor>'
+```
+
+Every query must contain one unquoted `kind:<kind>` filter or a concrete
+`ref:"ref:<kind>:<id>"`. Top-level `OR` across result kinds is rejected; group
+alternatives below a shared kind instead, for example
+`kind:service AND (owner:idp OR team:idp)`. `--field` selects attributes and
+`--include` expands relations. Output is normalized and bounded for agents by
+default; pass `--raw` for the original JSON:API response.
 
 ### Create/Update/Delete
 ```bash

--- a/docs/OAUTH2.md
+++ b/docs/OAUTH2.md
@@ -225,6 +225,11 @@ commands. The list below is illustrative — see
 ### APM/Traces
 - `apm_read` - Read APM data and traces
 
+### IDP Entity Graph
+- `repo_info_read` - Read repository context connected to entities
+- `code_analysis_read` - Read code analysis context connected to entities
+- `appsec_vm_read` - Read application-security vulnerability context connected to entities
+
 ### SLOs
 - `slos_read` - Read SLOs
 - `slos_write` - Create/update SLOs

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -47,6 +47,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "apm_remote_configuration_read",
         "apm_service_catalog_read",
         "apm_service_ingest_read",
+        "appsec_vm_read",
         "apps_run",
         "audit_logs_read",
         "aws_configuration_read",
@@ -55,6 +56,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "cases_read",
         "ci_visibility_read",
         "cloud_cost_management_read",
+        "code_analysis_read",
         "code_coverage_read",
         "connections_read",
         "dora_metrics_read",
@@ -86,6 +88,7 @@ pub fn read_only_scopes() -> Vec<&'static str> {
         "oci_configuration_read",
         "on_call_read",
         "reference_tables_read",
+        "repo_info_read",
         "rum_apps_read",
         "rum_retention_filters_read",
         "rum_session_replay_read",
@@ -119,6 +122,8 @@ pub fn default_scopes() -> Vec<&'static str> {
         "apm_service_ingest_read",
         "apm_service_ingest_write",
         "apm_service_renaming_write",
+        // Entity graph security context
+        "appsec_vm_read",
         // App Builder
         "apps_run",
         "apps_write",
@@ -138,6 +143,7 @@ pub fn default_scopes() -> Vec<&'static str> {
         "cases_write",
         // CI Visibility
         "ci_visibility_read",
+        "code_analysis_read",
         "code_coverage_read",
         // Cloud Cost Management
         "ccm_budget_write",
@@ -230,6 +236,8 @@ pub fn default_scopes() -> Vec<&'static str> {
         // Reference Tables
         "reference_tables_read",
         "reference_tables_write",
+        // Entity graph repository context
+        "repo_info_read",
         // RUM
         // RUM
         "rum_apps_read",
@@ -340,6 +348,10 @@ mod tests {
         assert!(scopes.contains(&"on_call_write"));
         assert!(scopes.contains(&"aws_configuration_read"));
         assert!(scopes.contains(&"gcp_configuration_read"));
+        // Entity graph
+        assert!(scopes.contains(&"repo_info_read"));
+        assert!(scopes.contains(&"code_analysis_read"));
+        assert!(scopes.contains(&"appsec_vm_read"));
         // Workflows
         assert!(scopes.contains(&"workflows_read"));
         assert!(scopes.contains(&"workflows_run"));
@@ -426,6 +438,9 @@ mod tests {
         assert!(!ro.contains(&"telemetry_rules_create"));
         assert!(ro.contains(&"security_monitoring_cws_agent_rules_read"));
         assert!(ro.contains(&"telemetry_rules_read"));
+        assert!(ro.contains(&"repo_info_read"));
+        assert!(ro.contains(&"code_analysis_read"));
+        assert!(ro.contains(&"appsec_vm_read"));
         // connections_read is a ReadOnly-tier permission; connections_write
         // is intentionally opt-in (see --extra-scopes) and must not appear.
         assert!(ro.contains(&"connections_read"));

--- a/src/commands/idp/entity_kinds.rs
+++ b/src/commands/idp/entity_kinds.rs
@@ -1,0 +1,1163 @@
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+
+use super::entity_query::default_fields_for_kind;
+use super::entity_types::{
+    KindAttribute, KindListResponse, KindRelation, KindResource, KindResponse,
+};
+use crate::config::Config;
+use crate::formatter::{self, Metadata};
+use crate::raw_client;
+use crate::util_ext;
+
+const KINDS_PATH: &str = "/api/v2/idp/entity_graph/kinds";
+
+#[derive(Debug, Clone, Serialize)]
+struct CuratedKindsResponse {
+    categories: Vec<KindCategory>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    custom_kinds: Vec<KindSummary>,
+    hints: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct KindCategory {
+    name: String,
+    description: String,
+    kinds: Vec<KindSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct KindSummary {
+    kind: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    display_name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    why_use: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    top_fields: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    top_relations: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AllKindsResponse {
+    kinds: Vec<KindSummary>,
+    count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct DescribeKindResponse {
+    kind: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    display_name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    description: String,
+    kind_exists: bool,
+    schema_available: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    default_fields: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attributes: Vec<AttributeSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    relations: Vec<RelationSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    examples: Vec<QueryExample>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    hints: Vec<String>,
+    caveats: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AttributeSummary {
+    name: String,
+    data_type: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    operators: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    calculation: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RelationSummary {
+    name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    target_kind: String,
+}
+
+#[derive(Debug, Serialize)]
+struct QueryExample {
+    question: String,
+    query: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    fields: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    include: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeseries_interval: Option<String>,
+}
+
+pub async fn list_kinds(
+    cfg: &Config,
+    all: bool,
+    include_custom: bool,
+    include_low_level: bool,
+    exclude_experimental: bool,
+) -> Result<()> {
+    let include_experimental = !exclude_experimental;
+    if all || include_custom {
+        cfg.validate_auth()?;
+        let live = fetch_kinds(cfg).await?;
+        if all {
+            let response = build_all_kinds_response(
+                live,
+                include_custom,
+                include_low_level,
+                include_experimental,
+            );
+            let metadata = kind_metadata(response.count);
+            return formatter::format_and_print(
+                &response,
+                &cfg.output_format,
+                cfg.agent_mode,
+                Some(&metadata),
+                cfg.jq.as_deref(),
+            );
+        }
+        let mut response = curated_kinds(include_low_level, include_experimental);
+        response.custom_kinds = custom_kind_summaries(&live);
+        let metadata = kind_metadata(curated_count(&response));
+        return formatter::format_and_print(
+            &response,
+            &cfg.output_format,
+            cfg.agent_mode,
+            Some(&metadata),
+            cfg.jq.as_deref(),
+        );
+    }
+
+    let response = curated_kinds(include_low_level, include_experimental);
+    let metadata = kind_metadata(curated_count(&response));
+    formatter::format_and_print(
+        &response,
+        &cfg.output_format,
+        cfg.agent_mode,
+        Some(&metadata),
+        cfg.jq.as_deref(),
+    )
+}
+
+pub async fn describe_kind(cfg: &Config, kind: &str, no_examples: bool) -> Result<()> {
+    let kind = kind.trim();
+    validate_kind_name(kind)?;
+    cfg.validate_auth()?;
+
+    let response = match fetch_kind(cfg, kind).await {
+        Ok(schema) => describe_response(schema, !no_examples),
+        Err(detail_error) if http_status(&detail_error) == Some(404) => {
+            match fetch_kind_from_list(cfg, kind).await {
+                Ok(schema) => {
+                    let mut response = describe_response(schema, !no_examples);
+                    response.warnings.push(format!(
+                        "The kind detail endpoint returned 404 for {kind:?}; schema was loaded from the kind list instead."
+                    ));
+                    response
+                }
+                Err(_) => {
+                    if let Some(summary) = curated_kind_summary(kind) {
+                        describe_fallback_response(summary, !no_examples, &detail_error)
+                    } else {
+                        bail!(
+                            "failed to describe entity kind {kind:?}: {detail_error}{}",
+                            unknown_kind_suggestion(kind)
+                        );
+                    }
+                }
+            }
+        }
+        Err(error) => bail!(
+            "failed to describe entity kind {kind:?}: {error}{}",
+            unknown_kind_suggestion(kind)
+        ),
+    };
+
+    formatter::format_and_print(
+        &response,
+        &cfg.output_format,
+        cfg.agent_mode,
+        Some(&Metadata {
+            count: Some(response.attributes.len() + response.relations.len()),
+            truncated: false,
+            command: Some("pup idp kinds describe".into()),
+            next_action: Some(format!(
+                "Query this kind with: pup idp entities query 'kind:{kind}'"
+            )),
+        }),
+        cfg.jq.as_deref(),
+    )
+}
+
+fn kind_metadata(count: usize) -> Metadata {
+    Metadata {
+        count: Some(count),
+        truncated: false,
+        command: Some("pup idp kinds list".into()),
+        next_action: Some("Inspect a kind with: pup idp kinds describe <kind>".into()),
+    }
+}
+
+pub(super) async fn fetch_kind(cfg: &Config, kind: &str) -> Result<KindResource> {
+    validate_kind_name(kind)?;
+    let path = format!("{KINDS_PATH}/{}", util_ext::percent_encode(kind));
+    let value = raw_client::raw_get(cfg, &path, &[]).await?;
+    let response: KindResponse =
+        serde_json::from_value(value).context("failed to decode entity kind schema")?;
+    Ok(response.data)
+}
+
+async fn fetch_kinds(cfg: &Config) -> Result<Vec<KindResource>> {
+    let value = raw_client::raw_get(cfg, KINDS_PATH, &[])
+        .await
+        .context("failed to list Datadog entity kinds")?;
+    let response: KindListResponse =
+        serde_json::from_value(value).context("failed to decode entity kind list")?;
+    Ok(response.data)
+}
+
+async fn fetch_kind_from_list(cfg: &Config, kind: &str) -> Result<KindResource> {
+    fetch_kinds(cfg)
+        .await?
+        .into_iter()
+        .find(|candidate| candidate.kind() == kind)
+        .ok_or_else(|| anyhow::anyhow!("kind {kind:?} was not found in the kind list"))
+}
+
+fn validate_kind_name(kind: &str) -> Result<()> {
+    if kind.is_empty() {
+        bail!("kind is required");
+    }
+    if !kind
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    {
+        bail!("invalid kind {kind:?}: use only letters, numbers, dots, underscores, and hyphens");
+    }
+    Ok(())
+}
+
+fn http_status(error: &anyhow::Error) -> Option<u16> {
+    error
+        .downcast_ref::<raw_client::HttpError>()
+        .map(|error| error.status)
+}
+
+pub(super) fn validate_includes_against_kind(
+    kind: &str,
+    includes: &[String],
+    schema: &KindResource,
+) -> Result<()> {
+    for include in includes {
+        if schema.attributes.relations.contains_key(include) {
+            continue;
+        }
+        if schema.attributes.attribute_types.contains_key(include) {
+            bail!(
+                "invalid --include {include:?} for kind {kind:?}: {include:?} is an attribute, not a relation.{}",
+                include_attribute_suggestion(kind, include)
+            );
+        }
+        bail!(
+            "invalid --include {include:?} for kind {kind:?}: --include only accepts relation names.{}",
+            valid_relation_suggestion(&schema.attributes.relations)
+        );
+    }
+    Ok(())
+}
+
+fn include_attribute_suggestion(kind: &str, include: &str) -> String {
+    if kind == "service" {
+        return match include {
+            "owner" => " Use --field owner to return the owner attribute, or --include owner_teams to expand owner team entities.".into(),
+            "contacts" => " Use --field contacts to return service contacts; contacts is not expandable with --include.".into(),
+            "links" => " Use --field links to return service links; links is not expandable with --include.".into(),
+            "additional_owners" => " Use --field additional_owners to return additional owners; additional_owners is not expandable with --include.".into(),
+            _ => format!(" Use --field {include} to return the attribute."),
+        };
+    }
+    format!(" Use --field {include} to return the attribute.")
+}
+
+fn valid_relation_suggestion(relations: &BTreeMap<String, KindRelation>) -> String {
+    if relations.is_empty() {
+        return " This kind has no described relations. Run pup idp kinds describe <kind> to inspect its fields and relations.".into();
+    }
+    let names = relations.keys().take(6).cloned().collect::<Vec<_>>();
+    format!(
+        " Valid relations include: {}. Run pup idp kinds describe <kind> for the full schema.",
+        names.join(", ")
+    )
+}
+
+fn build_all_kinds_response(
+    kinds: Vec<KindResource>,
+    include_custom: bool,
+    include_low_level: bool,
+    include_experimental: bool,
+) -> AllKindsResponse {
+    let mut summaries = kinds
+        .iter()
+        .filter(|kind| include_custom || !kind.kind().starts_with("idp_custom_entities."))
+        .filter(|kind| include_low_level || !is_low_level_kind(kind.kind()))
+        .filter(|kind| include_experimental || !is_experimental_kind(kind.kind()))
+        .map(live_kind_summary)
+        .collect::<Vec<_>>();
+    summaries.sort_by(|left, right| left.kind.cmp(&right.kind));
+    AllKindsResponse {
+        count: summaries.len(),
+        kinds: summaries,
+    }
+}
+
+fn custom_kind_summaries(kinds: &[KindResource]) -> Vec<KindSummary> {
+    let mut summaries = kinds
+        .iter()
+        .filter(|kind| kind.kind().starts_with("idp_custom_entities."))
+        .map(|kind| live_kind_summary_with_limits(kind, 8, 5))
+        .collect::<Vec<_>>();
+    summaries.sort_by(|left, right| left.kind.cmp(&right.kind));
+    summaries
+}
+
+fn live_kind_summary(kind: &KindResource) -> KindSummary {
+    live_kind_summary_with_limits(kind, 12, 8)
+}
+
+fn live_kind_summary_with_limits(
+    kind: &KindResource,
+    field_limit: usize,
+    relation_limit: usize,
+) -> KindSummary {
+    KindSummary {
+        kind: kind.kind().to_string(),
+        display_name: kind.attributes.display_name.clone(),
+        why_use: String::new(),
+        top_fields: kind
+            .attributes
+            .attribute_types
+            .keys()
+            .take(field_limit)
+            .cloned()
+            .collect(),
+        top_relations: kind
+            .attributes
+            .relations
+            .keys()
+            .take(relation_limit)
+            .cloned()
+            .collect(),
+    }
+}
+
+fn describe_response(schema: KindResource, include_examples: bool) -> DescribeKindResponse {
+    let kind = schema.kind().to_string();
+    let default_fields = default_fields_for_kind(&kind)
+        .iter()
+        .filter(|field| schema.attributes.attribute_types.contains_key(**field))
+        .map(|field| (*field).to_string())
+        .collect();
+    let attributes = summarize_attributes(&schema.attributes.attribute_types);
+    let relations = summarize_relations(&schema.attributes.relations);
+    let examples = if include_examples {
+        examples_for_kind(
+            &kind,
+            &schema.attributes.attribute_types,
+            &schema.attributes.relations,
+        )
+    } else {
+        Vec::new()
+    };
+    DescribeKindResponse {
+        kind: kind.clone(),
+        display_name: schema.attributes.display_name,
+        description: String::new(),
+        kind_exists: true,
+        schema_available: true,
+        default_fields,
+        attributes,
+        relations,
+        examples,
+        hints: hints_for_kind(&kind),
+        caveats: common_caveats(),
+        warnings: Vec::new(),
+    }
+}
+
+fn describe_fallback_response(
+    summary: KindSummary,
+    include_examples: bool,
+    cause: &anyhow::Error,
+) -> DescribeKindResponse {
+    let examples = if include_examples {
+        examples_for_kind(&summary.kind, &BTreeMap::new(), &BTreeMap::new())
+    } else {
+        Vec::new()
+    };
+    let relations = summary
+        .top_relations
+        .iter()
+        .map(|name| RelationSummary {
+            name: name.clone(),
+            target_kind: String::new(),
+        })
+        .collect();
+    let mut hints = hints_for_kind(&summary.kind);
+    hints.push(
+        "Live schema is unavailable for this curated kind. A query may still work with the curated fields, relations, and examples shown here."
+            .into(),
+    );
+    DescribeKindResponse {
+        kind: summary.kind.clone(),
+        display_name: summary.display_name,
+        description: summary.why_use,
+        kind_exists: true,
+        schema_available: false,
+        default_fields: summary.top_fields,
+        attributes: Vec::new(),
+        relations,
+        examples,
+        hints,
+        caveats: common_caveats(),
+        warnings: vec![format!(
+            "Live schema detail was unavailable for {:?} ({cause}). This does not mean the kind is invalid.",
+            summary.kind
+        )],
+    }
+}
+
+fn summarize_attributes(attributes: &BTreeMap<String, KindAttribute>) -> Vec<AttributeSummary> {
+    attributes
+        .iter()
+        .map(|(name, attribute)| AttributeSummary {
+            name: name.clone(),
+            data_type: attribute.data_type.clone(),
+            operators: operators_for_data_type(&attribute.data_type),
+            calculation: attribute
+                .calculation
+                .as_ref()
+                .map(|calculation| calculation.calculation_type.clone())
+                .filter(|calculation| !calculation.is_empty()),
+        })
+        .collect()
+}
+
+fn summarize_relations(relations: &BTreeMap<String, KindRelation>) -> Vec<RelationSummary> {
+    relations
+        .iter()
+        .map(|(name, relation)| RelationSummary {
+            name: name.clone(),
+            target_kind: relation.target_kind.clone(),
+        })
+        .collect()
+}
+
+fn operators_for_data_type(data_type: &str) -> Vec<String> {
+    let normalized = data_type.to_ascii_lowercase();
+    let operators: &[&str] = if normalized == "map" || normalized.starts_with("map<") {
+        &[]
+    } else if matches!(normalized.as_str(), "string" | "uuid") {
+        &["eq", "exists", "missing", "prefix", "wildcard"]
+    } else if normalized.starts_with("list<string>") {
+        &["eq", "exists", "missing", "wildcard"]
+    } else if normalized.starts_with("list") {
+        &["eq", "exists", "missing"]
+    } else if matches!(normalized.as_str(), "int" | "double" | "float" | "decimal") {
+        &["eq", "gt", "gte", "lt", "lte", "range", "exists", "missing"]
+    } else if matches!(normalized.as_str(), "bool" | "boolean")
+        || normalized.contains("timestamp")
+        || matches!(normalized.as_str(), "date" | "time")
+    {
+        &["eq", "exists", "missing"]
+    } else {
+        &["exists", "missing"]
+    };
+    operators
+        .iter()
+        .map(|operator| (*operator).into())
+        .collect()
+}
+
+fn common_caveats() -> Vec<String> {
+    vec![
+        "Use returned field and relation names exactly. Quoted kind filters like kind:\"service\" are invalid; use kind:service."
+            .into(),
+    ]
+}
+
+fn hints_for_kind(kind: &str) -> Vec<String> {
+    let hints: &[&str] = match kind {
+        "service" => &[
+            "Use service for ownership metadata, contacts, links, descriptions, health, incidents, monitors, SLOs, scorecards, and related operational context.",
+            "For Slack/contact/channel questions, request service fields such as contacts, links, owner, team, and additional_owners.",
+        ],
+        "team" => &[
+            "Use team for membership, hierarchy, and ownership identity.",
+            "Contact metadata for what a team owns usually lives on service entities. Query services owned by the team and request contacts, links, owner, team, and additional_owners.",
+        ],
+        "ai_skill" => &["Use ai_skill for agent skill inventory and source lookup. Repository/source fields connect skills back to code."],
+        "scorecard_outcome" => &["scorecard_outcome is deprecated in the entity graph. Prefer service aggregate fields such as highest_completed_scorecard_level."],
+        "scorecard_rule" | "scorecard_entity" => &["Do not expand the deprecated scorecard_outcomes relation. Prefer service aggregate fields for high-level scorecard reports."],
+        "integration.github.pull_request" => &["When filtering by pull request number, also scope by repository.full_name to avoid repository fanout limits."],
+        "source_code_vulnerability_secfinding" => &["service_name is useful when populated, but many rows may not be service-attributed. Treat repository-scoped monorepo results as broad fan-in, not exact service ownership."],
+        "integration.k8s.deployment" => &["Always scope deployment queries by team or service. Unscoped fleet-wide queries can return very large result sets."],
+        "recommended_system" => &["Use recommended_system for system-grouping recommendations."],
+        _ => &[],
+    };
+    hints.iter().map(|hint| (*hint).into()).collect()
+}
+
+fn examples_for_kind(
+    kind: &str,
+    attributes: &BTreeMap<String, KindAttribute>,
+    relations: &BTreeMap<String, KindRelation>,
+) -> Vec<QueryExample> {
+    match kind {
+        "service" => vec![
+            example(
+                "Pre-change service brief",
+                "kind:service AND name:catalog-http",
+                &[
+                    "name",
+                    "display_name",
+                    "owner",
+                    "team",
+                    "contacts",
+                    "links",
+                    "service_health_status",
+                    "highest_completed_scorecard_level",
+                ],
+                &["systems", "code_locations", "current_oncalls"],
+                Some("1h"),
+            ),
+            example(
+                "Services owned by a team with active incidents",
+                "kind:service AND owner:\"team-x\" AND active_incidents_count:>0",
+                &["name", "display_name", "owner", "active_incidents_count"],
+                &["owner_teams"],
+                Some("1h"),
+            ),
+            example(
+                "Services missing an owner",
+                "kind:service AND _missing_:owner",
+                &["name", "display_name", "owner"],
+                &[],
+                None,
+            ),
+        ],
+        "team" => vec![example(
+            "Team membership and hierarchy",
+            "kind:team AND name:idp",
+            &["name", "handle", "description", "user_count"],
+            &["users", "parent_teams", "child_teams"],
+            None,
+        )],
+        "system" => vec![example(
+            "System member services",
+            "kind:system AND name:service-catalog",
+            &["name", "display_name", "owner"],
+            &["services"],
+            None,
+        )],
+        "ai_skill" => vec![example(
+            "AI skills from a repository",
+            "kind:ai_skill AND source_repo:dd-source",
+            &[
+                "name",
+                "description",
+                "owner",
+                "team",
+                "source_repo",
+                "source_path",
+                "source_url",
+            ],
+            &["repository"],
+            None,
+        )],
+        "incident" => vec![example(
+            "Active incidents on a service",
+            "kind:incident AND service_names:catalog-http AND state:active",
+            &[
+                "public_id",
+                "title",
+                "state",
+                "severity",
+                "service_names",
+                "teams",
+            ],
+            &[],
+            Some("24h"),
+        )],
+        "integration.github.pull_request" => vec![example(
+            "Open pull requests by author",
+            "kind:integration.github.pull_request AND author.login:octocat AND state:open",
+            &[
+                "title",
+                "state",
+                "updated_at",
+                "mergeable",
+                "changed_files",
+                "html_url",
+            ],
+            &["repository", "author"],
+            None,
+        )],
+        "integration.jira.issue" => vec![example(
+            "Jira issue by key",
+            "kind:integration.jira.issue AND key:\"SER-2180\"",
+            &[
+                "key",
+                "summary",
+                "status",
+                "status_category",
+                "priority",
+                "assignee_name",
+                "html_url",
+            ],
+            &[],
+            None,
+        )],
+        "api_endpoint" => vec![example(
+            "Public API endpoints owned by a team",
+            "kind:api_endpoint AND service.owner:idp AND endpoint_is_public:true",
+            &[
+                "resource_name",
+                "http_method",
+                "http_route",
+                "endpoint_is_public",
+                "endpoint_authenticated",
+                "endpoint_is_rate_limited",
+                "service_name",
+                "team_names",
+            ],
+            &["service", "teams"],
+            None,
+        )],
+        "secret" | "iac_misconfiguration" => vec![example(
+            "Findings by repository",
+            &format!("kind:{kind} AND repository_id:\"github.com/datadog/dd-source\""),
+            &["severity", "repository_id"],
+            &[],
+            None,
+        )],
+        "integration.k8s.deployment" => vec![example(
+            "Kubernetes deployments by team",
+            "kind:integration.k8s.deployment AND team:idp",
+            &[
+                "name",
+                "team",
+                "service",
+                "cluster_name",
+                "namespace",
+                "available_replicas",
+                "ready_replicas",
+                "replicas_desired",
+                "unavailable_replicas",
+                "status",
+                "html_url",
+            ],
+            &[],
+            None,
+        )],
+        _ => generic_examples(kind, attributes, relations),
+    }
+}
+
+fn generic_examples(
+    kind: &str,
+    attributes: &BTreeMap<String, KindAttribute>,
+    relations: &BTreeMap<String, KindRelation>,
+) -> Vec<QueryExample> {
+    let fields = default_fields_for_kind(kind)
+        .iter()
+        .filter(|field| attributes.is_empty() || attributes.contains_key(**field))
+        .copied()
+        .collect::<Vec<_>>();
+    let mut examples = vec![example(
+        "List this kind",
+        &format!("kind:{kind}"),
+        &fields,
+        &[],
+        None,
+    )];
+    if attributes.contains_key("name") {
+        examples.push(example(
+            "Find by name substring",
+            &format!("kind:{kind} AND name:*example*"),
+            &["name"],
+            &[],
+            None,
+        ));
+    }
+    if let Some(relation) = relations.keys().next() {
+        examples.push(example(
+            "Filter through a relation",
+            &format!("kind:{kind} AND {relation}.name:*example*"),
+            &[],
+            &[],
+            None,
+        ));
+    }
+    examples
+}
+
+fn example(
+    question: &str,
+    query: &str,
+    fields: &[&str],
+    include: &[&str],
+    timeseries_interval: Option<&str>,
+) -> QueryExample {
+    QueryExample {
+        question: question.into(),
+        query: query.into(),
+        fields: strings(fields),
+        include: strings(include),
+        timeseries_interval: timeseries_interval.map(str::to_string),
+    }
+}
+
+fn curated_kinds(include_low_level: bool, include_experimental: bool) -> CuratedKindsResponse {
+    let mut categories = base_categories();
+    if include_experimental {
+        categories.extend(experimental_categories());
+    }
+    if include_low_level {
+        categories.push(category(
+            "infrastructure_low_level",
+            "Runtime infrastructure kinds. Useful for blast radius but noisy for default discovery.",
+            vec![
+                summary("deployment", "Deployment", "", &["name", "cluster_name", "namespace"], &["namespaces"]),
+                summary("host", "Host", "", &["hostname", "service", "team"], &["services"]),
+                summary("pod", "Pod", "", &["name", "service", "namespace"], &["services", "namespace"]),
+                summary("container", "Container", "", &["name", "service"], &["services"]),
+                summary("namespace", "Namespace", "", &["name"], &["services", "pods"]),
+                summary("cluster", "Cluster", "", &["cluster_name", "cluster_id", "node_count"], &[]),
+                summary("environment", "Environment", "", &["name"], &[]),
+            ],
+        ));
+    }
+    CuratedKindsResponse {
+        categories,
+        custom_kinds: Vec::new(),
+        hints: vec![
+            "For contact or channel questions about a team, query the team's owned services and request service fields such as contacts, links, owner, team, and additional_owners.".into(),
+            "The integration.github.* and github.* families overlap; prefer integration.github.* for repository and work-mirror data. Use native github.* when check/status graph details are specifically needed.".into(),
+        ],
+    }
+}
+
+fn base_categories() -> Vec<KindCategory> {
+    vec![
+        category(
+            "core",
+            "Primary entity graph anchors agents should usually start with.",
+            vec![
+                summary("service", "Service", "Core software/service entity with ownership, contacts, links, health, scorecard, dependency, vulnerability, and operational aggregates.", &["name", "display_name", "owner", "team", "tier", "lifecycle", "contacts", "links", "service_health_status"], &["owner_teams", "current_oncalls", "systems", "incidents", "slos", "monitors"]),
+                summary("team", "Team", "Ownership and accountability anchor for services, systems, users, and work.", &["name", "handle", "description", "user_count"], &["owned_services", "users", "parent_teams", "child_teams"]),
+                summary("user", "User", "People graph node for ownership, review, assignment, and identity workflows.", &["name", "email", "handle", "title"], &["teams"]),
+                summary("system", "System", "Groups services and code locations into a product or system boundary.", &["name", "display_name", "owner"], &["services", "code_locations", "current_oncalls"]),
+                summary("repository", "Repository", "Connects source ownership and catalog entities to code.", &["name", "display_name", "owner", "definition_github_url"], &["systems", "current_oncalls"]),
+                summary("code_location", "Code Location", "Bridge between services or systems and concrete source locations.", &["name", "repository_id", "path_pattern", "source"], &["repository", "services", "systems"]),
+            ],
+        ),
+        category(
+            "operations",
+            "Health, incident, SLO, monitor, and on-call context.",
+            vec![
+                summary("incident", "Incident", "Incident state connected to services and teams.", &["public_id", "title", "state", "severity", "service_names", "teams"], &["services"]),
+                summary("monitor", "Monitor", "Alerting state connected to service tags and monitor metadata.", &["name", "status", "monitor_id", "service_tags"], &[]),
+                summary("slo", "SLO", "Reliability objectives connected to services and teams.", &["name", "state", "target_threshold", "sli"], &["services", "teams"]),
+                summary("current_oncall", "Current On-Call", "Current on-call records keyed by provider service id.", &["current_oncall_id", "oncall_service_id", "provider", "user_name", "user_email"], &[]),
+                summary("pagerduty_incident", "PagerDuty Incident", "PagerDuty incident state routed through service ownership.", &["title", "status", "pagerduty_incident_id"], &["services"]),
+                summary("opsgenie_incident", "Opsgenie Incident", "Opsgenie incident state routed through service ownership.", &["title", "status"], &["services"]),
+            ],
+        ),
+        category(
+            "scorecards_governance",
+            "Software Catalog opinion and governance layer.",
+            vec![
+                summary("scorecard_outcome", "Scorecard Outcome", "Deprecated entity kind. Prefer service scorecard aggregate fields such as highest_completed_scorecard_level.", &["entity_reference", "entity_kind", "entity_owner", "rule_name", "state", "level"], &["scorecard_rule", "scorecard_entity"]),
+                summary("scorecard_rule", "Scorecard Rule", "Rule definitions. Do not expand the deprecated scorecard_outcomes relation.", &["name", "description", "level"], &["scorecard_outcomes"]),
+                summary("scorecard_entity", "Scorecard Entity", "Scorecard-scoped entity records. Do not expand the deprecated scorecard_outcomes relation.", &["reference", "entity_kind", "owner"], &["scorecard_outcomes"]),
+                summary("recommended_system", "Recommended System", "System-grouping recommendations for catalog hygiene and ownership cleanup.", &["name", "display_name", "status", "owners", "components", "html_url"], &[]),
+                summary("campaign", "Campaign", "Governance campaigns connected to remediation work.", &["title", "status", "status_name"], &[]),
+                summary("work", "Work", "Governance and remediation work items.", &["title", "status", "status_name", "assignee_id"], &[]),
+            ],
+        ),
+        category(
+            "security_code_quality",
+            "Security and code-quality findings connected to ownership.",
+            vec![
+                summary("library_vulnerability", "Library Vulnerability", "Dependency vulnerabilities with repository id and affected services fields.", &["severity", "repository_id", "services"], &[]),
+                summary("source_code_vulnerability", "Source Code Vulnerability", "Code vulnerabilities with repository id and service name fields.", &["severity", "repository_id", "service_name"], &[]),
+                summary("code_violation", "Code Violation", "Code quality findings with associated service and repository id fields.", &["status", "k9_severity", "associated_service", "repository_id"], &[]),
+                summary("secret", "Secret", "Secret-scanning findings by repository.", &["severity", "repository_id"], &[]),
+                summary("iac_misconfiguration", "IaC Misconfiguration", "Infrastructure-as-code findings by repository.", &["severity", "repository_id"], &[]),
+                summary("source_code_vulnerability_secfinding", "Source Code Vulnerability SecFinding", "Security finding projection for source-code vulnerabilities by repository.", &["severity", "finding_type", "repository_id", "service_name", "code_location_filename"], &[]),
+            ],
+        ),
+        category(
+            "runtime_api_surface",
+            "Runtime, API, and product-surface entities.",
+            vec![
+                summary("api_endpoint", "API Endpoint", "API exposure, authentication, rate-limit, service, and team ownership questions.", &["resource_name", "http_method", "http_route", "endpoint_is_public", "endpoint_authenticated", "endpoint_is_rate_limited", "service_name", "team_names"], &["service", "teams", "apis"]),
+                summary("api", "API", "API inventory connected to source and system metadata.", &["name", "display_name"], &["code_locations", "current_oncalls", "systems"]),
+                summary("frontend", "Frontend", "Frontend product surface connected to source, monitors, and systems.", &["name", "display_name", "owner"], &["code_locations", "current_oncalls", "monitors"]),
+                summary("datastore", "Datastore", "Dependency and blast-radius entity for persistence.", &["name", "display_name"], &["systems", "incidents", "slos", "monitors"]),
+                summary("queue", "Queue", "Dependency and blast-radius entity for asynchronous systems.", &["name", "display_name"], &["systems", "current_oncalls", "code_locations"]),
+            ],
+        ),
+    ]
+}
+
+fn experimental_categories() -> Vec<KindCategory> {
+    vec![
+        category(
+            "agent_native",
+            "Agent-facing skills and automation assets connected back to source.",
+            vec![summary("ai_skill", "AI Skill", "Agent skill inventory with owner, team, scope, source repository, path, and source URL.", &["name", "description", "owner", "team", "scope", "source_repo", "source_path", "source_url", "tags", "updated_at"], &["repository"])],
+        ),
+        category(
+            "work_integrations",
+            "Third-party work mirrors for pull request, review, Jira, and repository questions.",
+            vec![
+                summary("integration.github.pull_request", "GitHub Pull Request", "Rich GitHub pull request mirror for work-in-flight reports.", &["title", "state", "updated_at", "mergeable", "changed_files"], &["repository", "author", "reviewer_users", "reviewer_teams", "reviews", "review_threads"]),
+                summary("integration.github.repository", "GitHub Repository", "GitHub integration repository mirror.", &["name", "full_name", "owner"], &["pull_requests"]),
+                summary("integration.github.user", "GitHub User", "GitHub user identity for authors and reviewers.", &["login", "name"], &["authored_pull_requests", "reviewed_pull_requests"]),
+                summary("integration.github.team", "GitHub Team", "GitHub team identity for review routing.", &["name", "slug"], &["reviewing_pull_requests"]),
+                summary("integration.jira.issue", "Jira Issue", "Jira work items for daily and team reports.", &["key", "summary", "status", "status_category", "priority", "assignee_name"], &["project", "assignee", "reporter"]),
+                summary("integration.jira.project", "Jira Project", "Jira project grouping for issues.", &["key", "name"], &["issues"]),
+                summary("integration.jira.user", "Jira User", "Jira identity for assignment and reporting.", &["display_name", "email_address"], &["assigned_issues", "reported_issues"]),
+            ],
+        ),
+        category(
+            "infrastructure_integrations",
+            "Integration-backed infrastructure entities. Scope these queries narrowly by team, service, repository, or owner.",
+            vec![summary("integration.k8s.deployment", "Kubernetes Deployment", "Kubernetes deployment inventory and replica health by team or service. Avoid unscoped queries.", &["name", "team", "service", "cluster_name", "namespace", "available_replicas", "ready_replicas", "replicas_desired", "unavailable_replicas"], &["services"])],
+        ),
+        category(
+            "github_native_secondary",
+            "Overlapping GitHub graph family for status and check details. Prefer integration.github.* for repository and work-mirror data.",
+            vec![
+                summary("github.repository", "GitHub Repository", "Native GitHub repository graph for check and status details.", &["name", "name_with_owner", "url"], &["pull_requests", "owner", "repository_topics"]),
+                summary("github.pull_request", "GitHub Pull Request", "Native GitHub pull request graph for check and status details.", &["title", "state", "updated_at"], &["repository", "author", "reviews", "status_check_rollup"]),
+                summary("github.commit", "GitHub Commit", "Native GitHub commit graph for check and status details when available.", &["sha", "ref"], &["check_suites", "status", "status_check_rollup"]),
+                summary("github.status_check_rollup", "GitHub Status Check Rollup", "", &["id", "state", "ref"], &[]),
+            ],
+        ),
+    ]
+}
+
+fn category(name: &str, description: &str, kinds: Vec<KindSummary>) -> KindCategory {
+    KindCategory {
+        name: name.into(),
+        description: description.into(),
+        kinds,
+    }
+}
+
+fn summary(
+    kind: &str,
+    display_name: &str,
+    why_use: &str,
+    top_fields: &[&str],
+    top_relations: &[&str],
+) -> KindSummary {
+    KindSummary {
+        kind: kind.into(),
+        display_name: display_name.into(),
+        why_use: why_use.into(),
+        top_fields: strings(top_fields),
+        top_relations: strings(top_relations),
+    }
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).into()).collect()
+}
+
+fn curated_count(response: &CuratedKindsResponse) -> usize {
+    response
+        .categories
+        .iter()
+        .map(|category| category.kinds.len())
+        .sum::<usize>()
+        + response.custom_kinds.len()
+}
+
+fn is_low_level_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "deployment" | "host" | "pod" | "container" | "namespace" | "cluster" | "environment"
+    )
+}
+
+fn is_experimental_kind(kind: &str) -> bool {
+    kind == "ai_skill" || kind.starts_with("integration.") || kind.starts_with("github.")
+}
+
+fn curated_kind_summary(kind: &str) -> Option<KindSummary> {
+    curated_kinds(true, true)
+        .categories
+        .into_iter()
+        .flat_map(|category| category.kinds)
+        .find(|summary| summary.kind == kind)
+}
+
+fn unknown_kind_suggestion(kind: &str) -> String {
+    let suggestions: &[&str] = match kind.trim().to_ascii_lowercase().as_str() {
+        "github_pr"
+        | "github_prs"
+        | "github.pullrequest"
+        | "github_pull_request"
+        | "github_pull_requests" => &["integration.github.pull_request", "github.pull_request"],
+        "scorecard" | "scorecards" => &["scorecard_outcome", "scorecard_rule", "scorecard_entity"],
+        _ => &[],
+    };
+    if suggestions.is_empty() {
+        String::new()
+    } else {
+        format!(
+            ". Did you mean {}?",
+            suggestions
+                .iter()
+                .map(|suggestion| format!("{suggestion:?}"))
+                .collect::<Vec<_>>()
+                .join(" or ")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> KindResource {
+        serde_json::from_value(serde_json::json!({
+            "id": "service",
+            "attributes": {
+                "display_name": "Service",
+                "attribute_types": {
+                    "name": {"dataType": "string"},
+                    "owner": {"dataType": "string"},
+                    "active_incidents_count": {"dataType": "int", "calculation": {"type": "timeseries"}}
+                },
+                "relations": {"owner_teams": {"target_kind": "team"}}
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn curated_list_filters_optional_categories() {
+        let default = curated_kinds(false, true);
+        assert!(curated_kind_summary("service").is_some());
+        assert!(default
+            .categories
+            .iter()
+            .any(|category| category.name == "agent_native"));
+        assert!(!default
+            .categories
+            .iter()
+            .any(|category| category.name == "infrastructure_low_level"));
+
+        let filtered = curated_kinds(true, false);
+        assert!(filtered
+            .categories
+            .iter()
+            .any(|category| category.name == "infrastructure_low_level"));
+        assert!(!filtered
+            .categories
+            .iter()
+            .any(|category| category.name == "agent_native"));
+    }
+
+    #[test]
+    fn describe_summarizes_schema_and_operators() {
+        let response = describe_response(schema(), true);
+        assert!(response.schema_available);
+        assert_eq!(response.relations[0].name, "owner_teams");
+        let numeric = response
+            .attributes
+            .iter()
+            .find(|attribute| attribute.name == "active_incidents_count")
+            .unwrap();
+        assert!(numeric.operators.contains(&"gte".into()));
+        assert_eq!(numeric.calculation.as_deref(), Some("timeseries"));
+        assert!(!response.examples.is_empty());
+    }
+
+    #[test]
+    fn include_validation_distinguishes_attributes_and_relations() {
+        assert!(
+            validate_includes_against_kind("service", &["owner_teams".into()], &schema()).is_ok()
+        );
+        let error =
+            validate_includes_against_kind("service", &["owner".into()], &schema()).unwrap_err();
+        assert!(error.to_string().contains("attribute, not a relation"));
+        let error =
+            validate_includes_against_kind("service", &["unknown".into()], &schema()).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Valid relations include: owner_teams"));
+    }
+
+    #[test]
+    fn validates_kind_names() {
+        assert!(validate_kind_name("integration.github.pull_request").is_ok());
+        assert!(validate_kind_name("").is_err());
+        assert!(validate_kind_name("service/../../secret").is_err());
+    }
+
+    #[test]
+    fn all_kinds_filters_custom_low_level_and_experimental() {
+        let kinds: KindListResponse = serde_json::from_value(serde_json::json!({
+            "data": [
+                {"id": "service", "attributes": {}},
+                {"id": "pod", "attributes": {}},
+                {"id": "integration.github.pull_request", "attributes": {}},
+                {"id": "idp_custom_entities.widget", "attributes": {}}
+            ]
+        }))
+        .unwrap();
+        let response = build_all_kinds_response(kinds.data, false, false, false);
+        assert_eq!(response.count, 1);
+        assert_eq!(response.kinds[0].kind, "service");
+    }
+
+    #[tokio::test]
+    async fn fetch_kind_uses_detail_endpoint() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/v2/idp/entity_graph/kinds/service")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"service","attributes":{"display_name":"Service","attribute_types":{},"relations":{}}}}"#,
+            )
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        let kind = fetch_kind(&cfg, "service").await.unwrap();
+
+        assert_eq!(kind.kind(), "service");
+        assert_eq!(kind.attributes.display_name, "Service");
+        mock.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn fetch_kind_rejects_malformed_responses() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/v2/idp/entity_graph/kinds/service")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"unexpected":true}"#)
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        let error = fetch_kind(&cfg, "service").await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("failed to decode entity kind schema"));
+        mock.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn list_kinds_fetches_live_inventory_for_all() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", KINDS_PATH)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":[{"id":"service","attributes":{"display_name":"Service","attribute_types":{"name":{"dataType":"string"}},"relations":{}}}]}"#,
+            )
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        list_kinds(&cfg, true, false, false, false).await.unwrap();
+
+        mock.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn describe_kind_falls_back_to_live_kind_list_after_404() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let detail = server
+            .mock("GET", "/api/v2/idp/entity_graph/kinds/service")
+            .with_status(404)
+            .with_body("not found")
+            .create_async()
+            .await;
+        let list = server
+            .mock("GET", KINDS_PATH)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":[{"id":"service","attributes":{"display_name":"Service","attribute_types":{"name":{"dataType":"string"}},"relations":{}}}]}"#,
+            )
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        describe_kind(&cfg, "service", false).await.unwrap();
+
+        detail.assert_async().await;
+        list.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn describe_kind_errors_for_unknown_kind() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let detail = server
+            .mock("GET", "/api/v2/idp/entity_graph/kinds/unknown")
+            .with_status(404)
+            .with_body("not found")
+            .create_async()
+            .await;
+        let list = server
+            .mock("GET", KINDS_PATH)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[]}"#)
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        let error = describe_kind(&cfg, "unknown", false).await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("failed to describe entity kind \"unknown\""));
+        detail.assert_async().await;
+        list.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+}

--- a/src/commands/idp/entity_query.rs
+++ b/src/commands/idp/entity_query.rs
@@ -1,0 +1,1229 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::OnceLock;
+
+use anyhow::{bail, Context, Result};
+use regex::Regex;
+use serde_json::Value;
+
+use super::entity_kinds::{fetch_kind, validate_includes_against_kind};
+use super::entity_types::{
+    EntitiesResponse, EntityIdentity, EntityResource, NormalizedEntitiesResponse, NormalizedEntity,
+    NormalizedPage, QueryEcho, RelationshipSummary, ResourceIdentifier,
+};
+use crate::config::Config;
+use crate::formatter::{self, Metadata};
+use crate::raw_client;
+
+const ENTITIES_PATH: &str = "/api/v2/idp/entity_graph/entities";
+const MAX_PAGE_LIMIT: usize = 100;
+const MAX_RELATION_LIMIT: usize = 100;
+
+#[derive(Debug, Clone)]
+pub struct EntityQueryOptions {
+    pub query: String,
+    pub fields: Vec<String>,
+    pub include: Vec<String>,
+    pub order_by: Vec<String>,
+    pub limit: usize,
+    pub cursor: Option<String>,
+    pub free_text_match: Option<String>,
+    pub include_total_count: bool,
+    pub timeseries_interval: String,
+    pub relation_limit: usize,
+    pub raw: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OrderBy {
+    field: String,
+    direction: String,
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedQueryOptions {
+    query: String,
+    kind: String,
+    fields: Vec<String>,
+    include: Vec<String>,
+    order_by: Vec<OrderBy>,
+    limit: usize,
+    cursor: Option<String>,
+    free_text_match: Option<String>,
+    include_total_count: bool,
+    timeseries_interval: String,
+    relation_limit: usize,
+    raw: bool,
+}
+
+pub async fn query_entities(cfg: &Config, options: EntityQueryOptions) -> Result<()> {
+    let options = normalize_options(options)?;
+    let relation_target_kinds = validate_includes(cfg, &options).await?;
+
+    let query_pairs = entity_query_params(&options, &relation_target_kinds);
+    let query_refs: Vec<(&str, &str)> = query_pairs
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    let raw = raw_client::raw_get(cfg, ENTITIES_PATH, &query_refs)
+        .await
+        .context("failed to query Datadog entities")?;
+
+    if options.raw {
+        let (count, truncated, next_action) = raw_response_metadata(&raw);
+        return formatter::format_and_print(
+            &raw,
+            &cfg.output_format,
+            cfg.agent_mode,
+            Some(&Metadata {
+                count,
+                truncated,
+                command: Some("pup idp entities query".into()),
+                next_action,
+            }),
+            cfg.jq.as_deref(),
+        );
+    }
+
+    let response: EntitiesResponse =
+        serde_json::from_value(raw).context("failed to decode Datadog entity response")?;
+    let normalized = normalize_entities_response(&options, response);
+    let next_action = normalized
+        .page
+        .next_cursor
+        .as_ref()
+        .map(|cursor| format!("Fetch the next page with --cursor {cursor}"));
+    let metadata = Metadata {
+        count: Some(normalized.count),
+        truncated: normalized.page.truncated,
+        command: Some("pup idp entities query".into()),
+        next_action,
+    };
+    formatter::format_and_print(
+        &normalized,
+        &cfg.output_format,
+        cfg.agent_mode,
+        Some(&metadata),
+        cfg.jq.as_deref(),
+    )
+}
+
+fn normalize_options(options: EntityQueryOptions) -> Result<NormalizedQueryOptions> {
+    let query = options.query.trim().to_string();
+    if query.is_empty() {
+        bail!("query is required");
+    }
+    let kind = infer_kind(&query).ok_or_else(|| {
+        anyhow::anyhow!(
+            "query must include kind:<kind> or ref:\"ref:<kind>:<id>\"; quoted kind filters like kind:\"service\" are invalid"
+        )
+    })?;
+    if has_semantic_top_level_or(&query) {
+        bail!(
+            "top-level OR is invalid because the entity graph cannot determine one result kind; keep kind:<kind> or ref:\"ref:<kind>:<id>\" in the shared scope, for example kind:service AND (owner:idp OR team:idp)"
+        );
+    }
+    if free_text_pattern().is_match(&query) {
+        bail!(
+            "free_text is not an entity field; use a real field such as name:*text*, or set --free-text-match to partial or fuzzy"
+        );
+    }
+    validate_limit("limit", options.limit, MAX_PAGE_LIMIT)?;
+    validate_limit("relation-limit", options.relation_limit, MAX_RELATION_LIMIT)?;
+
+    let free_text_match = normalize_free_text_match(options.free_text_match)?;
+    let timeseries_interval = options.timeseries_interval.trim().to_string();
+    if !is_valid_go_duration(&timeseries_interval) {
+        bail!(
+            "invalid timeseries interval {:?}: use a duration such as 1h, 24h, or 168h",
+            options.timeseries_interval
+        );
+    }
+
+    let fields = clean_strings(options.fields);
+    let fields = if fields.is_empty() {
+        default_fields_for_kind(&kind)
+            .iter()
+            .map(|field| (*field).to_string())
+            .collect()
+    } else {
+        fields
+    };
+
+    Ok(NormalizedQueryOptions {
+        query,
+        kind,
+        fields,
+        include: clean_strings(options.include),
+        order_by: normalize_order_by(options.order_by)?,
+        limit: options.limit,
+        cursor: options.cursor.filter(|cursor| !cursor.trim().is_empty()),
+        free_text_match,
+        include_total_count: options.include_total_count,
+        timeseries_interval,
+        relation_limit: options.relation_limit,
+        raw: options.raw,
+    })
+}
+
+fn validate_limit(name: &str, value: usize, maximum: usize) -> Result<()> {
+    if value == 0 || value > maximum {
+        bail!("--{name} must be between 1 and {maximum}, got {value}");
+    }
+    Ok(())
+}
+
+fn normalize_free_text_match(value: Option<String>) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "partial" | "fuzzy" => Ok(Some(normalized)),
+        _ => bail!(
+            "invalid free-text match {:?}: use partial or fuzzy; put search text in a real field filter such as name:*text*",
+            value
+        ),
+    }
+}
+
+fn normalize_order_by(values: Vec<String>) -> Result<Vec<OrderBy>> {
+    clean_strings(values)
+        .into_iter()
+        .map(|value| {
+            let mut parts = value.split(':');
+            let field = parts.next().unwrap_or_default().trim();
+            let direction = parts.next().unwrap_or("asc").trim().to_ascii_lowercase();
+            if field.is_empty() || parts.next().is_some() {
+                bail!("invalid --order-by {value:?}: use <field> or <field>:<asc|desc>");
+            }
+            if direction != "asc" && direction != "desc" {
+                bail!(
+                    "invalid --order-by direction {direction:?} for field {field:?}: use asc or desc"
+                );
+            }
+            Ok(OrderBy {
+                field: field.to_string(),
+                direction,
+            })
+        })
+        .collect()
+}
+
+fn clean_strings(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+async fn validate_includes(cfg: &Config, options: &NormalizedQueryOptions) -> Result<Vec<String>> {
+    if options.include.is_empty() {
+        return Ok(Vec::new());
+    }
+    let Ok(schema) = fetch_kind(cfg, &options.kind).await else {
+        return Ok(Vec::new());
+    };
+    validate_includes_against_kind(&options.kind, &options.include, &schema)?;
+    Ok(options
+        .include
+        .iter()
+        .filter_map(|relation| schema.attributes.relations.get(relation))
+        .map(|relation| relation.target_kind.trim())
+        .filter(|kind| !kind.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn entity_query_params(
+    options: &NormalizedQueryOptions,
+    relation_target_kinds: &[String],
+) -> Vec<(String, String)> {
+    let mut params = vec![
+        ("query".into(), options.query.clone()),
+        ("page[limit]".into(), options.limit.to_string()),
+        ("time[past]".into(), options.timeseries_interval.clone()),
+    ];
+    if let Some(cursor) = &options.cursor {
+        params.push(("page[cursor]".into(), cursor.clone()));
+    }
+    if !options.include.is_empty() {
+        params.push(("include".into(), options.include.join(",")));
+    }
+    if !options.fields.is_empty() {
+        params.push((
+            format!("fields[{}]", options.kind),
+            options.fields.join(","),
+        ));
+    }
+    add_required_included_fields(&mut params, options, relation_target_kinds);
+    if !options.order_by.is_empty() {
+        params.push((
+            "order_by".into(),
+            options
+                .order_by
+                .iter()
+                .map(|order| format!("{}:{}", order.field, order.direction))
+                .collect::<Vec<_>>()
+                .join(","),
+        ));
+    }
+    if let Some(mode) = &options.free_text_match {
+        params.push(("free_text_match".into(), mode.clone()));
+    }
+    if options.include_total_count {
+        params.push(("meta[fields]".into(), "total_count".into()));
+    }
+    params
+}
+
+fn add_required_included_fields(
+    params: &mut Vec<(String, String)>,
+    options: &NormalizedQueryOptions,
+    relation_target_kinds: &[String],
+) {
+    let mut kinds = relation_target_kinds.to_vec();
+    kinds.extend(
+        options
+            .include
+            .iter()
+            .filter_map(|relation| required_included_field_kind(&options.kind, relation))
+            .map(str::to_string),
+    );
+    kinds.sort_unstable();
+    kinds.dedup();
+    for kind in kinds {
+        if !has_specific_default_fields(&kind) {
+            continue;
+        }
+        let key = format!("fields[{kind}]");
+        if params.iter().any(|(existing, _)| existing == &key) {
+            continue;
+        }
+        params.push((key, default_fields_for_kind(&kind).join(",")));
+    }
+}
+
+fn required_included_field_kind(kind: &str, relation: &str) -> Option<&'static str> {
+    match kind {
+        "integration.github.user"
+            if matches!(
+                relation,
+                "assigned_pull_requests"
+                    | "authored_pull_requests"
+                    | "reviewed_pull_requests"
+                    | "reviewing_pull_requests"
+            ) =>
+        {
+            Some("integration.github.pull_request")
+        }
+        "integration.github.team" if relation == "reviewing_pull_requests" => {
+            Some("integration.github.pull_request")
+        }
+        "integration.github.repository" if relation == "pull_requests" => {
+            Some("integration.github.pull_request")
+        }
+        "github.repository" if relation == "pull_requests" => Some("github.pull_request"),
+        _ => None,
+    }
+}
+
+fn normalize_entities_response(
+    options: &NormalizedQueryOptions,
+    response: EntitiesResponse,
+) -> NormalizedEntitiesResponse {
+    let included: HashMap<String, EntityResource> = response
+        .included
+        .into_iter()
+        .map(|entity| (entity_key(&entity.kind, &entity.id), entity))
+        .collect();
+    let mut warnings = Vec::new();
+    let results = response
+        .data
+        .into_iter()
+        .map(|entity| normalize_entity(entity, &included, options.relation_limit, &mut warnings))
+        .collect::<Vec<_>>();
+    let next_cursor =
+        (!response.meta.page.next_cursor.is_empty()).then_some(response.meta.page.next_cursor);
+    if next_cursor.is_some() {
+        warnings.push(
+            "Results are truncated. Use --cursor with the returned next_cursor to fetch the next page."
+                .into(),
+        );
+    }
+
+    NormalizedEntitiesResponse {
+        query: QueryEcho {
+            query: options.query.clone(),
+            inferred_kind: options.kind.clone(),
+            include: options.include.clone(),
+            fields: options.fields.clone(),
+            timeseries_interval: options.timeseries_interval.clone(),
+            relation_limit: options.relation_limit,
+        },
+        count: results.len(),
+        results,
+        page: NormalizedPage {
+            limit: options.limit,
+            truncated: next_cursor.is_some(),
+            next_cursor,
+        },
+        total_count: response.meta.total_count,
+        warnings,
+    }
+}
+
+fn normalize_entity(
+    entity: EntityResource,
+    included: &HashMap<String, EntityResource>,
+    relation_limit: usize,
+    warnings: &mut Vec<String>,
+) -> NormalizedEntity {
+    let identity = entity_identity(&entity, false);
+    let fields = data_fields(&entity.attributes);
+    let relationships = entity
+        .relationships
+        .iter()
+        .filter_map(|(name, relation)| {
+            let identifiers = parse_relationship_data(&relation.data);
+            if identifiers.is_empty() {
+                return None;
+            }
+            let truncated = identifiers.len() > relation_limit;
+            let sample = identifiers
+                .iter()
+                .take(relation_limit)
+                .map(|identifier| {
+                    included
+                        .get(&entity_key(&identifier.kind, &identifier.id))
+                        .map(|related| entity_identity(related, true))
+                        .unwrap_or_else(|| identifier_identity(identifier))
+                })
+                .collect();
+            if truncated {
+                warnings.push(format!(
+                    "Relationship {name:?} on {} has {} entities; sample limited to {relation_limit}. Re-query that relation more narrowly if needed.",
+                    identity.entity_ref,
+                    identifiers.len()
+                ));
+            }
+            Some((
+                name.clone(),
+                RelationshipSummary {
+                    count: identifiers.len(),
+                    truncated,
+                    sample,
+                },
+            ))
+        })
+        .collect();
+
+    NormalizedEntity {
+        entity: identity,
+        fields,
+        relationships,
+    }
+}
+
+fn entity_identity(entity: &EntityResource, include_fields: bool) -> EntityIdentity {
+    let entity_ref = string_attribute(&entity.attributes, "ref")
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            if entity.id.starts_with("ref:") {
+                entity.id.clone()
+            } else {
+                format!("ref:{}:{}", entity.kind, entity.id)
+            }
+        });
+    let display_name = ["display_name", "name", "title", "summary"]
+        .iter()
+        .find_map(|key| string_attribute(&entity.attributes, key).map(str::to_string));
+    EntityIdentity {
+        entity_ref,
+        kind: entity.kind.clone(),
+        id: entity.id.clone(),
+        display_name,
+        fields: if include_fields {
+            data_fields(&entity.attributes)
+        } else {
+            BTreeMap::new()
+        },
+    }
+}
+
+fn identifier_identity(identifier: &ResourceIdentifier) -> EntityIdentity {
+    EntityIdentity {
+        entity_ref: if identifier.id.starts_with("ref:") {
+            identifier.id.clone()
+        } else {
+            format!("ref:{}:{}", identifier.kind, identifier.id)
+        },
+        kind: identifier.kind.clone(),
+        id: identifier.id.clone(),
+        display_name: None,
+        fields: BTreeMap::new(),
+    }
+}
+
+fn data_fields(attributes: &BTreeMap<String, Value>) -> BTreeMap<String, Value> {
+    attributes
+        .iter()
+        .filter(|(key, _)| !matches!(key.as_str(), "ref" | "name" | "display_name"))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn string_attribute<'a>(attributes: &'a BTreeMap<String, Value>, key: &str) -> Option<&'a str> {
+    attributes.get(key).and_then(Value::as_str)
+}
+
+fn parse_relationship_data(value: &Value) -> Vec<ResourceIdentifier> {
+    if value.is_null() {
+        return Vec::new();
+    }
+    serde_json::from_value::<Vec<ResourceIdentifier>>(value.clone())
+        .or_else(|_| {
+            serde_json::from_value::<ResourceIdentifier>(value.clone()).map(|item| vec![item])
+        })
+        .unwrap_or_default()
+}
+
+fn raw_response_metadata(raw: &Value) -> (Option<usize>, bool, Option<String>) {
+    let count = raw.get("data").and_then(Value::as_array).map(Vec::len);
+    let cursor = raw
+        .pointer("/meta/page/next_cursor")
+        .and_then(Value::as_str)
+        .filter(|cursor| !cursor.is_empty());
+    (
+        count,
+        cursor.is_some(),
+        cursor.map(|cursor| format!("Fetch the next page with --cursor {cursor}")),
+    )
+}
+
+fn entity_key(kind: &str, id: &str) -> String {
+    format!("{kind}:{id}")
+}
+
+pub(super) fn infer_kind(query: &str) -> Option<String> {
+    if let Some(captures) = kind_pattern().captures(query) {
+        return captures.get(1).map(|value| value.as_str().to_string());
+    }
+    ref_kind_pattern()
+        .captures(query)
+        .and_then(|captures| captures.get(1))
+        .map(|value| value.as_str().to_string())
+}
+
+fn kind_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| Regex::new(r"(?:^|[\s(])kind:([A-Za-z0-9_.-]+)").unwrap())
+}
+
+fn ref_kind_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| Regex::new(r#"(?:^|[\s(])ref\s*:\s*"ref:([^:"]+):"#).unwrap())
+}
+
+fn free_text_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| Regex::new(r"(?:^|[\s(])free_text\s*:").unwrap())
+}
+
+fn has_semantic_top_level_or(query: &str) -> bool {
+    let bytes = query.as_bytes();
+    let mut minimum_depth = usize::MAX;
+    let mut or_depths = Vec::new();
+    let mut depth = 0usize;
+    let mut in_quote = false;
+    let mut escaped = false;
+
+    for (index, byte) in bytes.iter().copied().enumerate() {
+        if in_quote {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_quote = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_quote = true,
+            b'(' => depth += 1,
+            b')' => depth = depth.saturating_sub(1),
+            b' ' | b'\t' | b'\r' | b'\n' => {}
+            _ => {
+                minimum_depth = minimum_depth.min(depth);
+                if byte == b'O'
+                    && bytes.get(index + 1) == Some(&b'R')
+                    && boolean_boundary(bytes, index.checked_sub(1))
+                    && boolean_boundary(bytes, Some(index + 2))
+                {
+                    or_depths.push(depth);
+                }
+            }
+        }
+    }
+    or_depths.contains(&minimum_depth)
+}
+
+fn boolean_boundary(bytes: &[u8], index: Option<usize>) -> bool {
+    let Some(byte) = index.and_then(|index| bytes.get(index)) else {
+        return true;
+    };
+    matches!(byte, b' ' | b'\t' | b'\r' | b'\n' | b'(' | b')')
+}
+
+fn is_valid_go_duration(value: &str) -> bool {
+    if value.is_empty() || value.starts_with(['+', '-']) {
+        return false;
+    }
+    let mut rest = value;
+    while !rest.is_empty() {
+        let number_len = duration_number_len(rest);
+        if number_len == 0 {
+            return false;
+        }
+        rest = &rest[number_len..];
+        let Some(unit) = ["ns", "us", "µs", "ms", "s", "m", "h"]
+            .iter()
+            .find(|unit| rest.starts_with(**unit))
+        else {
+            return false;
+        };
+        rest = &rest[unit.len()..];
+    }
+    true
+}
+
+fn duration_number_len(value: &str) -> usize {
+    let bytes = value.as_bytes();
+    let integer_digits = bytes
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if integer_digits == 0 {
+        return 0;
+    }
+    if bytes.get(integer_digits) != Some(&b'.') {
+        return integer_digits;
+    }
+    let fraction_digits = bytes[integer_digits + 1..]
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if fraction_digits == 0 {
+        integer_digits
+    } else {
+        integer_digits + 1 + fraction_digits
+    }
+}
+
+pub(super) fn default_fields_for_kind(kind: &str) -> &'static [&'static str] {
+    match kind {
+        "service" => &[
+            "name",
+            "display_name",
+            "owner",
+            "team",
+            "tier",
+            "lifecycle",
+            "service_health_status",
+            "description",
+            "contacts",
+            "links",
+            "additional_owners",
+            "html_url",
+            "ref",
+        ],
+        "team" => &[
+            "name",
+            "handle",
+            "description",
+            "user_count",
+            "html_url",
+            "ref",
+        ],
+        "user" => &["name", "email", "handle", "title", "status", "ref"],
+        "system" => &[
+            "name",
+            "display_name",
+            "owner",
+            "description",
+            "html_url",
+            "ref",
+        ],
+        "repository" => &[
+            "name",
+            "display_name",
+            "owner",
+            "default_branch",
+            "definition_github_url",
+            "ref",
+        ],
+        "github.repository" => &[
+            "name",
+            "name_with_owner",
+            "url",
+            "visibility",
+            "open_pull_requests_count",
+            "ref",
+        ],
+        "integration.github.repository" => &[
+            "name",
+            "display_name",
+            "full_name",
+            "owner",
+            "html_url",
+            "ref",
+        ],
+        "code_location" => &[
+            "name",
+            "repository_id",
+            "path_pattern",
+            "source",
+            "entity_ref",
+            "ref",
+        ],
+        "ai_skill" => &[
+            "name",
+            "description",
+            "owner",
+            "team",
+            "scope",
+            "source_repo",
+            "source_path",
+            "source_url",
+            "tags",
+            "updated_at",
+            "ref",
+        ],
+        "scorecard_outcome" => &[
+            "entity_reference",
+            "entity_kind",
+            "entity_owner",
+            "rule_name",
+            "rule_id",
+            "state",
+            "level",
+            "ref",
+        ],
+        "scorecard_rule" => &["name", "description", "level", "ref"],
+        "incident" => &[
+            "public_id",
+            "title",
+            "state",
+            "severity",
+            "service_names",
+            "teams",
+            "visibility",
+        ],
+        "monitor" => &[
+            "name",
+            "status",
+            "monitor_id",
+            "service_tags",
+            "host_tags",
+            "env",
+            "timestamp",
+            "muted",
+        ],
+        "slo" => &[
+            "name",
+            "state",
+            "target_threshold",
+            "sli",
+            "service_names",
+            "team_names",
+            "error_budget_remaining",
+        ],
+        "current_oncall" => &[
+            "current_oncall_id",
+            "oncall_service_id",
+            "provider",
+            "user_name",
+            "user_email",
+            "escalation_level",
+        ],
+        "integration.github.pull_request" => &[
+            "title",
+            "state",
+            "updated_at",
+            "mergeable",
+            "changed_files",
+            "html_url",
+            "ref",
+        ],
+        "github.pull_request" => &[
+            "title",
+            "state",
+            "updated_at",
+            "mergeable",
+            "review_decision",
+            "url",
+            "ref",
+        ],
+        "integration.jira.issue" => &[
+            "key",
+            "summary",
+            "status",
+            "status_category",
+            "priority",
+            "assignee_name",
+            "due_date",
+            "html_url",
+            "ref",
+        ],
+        "api_endpoint" => &[
+            "resource_name",
+            "http_method",
+            "http_route",
+            "http_hosts",
+            "endpoint_is_public",
+            "endpoint_authenticated",
+            "endpoint_is_rate_limited",
+            "service_name",
+            "team_names",
+            "last_seen_traffic_at",
+            "ref",
+        ],
+        "library_vulnerability" => &[
+            "severity",
+            "repository_id",
+            "services",
+            "package_normalized_name",
+            "package_version",
+            "advisory_id",
+        ],
+        "source_code_vulnerability" => &[
+            "severity",
+            "repository_id",
+            "service_name",
+            "package_decl_filename",
+            "code_location_filename",
+            "finding_type",
+        ],
+        "secret" | "iac_misconfiguration" => &["severity", "repository_id"],
+        "source_code_vulnerability_secfinding" => &[
+            "severity",
+            "finding_type",
+            "repository_id",
+            "service_name",
+            "code_location_filename",
+            "package_decl_filename",
+        ],
+        "integration.k8s.deployment" => &[
+            "name",
+            "team",
+            "service",
+            "cluster_name",
+            "namespace",
+            "available_replicas",
+            "ready_replicas",
+            "replicas_desired",
+            "unavailable_replicas",
+            "status",
+            "html_url",
+        ],
+        "recommended_system" => &[
+            "name",
+            "display_name",
+            "status",
+            "owners",
+            "components",
+            "description",
+            "html_url",
+            "created_at",
+        ],
+        "code_violation" => &[
+            "status",
+            "k9_severity",
+            "associated_service",
+            "repository_id",
+            "category",
+            "message",
+        ],
+        _ => &[
+            "name",
+            "display_name",
+            "title",
+            "owner",
+            "team",
+            "status",
+            "state",
+            "html_url",
+            "ref",
+        ],
+    }
+}
+
+fn has_specific_default_fields(kind: &str) -> bool {
+    matches!(
+        kind,
+        "service"
+            | "team"
+            | "user"
+            | "system"
+            | "repository"
+            | "github.repository"
+            | "integration.github.repository"
+            | "code_location"
+            | "ai_skill"
+            | "scorecard_outcome"
+            | "scorecard_rule"
+            | "incident"
+            | "monitor"
+            | "slo"
+            | "current_oncall"
+            | "integration.github.pull_request"
+            | "github.pull_request"
+            | "integration.jira.issue"
+            | "api_endpoint"
+            | "library_vulnerability"
+            | "source_code_vulnerability"
+            | "secret"
+            | "iac_misconfiguration"
+            | "source_code_vulnerability_secfinding"
+            | "integration.k8s.deployment"
+            | "recommended_system"
+            | "code_violation"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Matcher;
+
+    fn options(query: &str) -> EntityQueryOptions {
+        EntityQueryOptions {
+            query: query.into(),
+            fields: Vec::new(),
+            include: Vec::new(),
+            order_by: Vec::new(),
+            limit: 25,
+            cursor: None,
+            free_text_match: None,
+            include_total_count: false,
+            timeseries_interval: "1h".into(),
+            relation_limit: 25,
+            raw: false,
+        }
+    }
+
+    #[test]
+    fn normalizes_valid_query_and_defaults() {
+        let normalized =
+            normalize_options(options("kind:service AND (owner:idp OR team:idp)")).unwrap();
+        assert_eq!(normalized.kind, "service");
+        assert!(normalized.fields.contains(&"owner".into()));
+        assert_eq!(normalized.limit, 25);
+        assert_eq!(normalized.relation_limit, 25);
+    }
+
+    #[test]
+    fn rejects_query_without_concrete_kind() {
+        let error = normalize_options(options("name:*catalog*")).unwrap_err();
+        assert!(error.to_string().contains("must include kind:<kind>"));
+        let error = normalize_options(options(r#"kind:"service""#)).unwrap_err();
+        assert!(error.to_string().contains("quoted kind filters"));
+        let normalized = normalize_options(options(r#"ref:"ref:team:idp""#)).unwrap();
+        assert_eq!(normalized.kind, "team");
+    }
+
+    #[test]
+    fn rejects_semantic_top_level_or_but_allows_grouped_filters() {
+        let error = normalize_options(options("kind:service OR kind:team")).unwrap_err();
+        assert!(error.to_string().contains("top-level OR"));
+        let error = normalize_options(options("(kind:service OR kind:team)")).unwrap_err();
+        assert!(error.to_string().contains("top-level OR"));
+        assert!(normalize_options(options("kind:service AND (owner:idp OR team:idp)")).is_ok());
+    }
+
+    #[test]
+    fn validates_modes_limits_ordering_and_duration() {
+        let mut invalid = options("kind:service");
+        invalid.free_text_match = Some("contains".into());
+        assert!(normalize_options(invalid).is_err());
+
+        let mut invalid = options("kind:service");
+        invalid.limit = 101;
+        assert!(normalize_options(invalid).is_err());
+
+        let mut invalid = options("kind:service");
+        invalid.relation_limit = 0;
+        assert!(normalize_options(invalid).is_err());
+
+        let mut invalid = options("kind:service");
+        invalid.order_by = vec!["name:sideways".into()];
+        assert!(normalize_options(invalid).is_err());
+
+        let mut invalid = options("kind:service");
+        invalid.timeseries_interval = "7d".into();
+        assert!(normalize_options(invalid).is_err());
+
+        let error = normalize_options(options("kind:service AND free_text:catalog")).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("free_text is not an entity field"));
+
+        assert!(is_valid_go_duration("1h30m"));
+        assert!(is_valid_go_duration("1.5h"));
+    }
+
+    #[test]
+    fn builds_entity_query_parameters() {
+        let mut input = options("kind:integration.github.repository AND name:api");
+        input.include = vec!["pull_requests".into()];
+        input.order_by = vec!["updated_at:desc".into()];
+        input.cursor = Some("cursor value".into());
+        input.include_total_count = true;
+        let normalized = normalize_options(input).unwrap();
+        let params: BTreeMap<_, _> = entity_query_params(&normalized, &[]).into_iter().collect();
+        assert_eq!(params["page[cursor]"], "cursor value");
+        assert_eq!(params["order_by"], "updated_at:desc");
+        assert_eq!(params["meta[fields]"], "total_count");
+        assert!(params.contains_key("fields[integration.github.pull_request]"));
+    }
+
+    #[test]
+    fn normalizes_relationships_and_pagination() {
+        let normalized_options = normalize_options(options("kind:service")).unwrap();
+        let response: EntitiesResponse = serde_json::from_value(serde_json::json!({
+            "data": [{
+                "type": "service",
+                "id": "checkout",
+                "attributes": {"name": "checkout", "owner": "payments", "ref": "ref:service:checkout"},
+                "relationships": {"owner_teams": {"data": [{"type": "team", "id": "payments"}]}}
+            }],
+            "included": [{
+                "type": "team",
+                "id": "payments",
+                "attributes": {"name": "Payments", "handle": "payments"}
+            }],
+            "meta": {"total_count": 3, "page": {"next_cursor": "next"}}
+        }))
+        .unwrap();
+        let normalized = normalize_entities_response(&normalized_options, response);
+        assert_eq!(normalized.count, 1);
+        assert_eq!(normalized.total_count, Some(3));
+        assert!(normalized.page.truncated);
+        assert_eq!(
+            normalized.results[0].relationships["owner_teams"].sample[0]
+                .display_name
+                .as_deref(),
+            Some("Payments")
+        );
+    }
+
+    #[test]
+    fn normalizes_single_null_malformed_and_truncated_relations() {
+        let mut input = options("kind:service");
+        input.relation_limit = 1;
+        let normalized_options = normalize_options(input).unwrap();
+        let response: EntitiesResponse = serde_json::from_value(serde_json::json!({
+            "data": [{
+                "type": "service",
+                "id": "checkout",
+                "attributes": {},
+                "relationships": {
+                    "single": {"data": {"type": "team", "id": "payments"}},
+                    "many": {"data": [
+                        {"type": "system", "id": "store"},
+                        {"type": "system", "id": "billing"}
+                    ]},
+                    "empty": {"data": null},
+                    "malformed": {"data": "not-an-identifier"}
+                }
+            }],
+            "meta": {"page": {"next_cursor": ""}}
+        }))
+        .unwrap();
+
+        let normalized = normalize_entities_response(&normalized_options, response);
+
+        let entity = &normalized.results[0];
+        assert_eq!(entity.entity.entity_ref, "ref:service:checkout");
+        assert_eq!(entity.relationships["single"].count, 1);
+        assert_eq!(entity.relationships["many"].count, 2);
+        assert!(entity.relationships["many"].truncated);
+        assert!(!entity.relationships.contains_key("empty"));
+        assert!(!entity.relationships.contains_key("malformed"));
+        assert!(normalized
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("sample limited to 1")));
+    }
+
+    #[tokio::test]
+    async fn query_entities_sends_encoded_parameters() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let query = "kind:service AND owner:payments";
+        let mock = server
+            .mock("GET", ENTITIES_PATH)
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("query".into(), query.into()),
+                Matcher::UrlEncoded("page[limit]".into(), "25".into()),
+                Matcher::UrlEncoded("time[past]".into(), "1h".into()),
+                Matcher::UrlEncoded(
+                    "fields[service]".into(),
+                    default_fields_for_kind("service").join(","),
+                ),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[],"meta":{"page":{"next_cursor":""}}}"#)
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        query_entities(&cfg, options(query)).await.unwrap();
+
+        mock.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn query_entities_reports_api_errors() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", ENTITIES_PATH)
+            .match_query(Matcher::Any)
+            .with_status(500)
+            .with_body("entity graph unavailable")
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        let error = query_entities(&cfg, options("kind:service"))
+            .await
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("failed to query Datadog entities"));
+        mock.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn query_entities_rejects_attribute_includes_from_live_schema() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let schema = server
+            .mock("GET", "/api/v2/idp/entity_graph/kinds/service")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"service","attributes":{"attribute_types":{"owner":{"dataType":"string"}},"relations":{"owner_teams":{"target_kind":"team"}}}}}"#,
+            )
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+        let mut input = options("kind:service");
+        input.include = vec!["owner".into()];
+
+        let error = query_entities(&cfg, input).await.unwrap_err();
+
+        assert!(error.to_string().contains("attribute, not a relation"));
+        schema.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn query_entities_projects_known_relation_target_kinds() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let schema = server
+            .mock("GET", "/api/v2/idp/entity_graph/kinds/service")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"data":{"id":"service","attributes":{"relations":{"owner_teams":{"target_kind":"team"},"systems":{"target_kind":"system"}}}}}"#,
+            )
+            .create_async()
+            .await;
+        let entities = server
+            .mock("GET", ENTITIES_PATH)
+            .match_query(Matcher::AllOf(vec![
+                Matcher::UrlEncoded(
+                    "fields[team]".into(),
+                    default_fields_for_kind("team").join(","),
+                ),
+                Matcher::UrlEncoded(
+                    "fields[system]".into(),
+                    default_fields_for_kind("system").join(","),
+                ),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[],"meta":{"page":{"next_cursor":""}}}"#)
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+        let mut input = options("kind:service");
+        input.include = vec!["owner_teams".into(), "systems".into()];
+
+        query_entities(&cfg, input).await.unwrap();
+
+        schema.assert_async().await;
+        entities.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn query_entities_continues_when_kind_schema_is_unavailable() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let schema = server
+            .mock("GET", "/api/v2/idp/entity_graph/kinds/service")
+            .with_status(500)
+            .with_body("schema unavailable")
+            .create_async()
+            .await;
+        let entities = server
+            .mock("GET", ENTITIES_PATH)
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[],"meta":{"page":{"next_cursor":""}}}"#)
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+        let mut input = options("kind:service");
+        input.include = vec!["owner_teams".into()];
+
+        query_entities(&cfg, input).await.unwrap();
+
+        schema.assert_async().await;
+        entities.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn query_entities_rejects_malformed_json() {
+        let _guard = crate::test_support::lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", ENTITIES_PATH)
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("not json")
+            .create_async()
+            .await;
+        let cfg = crate::test_support::test_config(&server.url());
+
+        let error = query_entities(&cfg, options("kind:service"))
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("expected ident"));
+        mock.assert_async().await;
+        crate::test_support::cleanup_env();
+    }
+}

--- a/src/commands/idp/entity_types.rs
+++ b/src/commands/idp/entity_types.rs
@@ -1,0 +1,172 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct KindListResponse {
+    #[serde(default)]
+    pub data: Vec<KindResource>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct KindResponse {
+    pub data: KindResource,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct KindResource {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub attributes: KindAttributes,
+}
+
+impl KindResource {
+    pub(super) fn kind(&self) -> &str {
+        if self.id.is_empty() {
+            &self.attributes.name
+        } else {
+            &self.id
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(super) struct KindAttributes {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub attribute_types: BTreeMap<String, KindAttribute>,
+    #[serde(default)]
+    pub relations: BTreeMap<String, KindRelation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct KindAttribute {
+    #[serde(default, rename = "dataType")]
+    pub data_type: String,
+    pub calculation: Option<KindCalculation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct KindCalculation {
+    #[serde(default, rename = "type")]
+    pub calculation_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct KindRelation {
+    #[serde(default)]
+    pub target_kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct EntitiesResponse {
+    #[serde(default)]
+    pub data: Vec<EntityResource>,
+    #[serde(default)]
+    pub included: Vec<EntityResource>,
+    #[serde(default)]
+    pub meta: EntityMeta,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct EntityResource {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub id: String,
+    #[serde(default)]
+    pub attributes: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub relationships: BTreeMap<String, EntityRelationship>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct EntityRelationship {
+    #[serde(default)]
+    pub data: Value,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct EntityMeta {
+    pub total_count: Option<usize>,
+    #[serde(default)]
+    pub page: PageMeta,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct PageMeta {
+    #[serde(default)]
+    pub next_cursor: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ResourceIdentifier {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct NormalizedEntitiesResponse {
+    pub query: QueryEcho,
+    pub results: Vec<NormalizedEntity>,
+    pub page: NormalizedPage,
+    pub count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_count: Option<usize>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct QueryEcho {
+    pub query: String,
+    pub inferred_kind: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<String>,
+    pub timeseries_interval: String,
+    pub relation_limit: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct NormalizedPage {
+    pub limit: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct NormalizedEntity {
+    pub entity: EntityIdentity,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, Value>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub relationships: BTreeMap<String, RelationshipSummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct RelationshipSummary {
+    pub count: usize,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sample: Vec<EntityIdentity>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct EntityIdentity {
+    #[serde(rename = "ref")]
+    pub entity_ref: String,
+    pub kind: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, Value>,
+}

--- a/src/commands/idp/mod.rs
+++ b/src/commands/idp/mod.rs
@@ -6,7 +6,13 @@ use crate::formatter;
 use crate::raw_client;
 use crate::util_ext;
 
+mod entity_kinds;
+mod entity_query;
+mod entity_types;
 mod migrate;
+
+pub use entity_kinds::{describe_kind, list_kinds};
+pub use entity_query::{query_entities, EntityQueryOptions};
 pub use migrate::migrate_schema;
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -1526,6 +1526,8 @@ enum Commands {
     /// suggested next actions from the Datadog Service Catalog / IDP.
     ///
     /// CAPABILITIES:
+    ///   • Discover entity kinds and inspect their live query schemas
+    ///   • Query entities and traverse declared relationships
     ///   • Get a full context summary for any entity (assist)
     ///   • Find entities by name or query (find)
     ///   • Resolve ownership and on-call (owner)
@@ -1539,6 +1541,13 @@ enum Commands {
     ///
     ///   # Find entities matching a query
     ///   pup idp find "catalog"
+    ///
+    ///   # Discover entity kinds and their schemas
+    ///   pup idp kinds list
+    ///   pup idp kinds describe service
+    ///
+    ///   # Query across the Datadog entity graph
+    ///   pup idp entities query 'kind:service AND owner:payments'
     ///
     ///   # Who owns this service?
     ///   pup idp owner catalog-http
@@ -5046,6 +5055,16 @@ enum InfraHostActions {
 // ---- IDP (Internal Developer Portal) ----
 #[derive(Subcommand)]
 enum IdpActions {
+    /// Discover the kinds, fields, and relations available in the entity graph
+    Kinds {
+        #[command(subcommand)]
+        action: IdpKindsActions,
+    },
+    /// Query entities and traverse their relations
+    Entities {
+        #[command(subcommand)]
+        action: IdpEntitiesActions,
+    },
     /// Get full context summary with suggested next actions
     ///
     /// The flagship IDP command. Makes parallel API calls to return
@@ -5147,6 +5166,108 @@ enum IdpActions {
     MigrateSchema {
         /// Path to the YAML file (optional — auto-discovers *.datadog.yaml if omitted)
         file: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum IdpKindsActions {
+    /// List useful entity kinds, grouped by common agent workflows
+    ///
+    /// By default this returns a curated local index. Use --all to source the
+    /// inventory from the server, --include-custom for organization-defined
+    /// kinds, and --include-low-level for noisy infrastructure kinds.
+    ///
+    /// EXAMPLES:
+    ///   pup idp kinds list
+    ///   pup idp kinds list --all --include-custom
+    ///   pup idp kinds list --include-low-level --exclude-experimental
+    #[command(verbatim_doc_comment)]
+    List {
+        /// Source the filtered inventory from the live server instead of the curated index
+        #[arg(long)]
+        all: bool,
+        /// Include organization-defined idp_custom_entities.* kinds
+        #[arg(long)]
+        include_custom: bool,
+        /// Include low-level infrastructure kinds such as pods and containers
+        #[arg(long)]
+        include_low_level: bool,
+        /// Hide experimental integration and agent-native kinds
+        #[arg(long)]
+        exclude_experimental: bool,
+    },
+    /// Describe one entity kind's queryable fields and expandable relations
+    ///
+    /// Returns live schema details, supported operators, default fields,
+    /// examples, hints, and known caveats. Curated kinds fall back to local
+    /// guidance when the server's detail endpoint is unavailable.
+    ///
+    /// EXAMPLES:
+    ///   pup idp kinds describe service
+    ///   pup idp kinds describe integration.github.pull_request
+    ///   pup idp kinds describe service --no-examples
+    #[command(verbatim_doc_comment)]
+    Describe {
+        /// Entity kind, for example service, team, or integration.github.pull_request
+        kind: String,
+        /// Omit query examples from the response
+        #[arg(long)]
+        no_examples: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum IdpEntitiesActions {
+    /// Query entities using the Datadog entity graph DSL
+    ///
+    /// The query must select exactly one top-level kind with kind:<kind> or a
+    /// concrete ref:"ref:<kind>:<id>". Group alternatives beneath that shared
+    /// kind, for example: kind:service AND (owner:idp OR team:idp).
+    ///
+    /// Use --field for returned attributes and --include only for relations.
+    /// Discover valid names with `pup idp kinds describe <kind>`.
+    /// Results are normalized for agents by default; use --raw for the original
+    /// JSON:API response. Pagination is explicit through --cursor.
+    ///
+    /// EXAMPLES:
+    ///   pup idp entities query 'kind:service AND owner:payments'
+    ///   pup idp entities query 'kind:service AND name:*catalog*' --field name,owner,contacts
+    ///   pup idp entities query 'kind:team AND name:idp' --include users,owned_services
+    ///   pup idp entities query 'kind:incident AND state:active' --timeseries-interval 24h
+    #[command(verbatim_doc_comment)]
+    Query {
+        /// Entity graph query DSL expression
+        query: String,
+        /// Attributes to return (comma-separated or repeated)
+        #[arg(long, value_delimiter = ',')]
+        field: Vec<String>,
+        /// Relations to expand (comma-separated or repeated)
+        #[arg(long, value_delimiter = ',')]
+        include: Vec<String>,
+        /// Sort expression <field>[:asc|desc] (comma-separated or repeated)
+        #[arg(long, value_delimiter = ',')]
+        order_by: Vec<String>,
+        /// Maximum entities in this page (1-100)
+        #[arg(long, default_value_t = 25)]
+        limit: usize,
+        /// Cursor returned by the previous page
+        #[arg(long)]
+        cursor: Option<String>,
+        /// Text matching mode: partial or fuzzy
+        #[arg(long, value_parser = ["partial", "fuzzy"])]
+        free_text_match: Option<String>,
+        /// Ask the API to return the total matching entity count
+        #[arg(long)]
+        include_total_count: bool,
+        /// Lookback for timeseries-backed calculated fields (for example 1h or 24h)
+        #[arg(long, default_value = "1h")]
+        timeseries_interval: String,
+        /// Maximum related entities sampled per expanded relation (1-100)
+        #[arg(long, default_value_t = 25)]
+        relation_limit: usize,
+        /// Return the original JSON:API response instead of normalized output
+        #[arg(long)]
+        raw: bool,
     },
 }
 
@@ -14016,6 +14137,60 @@ async fn main_inner() -> anyhow::Result<()> {
         }
         // --- IDP (Internal Developer Portal) ---
         Commands::Idp { action } => match action {
+            IdpActions::Kinds { action } => match action {
+                IdpKindsActions::List {
+                    all,
+                    include_custom,
+                    include_low_level,
+                    exclude_experimental,
+                } => {
+                    commands::idp::list_kinds(
+                        &cfg,
+                        all,
+                        include_custom,
+                        include_low_level,
+                        exclude_experimental,
+                    )
+                    .await?;
+                }
+                IdpKindsActions::Describe { kind, no_examples } => {
+                    commands::idp::describe_kind(&cfg, &kind, no_examples).await?;
+                }
+            },
+            IdpActions::Entities { action } => match action {
+                IdpEntitiesActions::Query {
+                    query,
+                    field,
+                    include,
+                    order_by,
+                    limit,
+                    cursor,
+                    free_text_match,
+                    include_total_count,
+                    timeseries_interval,
+                    relation_limit,
+                    raw,
+                } => {
+                    cfg.validate_auth()?;
+                    commands::idp::query_entities(
+                        &cfg,
+                        commands::idp::EntityQueryOptions {
+                            query,
+                            fields: field,
+                            include,
+                            order_by,
+                            limit,
+                            cursor,
+                            free_text_match,
+                            include_total_count,
+                            timeseries_interval,
+                            relation_limit,
+                            raw,
+                        },
+                    )
+                    .await?;
+                }
+            },
             IdpActions::Assist { entity } => {
                 cfg.validate_auth()?;
                 commands::idp::assist(&cfg, &entity).await?;

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -687,6 +687,188 @@ fn test_logs_patterns_parses_and_is_read_only() {
 }
 
 #[test]
+fn test_idp_entity_graph_commands_parse() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "idp",
+        "entities",
+        "query",
+        "kind:service AND owner:payments",
+        "--field",
+        "name,owner",
+        "--include",
+        "owner_teams",
+        "--order-by",
+        "name:desc",
+        "--limit",
+        "50",
+        "--cursor",
+        "next-page",
+        "--free-text-match",
+        "fuzzy",
+        "--include-total-count",
+        "--timeseries-interval",
+        "24h",
+        "--relation-limit",
+        "10",
+        "--raw",
+    ])
+    .expect("IDP entity query should parse");
+
+    match cli.command {
+        crate::Commands::Idp {
+            action:
+                crate::IdpActions::Entities {
+                    action:
+                        crate::IdpEntitiesActions::Query {
+                            query,
+                            field,
+                            include,
+                            order_by,
+                            limit,
+                            cursor,
+                            free_text_match,
+                            include_total_count,
+                            timeseries_interval,
+                            relation_limit,
+                            raw,
+                        },
+                },
+        } => {
+            assert_eq!(query, "kind:service AND owner:payments");
+            assert_eq!(field, vec!["name", "owner"]);
+            assert_eq!(include, vec!["owner_teams"]);
+            assert_eq!(order_by, vec!["name:desc"]);
+            assert_eq!(limit, 50);
+            assert_eq!(cursor.as_deref(), Some("next-page"));
+            assert_eq!(free_text_match.as_deref(), Some("fuzzy"));
+            assert!(include_total_count);
+            assert_eq!(timeseries_interval, "24h");
+            assert_eq!(relation_limit, 10);
+            assert!(raw);
+        }
+        _ => panic!("expected IdpEntitiesActions::Query"),
+    }
+
+    let kinds = crate::Cli::try_parse_from([
+        "pup",
+        "idp",
+        "kinds",
+        "list",
+        "--all",
+        "--include-custom",
+        "--include-low-level",
+        "--exclude-experimental",
+    ])
+    .expect("IDP kinds list should parse");
+    match kinds.command {
+        crate::Commands::Idp {
+            action:
+                crate::IdpActions::Kinds {
+                    action:
+                        crate::IdpKindsActions::List {
+                            all,
+                            include_custom,
+                            include_low_level,
+                            exclude_experimental,
+                        },
+                },
+        } => {
+            assert!(all);
+            assert!(include_custom);
+            assert!(include_low_level);
+            assert!(exclude_experimental);
+        }
+        _ => panic!("expected IdpKindsActions::List"),
+    }
+}
+
+#[test]
+fn test_idp_entity_query_rejects_unknown_free_text_match_mode() {
+    use clap::Parser;
+
+    let result = crate::Cli::try_parse_from([
+        "pup",
+        "idp",
+        "entities",
+        "query",
+        "kind:service",
+        "--free-text-match",
+        "exact",
+    ]);
+    let Err(error) = result else {
+        panic!("unsupported matching modes should fail during CLI parsing");
+    };
+
+    let message = error.to_string();
+    assert!(message.contains("invalid value 'exact'"));
+    assert!(message.contains("partial"));
+    assert!(message.contains("fuzzy"));
+}
+
+#[test]
+fn test_idp_entity_graph_schema_marks_commands_read_only() {
+    use clap::CommandFactory;
+
+    let schema = crate::build_agent_schema(&crate::Cli::command());
+    let idp = schema["commands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|command| command["name"] == "idp")
+        .unwrap();
+    let kinds = idp["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|command| command["name"] == "kinds")
+        .unwrap();
+    let describe = kinds["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|command| command["name"] == "describe")
+        .unwrap();
+    assert_eq!(describe["read_only"], true);
+
+    let entities = idp["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|command| command["name"] == "entities")
+        .unwrap();
+    let query = entities["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|command| command["name"] == "query")
+        .unwrap();
+    assert_eq!(query["read_only"], true);
+    assert!(query["flags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|flag| flag["name"] == "--relation-limit"));
+}
+
+#[test]
+fn test_read_only_guard_allows_idp_entity_graph_commands() {
+    use clap::CommandFactory;
+
+    for args in [
+        vec!["pup", "idp", "kinds", "list"],
+        vec!["pup", "idp", "kinds", "describe", "service"],
+        vec!["pup", "idp", "entities", "query", "kind:service"],
+    ] {
+        let matches = crate::Cli::command().try_get_matches_from(args).unwrap();
+        let leaf = crate::get_leaf_subcommand_name(&matches).unwrap();
+        assert!(!crate::is_write_command_name(&leaf));
+    }
+}
+
+#[test]
 fn test_logs_search_and_aggregate_default_to_auto_storage() {
     use clap::Parser;
 


### PR DESCRIPTION
## Summary

Expose Datadog entity graph discovery and querying through Pup so humans and agents can inspect available kinds, learn their live schema, and answer bounded cross-entity questions.

This adds the broad read-only workflow under the existing IDP namespace without changing or deprecating the current assist, find, owner, deps, register, or migrate-schema commands.

## Changes

- Add `pup idp kinds list` with curated, live, custom, low-level, and experimental-kind controls.
- Add `pup idp kinds describe <kind>` with live fields, relations, operators, examples, caveats, and explicit fallback behavior.
- Add `pup idp entities query <dsl>` with field projection, relation expansion, ordering, time windows, pagination, total counts, raw output, and agent-friendly normalization.
- Validate known DSL failure modes, limits, durations, ordering, free-text mode, and attribute-versus-relation includes before querying.
- Use live relation target kinds to keep expanded related resources compact and report result/relation truncation explicitly.
- Add `repo_info_read`, `code_analysis_read`, and `appsec_vm_read` to default and read-only OAuth scope sets.
- Document the new commands and OAuth scopes while preserving the existing IDP command surface.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (1,884 passed)
- `cargo build --release`
- Mock HTTP tests for exact endpoints, query encoding, schema fallback, validation, malformed responses, normalization, projection, and errors
- CLI parser, agent-schema, read-only guard, and OAuth-scope tests
- Read-only live dogfood through `dd-auth` covering standard/custom kind discovery, service schema and relations, cursor continuation, raw/agent output, GitHub repositories, code violations, vulnerabilities, and invalid includes

`cargo audit` reports only advisories already present on upstream `main`; this PR does not change `Cargo.toml` or `Cargo.lock`.

## Authentication note

Existing OAuth sessions must run `pup auth login` again to receive the newly requested graph-domain scopes.
