### PR TITLE
chore(cost): remove deprecated OCI config command

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -237,7 +237,7 @@ pup infrastructure hosts list
 
 ### Cost & Usage
 - **usage** - Usage and billing (summary, hourly)
-- **costs** - Cost management: `datadog` subgroup (projected, attribution, by-org, aws-config, azure-config, gcp-config), `ccm` subgroup (custom-costs, tag-descriptions, tag-metadata, tags, tag-keys, budgets, commitments), `oci-configs` subgroup (list), and `anomalies` subgroup (list)
+- **costs** - Cost management: `datadog` subgroup (projected, attribution, by-org, aws-config, azure-config, gcp-config), `ccm` subgroup (custom-costs, tag-descriptions, tag-metadata, tags, tag-keys, budgets, commitments), and `anomalies` subgroup (list)
 
 ### Configuration & Data Management
 - **obs-pipelines** - Observability pipelines (list, get, create, update, diff, delete, validate)

--- a/src/commands/cost.rs
+++ b/src/commands/cost.rs
@@ -182,17 +182,6 @@ pub async fn gcp_config_delete(cfg: &Config, id: i64) -> Result<()> {
     Ok(())
 }
 
-// ---- Cloud Cost Management — OCI Configs ----
-
-pub async fn oci_configs_list(cfg: &Config) -> Result<()> {
-    let api = make_ccm_api(cfg);
-    let resp = api
-        .list_cost_oci_configs()
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to list OCI configs: {e:?}"))?;
-    formatter::output(cfg, &resp)
-}
-
 // ---- Cloud Cost Management — Anomalies ----
 
 pub async fn anomalies_list(cfg: &Config) -> Result<()> {
@@ -216,38 +205,6 @@ mod tests {
         let cfg = test_config(&s.url());
         mock_all(&mut s, r#"{"data": []}"#).await;
         let _ = super::projected(&cfg).await;
-        cleanup_env();
-    }
-
-    #[tokio::test]
-    async fn test_oci_configs_list() {
-        let _lock = lock_env().await;
-        let mut server = mockito::Server::new_async().await;
-        let cfg = test_config(&server.url());
-        let _mock = mock_any(&mut server, "GET", r#"{"data":[]}"#).await;
-        let result = super::oci_configs_list(&cfg).await;
-        assert!(
-            result.is_ok(),
-            "oci_configs_list failed: {:?}",
-            result.err()
-        );
-        cleanup_env();
-    }
-
-    #[tokio::test]
-    async fn test_oci_configs_list_error() {
-        let _lock = lock_env().await;
-        let mut server = mockito::Server::new_async().await;
-        let cfg = test_config(&server.url());
-        let _mock = server
-            .mock("GET", mockito::Matcher::Any)
-            .with_status(403)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"errors":["Forbidden"]}"#)
-            .create_async()
-            .await;
-        let result = super::oci_configs_list(&cfg).await;
-        assert!(result.is_err(), "expected error for 403 response");
         cleanup_env();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8646,12 +8646,6 @@ enum CostActions {
         #[command(subcommand)]
         action: CostCcmActions,
     },
-    /// Manage OCI (Oracle Cloud Infrastructure) cost configs
-    #[command(name = "oci-configs")]
-    OciConfigs {
-        #[command(subcommand)]
-        action: CostOciConfigsActions,
-    },
     /// Manage Cloud Cost Management anomalies
     Anomalies {
         #[command(subcommand)]
@@ -9083,13 +9077,6 @@ enum CostCcmCommitmentsActions {
         #[arg(long, help = "Tag filter (key:value syntax)")]
         filter_by: Option<String>,
     },
-}
-
-// ---- Cost OCI Configs ----
-#[derive(Subcommand)]
-enum CostOciConfigsActions {
-    /// List OCI cost configs
-    List,
 }
 
 // ---- Cost Anomalies ----
@@ -16709,9 +16696,6 @@ async fn main_inner() -> anyhow::Result<()> {
                             .await?;
                         }
                     },
-                },
-                CostActions::OciConfigs { action } => match action {
-                    CostOciConfigsActions::List => commands::cost::oci_configs_list(&cfg).await?,
                 },
                 CostActions::Anomalies { action } => match action {
                     CostAnomaliesActions::List => commands::cost::anomalies_list(&cfg).await?,


### PR DESCRIPTION
## Summary

Removes the dedicated `pup costs oci-configs list` command as the public OCI config endpoint begins deprecation.

[CCC-2277](https://datadoghq.atlassian.net/browse/CCC-2277)

## Changes

- remove the CLI registration and dispatch
- remove the command implementation and tests
- update the command reference
- keep generic `pup api` access while the backend route remains live

## Testing

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --quiet` — 1,881 passed; the same five `unused.local` DNS tests fail on the untouched baseline
- dedicated OCI command identifier search returns no matches

[CCC-2277]: https://datadoghq.atlassian.net/browse/CCC-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ