### PR TITLE
fix(apm): send from/to on flow-map and apply --env

### DIFF
--- a/src/commands/apm.rs
+++ b/src/commands/apm.rs
@@ -75,12 +75,27 @@ pub async fn flow_map(
     limit: i64,
     from: String,
     to: String,
+    env: Option<String>,
 ) -> Result<()> {
-    let from_ts = util_ext::parse_time_to_unix(&from)?;
-    let to_ts = util_ext::parse_time_to_unix(&to)?;
-    let path =
-        format!("/api/ui/apm/flow-map?query={query}&limit={limit}&start={from_ts}&end={to_ts}");
-    let data = raw_client::raw_get(cfg, &path, &[]).await?;
+    let from_ts = util_ext::parse_time_to_unix(&from)?.to_string();
+    let to_ts = util_ext::parse_time_to_unix(&to)?.to_string();
+    // The endpoint ignores a top-level env parameter, so fold env into the query.
+    let query = match env {
+        Some(env) => format!("{query} env:{env}"),
+        None => query,
+    };
+    let limit = limit.to_string();
+    let data = raw_client::raw_get(
+        cfg,
+        "/api/ui/apm/flow-map",
+        &[
+            ("query", query.as_str()),
+            ("limit", limit.as_str()),
+            ("from", from_ts.as_str()),
+            ("to", to_ts.as_str()),
+        ],
+    )
+    .await?;
     formatter::output(cfg, &data)
 }
 
@@ -503,6 +518,95 @@ mod tests {
             result.err()
         );
         mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_apm_flow_map_uses_from_to() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("GET", "/api/ui/apm/flow-map")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("query".into(), "service:web".into()),
+                mockito::Matcher::UrlEncoded("limit".into(), "100".into()),
+                mockito::Matcher::Regex("from=".into()),
+                mockito::Matcher::Regex("to=".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {}}"#)
+            .create_async()
+            .await;
+
+        let result = super::flow_map(
+            &cfg,
+            "service:web".into(),
+            100,
+            "1h".into(),
+            "now".into(),
+            None,
+        )
+        .await;
+        assert!(result.is_ok(), "flow_map failed: {:?}", result.err());
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_apm_flow_map_folds_env_into_query() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let mock = server
+            .mock("GET", "/api/ui/apm/flow-map")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "query".into(),
+                "service:web env:prod".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data": {}}"#)
+            .create_async()
+            .await;
+
+        let result = super::flow_map(
+            &cfg,
+            "service:web".into(),
+            100,
+            "1h".into(),
+            "now".into(),
+            Some("prod".into()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "flow_map with env failed: {:?}",
+            result.err()
+        );
+        mock.assert_async().await;
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_apm_flow_map_rejects_bad_time() {
+        let _lock = lock_env().await;
+        let server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+
+        let result = super::flow_map(
+            &cfg,
+            "service:web".into(),
+            100,
+            "not-a-time".into(),
+            "now".into(),
+            None,
+        )
+        .await;
+        assert!(result.is_err(), "expected invalid --from to error");
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16699,9 +16699,9 @@ async fn main_inner() -> anyhow::Result<()> {
                     limit,
                     from,
                     to,
-                    ..
+                    env,
                 } => {
-                    commands::apm::flow_map(&cfg, query, limit, from, to).await?;
+                    commands::apm::flow_map(&cfg, query, limit, from, to, env).await?;
                 }
                 ApmActions::Troubleshooting { action } => match action {
                     ApmTroubleshootingActions::List {


### PR DESCRIPTION
## Summary

`pup apm flow-map` failed with HTTP 400 on every invocation because it sent `start`/`end` query parameters to an endpoint that requires `from`/`to`. While fixing that, `--env` turned out to be parsed and then silently discarded, so it is now applied.

## Changes

- Send `from`/`to` instead of `start`/`end` (src/commands/apm.rs:80). The endpoint rejected every request with `{"errors":[{"status":"400","title":"Missing Parameter","detail":"missing parameter \"from\" in \"query\""}]}`. The sibling `services_resources` on the same `/api/ui` namespace already used `from`/`to` correctly; flow-map was the outlier.
- Apply `--env` instead of dropping it (src/main.rs:16702). The routing arm destructured the field away with `..`, so the flag never reached the command. It is folded into the query as `env:<value>` (src/commands/apm.rs:83) rather than sent as a parameter, because the endpoint ignores a top-level `env=` — only a term inside `query` actually filters.
- Build the request with `raw_get`'s query-pairs argument instead of interpolating into the path (src/commands/apm.rs:88-97), so `query` is URL-encoded. This is required because the endpoint's `query` is span-search syntax: space-separated terms with an implicit AND, which is what env-folding produces. A comma-separated list is not accepted (`query=service:foo,env:production` returns `400 Invalid Parameter`). Encoding also fixes pre-existing breakage for any `--query` containing spaces or `&`.

## Testing

- Added three unit tests (src/commands/apm.rs:525, :559, :595) covering the parameters sent (`from`/`to`, not `start`/`end`), `--env` being folded into the query as `env:<value>`, and an unparseable `--from` returning an error rather than reaching the network.
- Confirmed the two behavioural tests are real regression tests by temporarily restoring the old `start`/`end` and dropped-`env` code: both fail against it (mockito returns 501 when the query matcher misses), then pass again once the fix is restored.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Full suite: 1854 passed, 6 failed. **All 6 failures are pre-existing and unrelated** — they fail identically on clean `main` with this change stashed: `commands::cases::tests::test_cases_timeline`, `commands::model_lab::tests::test_model_lab_runs_delete`, `commands::notebooks::tests::test_notebooks_edit_markdown_appends_to_content_endpoint`, `commands::security::tests::test_security_iocs_list_with_params`, `commands::tag_rules::tests::test_tag_rules_update`, `commands::users::tests::test_service_account_app_keys_list`.
- To verify by hand, against a real org: the command below returned HTTP 400 before this change and returns a flow map now. Swapping `--env production` for a nonexistent environment returns an empty graph, which confirms the flag reaches the API instead of being ignored.

```bash
pup apm flow-map --query "service:<some-service>" --env production
```
