### PR TITLE
docs(output): list all supported formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ pup idp entities query 'kind:service AND owner:payments' \
 
 ## Global Flags
 
-- `-o, --output`: Output format (json, table, yaml) - default: json
+- `-o, --output`: Output format (`json`, `table`, `yaml`, `csv`, or `tsv`) — default: `json`
 - `-y, --yes`: Skip confirmation prompts for destructive operations
 
 ## Environment Variables

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -254,7 +254,7 @@ Available on all commands:
 ```bash
 --config string      Config file path (default: ~/.config/pup/config.yaml)
 --site string        Datadog site (default: datadoghq.com)
---output string      Output format: json, yaml, table (default: json)
+--output string      Output format: json, table, yaml, csv, tsv (default: json)
 --jq string          Filter/transform output with a jq expression (applied before formatting)
 --verbose            Enable verbose logging
 --yes                Skip confirmation prompts

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1239,6 +1239,12 @@ pup monitors list --output=yaml
 pup monitors list --output=table
 ```
 
+### CSV and TSV Output
+```bash
+pup monitors list --output=csv
+pup monitors list --output=tsv
+```
+
 ### Custom Fields
 ```bash
 pup monitors list --fields="id,name,type,status"

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ use std::io::IsTerminal;
 #[derive(Parser)]
 #[command(name = "pup", version = version::VERSION, about = "Datadog API CLI")]
 pub(crate) struct Cli {
-    /// Output format (json, table, yaml, csv). Defaults to json, or $DD_OUTPUT / $PUP_OUTPUT when set.
+    /// Output format (json, table, yaml, csv, tsv). Defaults to json, or $DD_OUTPUT / $PUP_OUTPUT when set.
     #[arg(short, long, global = true)]
     output: Option<String>,
     /// Auto-approve destructive operations
@@ -11591,7 +11591,7 @@ fn build_agent_schema_scoped(
                 "name": "--output",
                 "type": "string",
                 "default": "json",
-                "description": "Output format (json, table, yaml, csv)"
+                "description": "Output format (json, table, yaml, csv, tsv)"
             },
             {
                 "name": "--yes",
@@ -11720,7 +11720,7 @@ fn build_agent_schema(cmd: &clap::Command) -> serde_json::Value {
                 "name": "--output",
                 "type": "string",
                 "default": "json",
-                "description": "Output format (json, table, yaml, csv)"
+                "description": "Output format (json, table, yaml, csv, tsv)"
             },
             {
                 "name": "--yes",


### PR DESCRIPTION
## What does this PR do?

Pup already supports CSV and TSV output, but its help and documentation don’t consistently advertise them. This updates the CLI and agent-schema descriptions, aligns the README and command reference, and adds CSV/TSV examples.

## Motivation

Users shouldn’t have to inspect the implementation to discover valid output formats. Some descriptions currently omit TSV, while others omit both CSV and TSV, which makes supported behavior look unavailable.

## Additional Notes

### Testing

- `cargo test -- --test-threads=1` — 1,916 passed
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings -A clippy::needless_match`

### Blast Radius

Help text, agent-schema descriptions, and documentation only. Output parsing and formatting behavior are unchanged.

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->
