### PR TITLE
feat(table): render single resources vertically

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1239,6 +1239,8 @@ pup monitors list --output=yaml
 pup monitors list --output=table
 ```
 
+Single-resource responses use field/value rows, while collections remain horizontal.
+
 ### CSV and TSV Output
 ```bash
 pup monitors list --output=csv

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -236,6 +236,14 @@ pub fn eprint_formatted(
 }
 
 fn format_table_to_string(data: &serde_json::Value) -> Result<String> {
+    let table_data = unwrap_data(data);
+    if matches!(table_data, serde_json::Value::Object(_)) {
+        return format_vertical_table(table_data);
+    }
+    format_horizontal_table(table_data)
+}
+
+fn format_horizontal_table(data: &serde_json::Value) -> Result<String> {
     let raw_rows = extract_rows(data);
     let owned_rows: Vec<serde_json::Value> = raw_rows.iter().map(|r| flatten_row(r)).collect();
     let rows: Vec<&serde_json::Value> = owned_rows.iter().collect();
@@ -311,6 +319,23 @@ fn format_table_to_string(data: &serde_json::Value) -> Result<String> {
     Ok(table.to_string())
 }
 
+fn format_vertical_table(data: &serde_json::Value) -> Result<String> {
+    let flat = flatten_row(data);
+    let Some(fields) = flat.as_object() else {
+        return Ok("No results found".to_string());
+    };
+    if fields.is_empty() {
+        return Ok("No results found".to_string());
+    }
+
+    let mut table = comfy_table::Table::new();
+    table.set_header(["FIELD", "VALUE"]);
+    for (field, value) in fields {
+        table.add_row([field.clone(), format_cell(Some(value))]);
+    }
+    Ok(table.to_string())
+}
+
 fn print_yaml(data: &serde_json::Value) -> Result<()> {
     let sorted_data = sort_json_value(data.clone());
     let yaml = serde_norway::to_string(&sorted_data)?;
@@ -326,8 +351,16 @@ fn flatten_row(value: &serde_json::Value) -> serde_json::Value {
         let mut flat = serde_json::Map::new();
         for (k, v) in map {
             if let serde_json::Value::Object(inner) = v {
+                if inner.is_empty() {
+                    flat.insert(k.clone(), v.clone());
+                    continue;
+                }
                 for (ik, iv) in inner {
                     if let serde_json::Value::Object(inner2) = iv {
+                        if inner2.is_empty() {
+                            flat.insert(format!("{k}.{ik}"), iv.clone());
+                            continue;
+                        }
                         for (iik, iiv) in inner2 {
                             flat.insert(format!("{k}.{ik}.{iik}"), iiv.clone());
                         }
@@ -508,16 +541,17 @@ fn print_tsv(data: &serde_json::Value) -> Result<()> {
 /// Extract displayable rows from a JSON value.
 /// Handles: arrays, objects with "data" field, single objects.
 fn extract_rows(value: &serde_json::Value) -> Vec<&serde_json::Value> {
-    match value {
+    match unwrap_data(value) {
         serde_json::Value::Array(arr) => arr.iter().collect(),
-        serde_json::Value::Object(map) => {
-            // API responses often wrap data: { "data": [...], "meta": ... }
-            if let Some(data) = map.get("data") {
-                return extract_rows(data);
-            }
-            vec![value]
-        }
+        value @ serde_json::Value::Object(_) => vec![value],
         _ => vec![],
+    }
+}
+
+fn unwrap_data(value: &serde_json::Value) -> &serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => map.get("data").map(unwrap_data).unwrap_or(value),
+        _ => value,
     }
 }
 
@@ -789,6 +823,21 @@ mod tests {
     }
 
     #[test]
+    fn test_flatten_row_preserves_empty_objects() {
+        let row = serde_json::json!({
+            "attributes": {},
+            "relationships": {"notebook": {}}
+        });
+        let flat = flatten_row(&row);
+        let obj = flat.as_object().unwrap();
+        assert_eq!(obj.get("attributes"), Some(&serde_json::json!({})));
+        assert_eq!(
+            obj.get("relationships.notebook"),
+            Some(&serde_json::json!({}))
+        );
+    }
+
+    #[test]
     fn test_flatten_row_no_nested() {
         let row = serde_json::json!({"id": "abc", "name": "foo"});
         let flat = flatten_row(&row);
@@ -960,6 +1009,47 @@ mod tests {
         let data = serde_json::json!([{"id": 1, "name": "test"}]);
         let result = format_and_print(&data, &OutputFormat::Table, false, None, None);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_single_object_table_uses_vertical_layout() {
+        let data = serde_json::json!({"id": 42, "name": "api", "active": true});
+        let rendered = format_table_to_string(&data).unwrap();
+        assert!(rendered.contains("| FIELD  | VALUE |"));
+        assert!(rendered.contains("| id     | 42    |"));
+        assert!(rendered.contains("| name   | api   |"));
+        assert!(rendered.contains("| active | true  |"));
+    }
+
+    #[test]
+    fn test_data_wrapped_object_table_uses_vertical_layout() {
+        let data = serde_json::json!({"data": {"id": 42, "name": "api"}, "meta": {}});
+        let rendered = format_table_to_string(&data).unwrap();
+        assert!(rendered.contains("| FIELD | VALUE |"));
+        assert!(rendered.contains("| id    | 42    |"));
+        assert!(!rendered.contains("meta"));
+    }
+
+    #[test]
+    fn test_single_item_array_table_stays_horizontal() {
+        let data = serde_json::json!([{"id": 42, "name": "api"}]);
+        let rendered = format_table_to_string(&data).unwrap();
+        assert!(rendered.contains("| id | name |"));
+        assert!(!rendered.contains("| FIELD | VALUE |"));
+    }
+
+    #[test]
+    fn test_empty_object_table_has_no_results() {
+        assert_eq!(
+            format_table_to_string(&serde_json::json!({})).unwrap(),
+            "No results found"
+        );
+    }
+
+    #[test]
+    fn test_vertical_table_renders_empty_nested_object() {
+        let rendered = format_table_to_string(&serde_json::json!({"attributes": {}})).unwrap();
+        assert!(rendered.contains("| attributes | {0 fields} |"));
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Single-resource table responses now render as FIELD / VALUE rows. Collections—including one-item arrays—remain horizontal so list output keeps its existing semantics.

This also unwraps data envelopes before choosing a layout and preserves empty nested objects instead of silently dropping them during flattening.

## Motivation

Horizontal tables work well for comparing a collection of resources, but they get extremely wide when a single resource turns every field into another column. A vertical layout is much easier to scan and makes better use of normal terminal dimensions.

### Before

<img width="1800" height="330" alt="image" src="https://github.com/user-attachments/assets/47106348-f44b-4368-a7aa-b4d41bf09e8d" />

### After

<img width="1040" height="920" alt="image" src="https://github.com/user-attachments/assets/de9f599d-56f7-4f3d-8629-c0d34eed4ed1" />


## Additional Notes

### Testing

- `cargo test -- --test-threads=1 — 1,922 passed`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings -A clippy::needless_match`
- Unit coverage for plain objects, data-wrapped objects, one-item arrays, empty objects, and empty nested objects

### Blast Radius

`--output` table when the effective response payload is a single object. Array responses remain horizontal, and other output formats are unchanged.

## Checklist

- [ ] The code change follows the project conventions (see [CONTRIBUTING.md](../docs/CONTRIBUTING.md))
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] All CI checks pass
- [ ] Code coverage is maintained or improved

## Related Issues

<!-- Link related issues here. Use "Closes #123" to automatically close issues when the PR is merged. -->
