### PR TITLE
feat(llm-obs): export annotated interaction data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ dependencies = [
  "shell-words",
  "ssh-key 0.6.7",
  "tar",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ native = [
     "dep:uuid",
     "dep:chrono",
     "dep:regex",
+    "dep:tempfile",
     "dep:clap",
     "dep:clap_complete",
     "tokio/full",
@@ -53,6 +54,7 @@ wasi = [
     "dep:uuid",
     "dep:chrono",
     "dep:regex",
+    "dep:tempfile",
     "dep:clap",
     "dep:clap_complete",
     "tokio/rt",
@@ -93,6 +95,7 @@ http = "1"
 
 # Error handling
 anyhow = "1"
+tempfile = { version = "3", optional = true }
 
 # POSIX shell word splitting (used for alias expansion)
 shell-words = "1"

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -66,7 +66,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | data-deletion | requests (list, create, cancel) | src/commands/data_deletion.rs | ✅ |
 | data-governance | scanner-rules (list) | src/commands/data_governance.rs | ✅ |
 | obs-pipelines | list, get, create, update, diff, delete, validate | src/commands/obs_pipelines.rs | ✅ |
-| llm-obs | projects (create, list), experiments (create, list, update, delete, summary, events (list, get, submit), metric-values, dimension-values), datasets (create, list, batch-update, clone, restore, records, records-add, records-all, records-full), spans (search), patterns (configs (list, get), runs (list, status), topics, topics-with-points, points), agent-insights (list, get, update-status, submit-feedback), annotation-queues (create, list, update, delete, interactions (add, delete, list), schema (get, update), annotations (upsert, delete)), model-pricing | src/commands/llm_obs.rs | ✅ |
+| llm-obs | projects (create, list), experiments (create, list, update, delete, summary, events (list, get, submit), metric-values, dimension-values), datasets (create, list, batch-update, clone, restore, records, records-add, records-all, records-full), spans (search), patterns (configs (list, get), runs (list, status), topics, topics-with-points, points), agent-insights (list, get, update-status, submit-feedback), annotations (export), annotation-queues (create, list, update, delete, interactions (add, delete, list), schema (get, update), annotations (upsert, delete)), model-pricing | src/commands/llm_obs.rs | ✅ |
 | reference-tables | list, get, create, batch-query | src/commands/reference_tables.rs | ✅ |
 | network | flows list, devices (list, get, interfaces, tags), interfaces (list, update) | src/commands/network.rs | ✅ |
 | cloud | aws, gcp, azure, oci | src/commands/cloud.rs | ✅ |
@@ -93,6 +93,18 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 **Profiling note:** `pup profiling` has no subcommands yet. Use the Datadog MCP server instead: https://docs.datadoghq.com/bits_ai/mcp_server. Enable profiling in the MCP toolset with: https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core,profiling
 
 ## Common Patterns
+
+### Export an LLM Observability annotated interaction
+
+Export one annotation together with all event data for its trace, span, experiment trace, or session. `--queue` accepts either the queue ID or its exact name. The command writes JSONL by default and refuses to replace an existing file unless `--force` is provided.
+
+```bash
+pup llm-obs annotations export \
+  --queue quality-review \
+  --interaction-id 23851556-a8c7-41c1-be75-03eb665a132f \
+  --format jsonl \
+  --out interaction.jsonl
+```
 
 ### List Operations
 ```bash

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -96,7 +96,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 
 ### Export an LLM Observability annotated interaction
 
-Export one annotation together with all event data for its trace, span, experiment trace, or session. `--queue` accepts either the queue ID or its exact name. The command writes JSONL by default and refuses to replace an existing file unless `--force` is provided.
+Export one annotation together with all event data for its trace, span, experiment trace, or session. `--queue` accepts either the queue ID or its exact name. Without `--out`, the command uses Pup's standard output formatter (JSON by default) and honors global `--output` and `--jq` flags. File exports default to JSON; pass `--format jsonl` for JSONL. Existing files are not replaced unless `--force` is provided.
 
 ```bash
 pup llm-obs annotations export \

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -96,7 +96,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 
 ### Export an LLM Observability annotated interaction
 
-Export one annotation together with all event data for its trace, span, experiment trace, or session. `--queue` accepts either the queue ID or its exact name. Without `--out`, the command uses Pup's standard output formatter (JSON by default) and honors global `--output` and `--jq` flags. File exports default to JSON; pass `--format jsonl` for JSONL. Existing files are not replaced unless `--force` is provided.
+Export one annotation together with its complete interaction data. Event-backed interactions are fetched across every cursor page, while stored-content interactions retain their `content` payload. `--queue` accepts either the queue ID or its exact name. Without `--out`, the command uses Pup's standard output formatter (JSON by default) and honors global `--output` and `--jq` flags. File exports default to JSON; pass `--format jsonl` for JSONL. Existing files are not replaced unless `--force` is provided. Use repeatable `--header KEY:VALUE` / `-H KEY:VALUE` flags for request-routing headers such as Rapid test drives.
 
 ```bash
 pup llm-obs annotations export \

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -26,6 +26,28 @@ export DD_APP_KEY="your-app-key"
 export DD_SITE="datadoghq.com"
 ```
 
+## LLM Observability
+
+### Export an Annotated Interaction
+```bash
+# Print the annotation and complete interaction data as JSON
+pup llm-obs annotations export \
+  --queue quality-review \
+  --interaction-id 23851556-a8c7-41c1-be75-03eb665a132f
+
+# Select part of the standard JSON output
+pup --jq '.interaction_data.events' llm-obs annotations export \
+  --queue 13851556-a8c7-41c1-be75-03eb665a132f \
+  --interaction-id 23851556-a8c7-41c1-be75-03eb665a132f
+
+# Write JSONL to a file; --force is required to replace an existing file
+pup llm-obs annotations export \
+  --queue quality-review \
+  --interaction-id 23851556-a8c7-41c1-be75-03eb665a132f \
+  --out interaction.jsonl \
+  --format jsonl
+```
+
 ## Metrics
 
 ### List Metrics

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -46,6 +46,12 @@ pup llm-obs annotations export \
   --interaction-id 23851556-a8c7-41c1-be75-03eb665a132f \
   --out interaction.jsonl \
   --format jsonl
+
+# Route every queue lookup and pagination request through a Rapid test drive
+pup llm-obs annotations export \
+  --queue 13851556-a8c7-41c1-be75-03eb665a132f \
+  --interaction-id 23851556-a8c7-41c1-be75-03eb665a132f \
+  --header 'test-drive-scion-s60: 1'
 ```
 
 ## Metrics

--- a/skills/dd-pup/SKILL.md
+++ b/skills/dd-pup/SKILL.md
@@ -249,6 +249,7 @@ pup llm-obs experiments update <experiment-id> --file experiment.json
 pup llm-obs experiments delete --file delete-request.json
 pup llm-obs datasets list --project-id <project-id>
 pup llm-obs datasets create --project-id <project-id> --file dataset.json
+pup llm-obs annotations export --queue <queue-id-or-name> --interaction-id <interaction-id>
 ```
 
 ### Reference Tables
@@ -324,4 +325,3 @@ pup auth status
 | EU1 | `datadoghq.eu` |
 | AP1 | `ap1.datadoghq.com` |
 | US1-FED | `ddog-gov.com` |
-

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -14,7 +14,7 @@ fn parse_kv(s: &str) -> Result<(String, String)> {
 }
 
 /// Parse `key:value` into (key, value). Splits on the first `:` only.
-fn parse_header_str(s: &str) -> Result<(String, String)> {
+pub(crate) fn parse_header_str(s: &str) -> Result<(String, String)> {
     let pos = s
         .find(':')
         .ok_or_else(|| anyhow::anyhow!("expected KEY:VALUE, got {s:?}"))?;

--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -16,6 +16,11 @@ use crate::raw_client;
 use crate::util;
 use crate::util_ext;
 
+use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
 fn make_api(cfg: &Config) -> AgentObservabilityAPI {
     crate::make_api!(AgentObservabilityAPI, cfg)
 }
@@ -594,6 +599,233 @@ pub async fn annotation_queue_interactions_list(cfg: &Config, queue_id: &str) ->
         .await
         .map_err(|e| anyhow::anyhow!("failed to list annotated interactions: {e:?}"))?;
     formatter::output(cfg, &resp)
+}
+
+const ANNOTATED_INTERACTION_DATA_PAGE_SIZE: &str = "500";
+
+#[derive(Debug, serde::Deserialize)]
+struct AnnotatedInteractionDataPage {
+    annotated_interaction: serde_json::Value,
+    interaction_data: InteractionDataPage,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct InteractionDataPage {
+    #[serde(rename = "type")]
+    interaction_type: String,
+    events: Vec<serde_json::Value>,
+    #[serde(default)]
+    next_cursor: Option<String>,
+}
+
+fn parse_annotated_interaction_data_page(
+    response: serde_json::Value,
+) -> Result<AnnotatedInteractionDataPage> {
+    let attributes = response
+        .get("data")
+        .and_then(|data| data.get("attributes"))
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("response is missing data.attributes"))?;
+    serde_json::from_value(attributes)
+        .map_err(|e| anyhow::anyhow!("invalid annotated interaction response: {e}"))
+}
+
+async fn resolve_annotation_queue_id(cfg: &Config, queue: &str) -> Result<String> {
+    if uuid::Uuid::parse_str(queue).is_ok() {
+        return Ok(queue.to_string());
+    }
+    if queue.is_empty() {
+        anyhow::bail!("--queue cannot be empty");
+    }
+
+    let response = raw_client::raw_get(cfg, "/api/v2/llm-obs/v1/annotation-queues", &[])
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to resolve annotation queue '{queue}': {e:?}"))?;
+    let queues = response
+        .get("data")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("annotation queue list response is missing data"))?;
+
+    let matching_ids: Vec<&str> = queues
+        .iter()
+        .filter(|item| {
+            item.pointer("/attributes/name")
+                .and_then(serde_json::Value::as_str)
+                == Some(queue)
+        })
+        .filter_map(|item| {
+            item.pointer("/attributes/queue_id")
+                .and_then(serde_json::Value::as_str)
+                .or_else(|| item.get("id").and_then(serde_json::Value::as_str))
+        })
+        .collect();
+
+    match matching_ids.as_slice() {
+        [queue_id] if uuid::Uuid::parse_str(queue_id).is_ok() => Ok((*queue_id).to_string()),
+        [_] => anyhow::bail!("annotation queue '{queue}' returned an invalid queue ID"),
+        [] => anyhow::bail!("no annotation queue found with exact name '{queue}'"),
+        _ => anyhow::bail!(
+            "multiple annotation queues are named '{queue}'; pass the queue ID instead"
+        ),
+    }
+}
+
+async fn fetch_annotated_interaction_export(
+    cfg: &Config,
+    queue_id: &str,
+    interaction_id: &str,
+) -> Result<serde_json::Value> {
+    let path = format!(
+        "/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotated-interactions/{interaction_id}"
+    );
+    let mut cursor: Option<String> = None;
+    let mut seen_cursors = HashSet::new();
+    let mut annotated_interaction: Option<serde_json::Value> = None;
+    let mut interaction_type: Option<String> = None;
+    let mut events = Vec::new();
+
+    loop {
+        let mut query = vec![("limit", ANNOTATED_INTERACTION_DATA_PAGE_SIZE)];
+        if let Some(ref value) = cursor {
+            query.push(("cursor", value.as_str()));
+        }
+        let response = raw_client::raw_get(cfg, &path, &query)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to fetch annotated interaction data: {e:?}"))?;
+        let page = parse_annotated_interaction_data_page(response)?;
+
+        if let Some(existing) = &annotated_interaction {
+            if existing != &page.annotated_interaction {
+                anyhow::bail!("annotated interaction changed while the export was being fetched");
+            }
+        } else {
+            annotated_interaction = Some(page.annotated_interaction);
+        }
+        if let Some(existing) = &interaction_type {
+            if existing != &page.interaction_data.interaction_type {
+                anyhow::bail!("interaction type changed while the export was being fetched");
+            }
+        } else {
+            interaction_type = Some(page.interaction_data.interaction_type);
+        }
+
+        events.extend(page.interaction_data.events);
+        let Some(next_cursor) = page
+            .interaction_data
+            .next_cursor
+            .filter(|value| !value.is_empty())
+        else {
+            break;
+        };
+        if !seen_cursors.insert(next_cursor.clone()) {
+            anyhow::bail!("the server returned a repeated pagination cursor");
+        }
+        cursor = Some(next_cursor);
+    }
+
+    Ok(serde_json::json!({
+        "annotated_interaction": annotated_interaction
+            .ok_or_else(|| anyhow::anyhow!("response did not contain an annotated interaction"))?,
+        "interaction_data": {
+            "type": interaction_type
+                .ok_or_else(|| anyhow::anyhow!("response did not contain an interaction type"))?,
+            "events": events,
+        },
+    }))
+}
+
+fn serialize_annotation_export(value: &serde_json::Value, format: &str) -> Result<Vec<u8>> {
+    let mut bytes = match format {
+        "json" => serde_json::to_vec_pretty(value)?,
+        "jsonl" => serde_json::to_vec(value)?,
+        _ => anyhow::bail!("unsupported export format '{format}'"),
+    };
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn temporary_export_path(path: &Path, attempt: u8) -> Result<PathBuf> {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow::anyhow!("output path must name a file"))?;
+    Ok(path.with_file_name(format!(".{name}.pup-{}-{attempt}.tmp", std::process::id())))
+}
+
+fn write_annotation_export(path: &Path, bytes: &[u8], force: bool) -> Result<()> {
+    if path.exists() && !force {
+        anyhow::bail!(
+            "output file '{}' already exists; pass --force to overwrite it",
+            path.display()
+        );
+    }
+
+    let mut temporary = None;
+    for attempt in 0..100 {
+        let candidate = temporary_export_path(path, attempt)?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&candidate) {
+            Ok(file) => {
+                temporary = Some((candidate, file));
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "failed to create export beside '{}': {error}",
+                    path.display()
+                ))
+            }
+        }
+    }
+    let (temporary_path, mut file) =
+        temporary.ok_or_else(|| anyhow::anyhow!("could not allocate a temporary export file"))?;
+
+    let result = (|| -> Result<()> {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        #[cfg(windows)]
+        if force && path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        std::fs::rename(&temporary_path, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary_path);
+    }
+    result.map_err(|e| anyhow::anyhow!("failed to write export '{}': {e}", path.display()))
+}
+
+pub async fn annotations_export(
+    cfg: &Config,
+    queue: &str,
+    interaction_id: &str,
+    format: &str,
+    out: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    if uuid::Uuid::parse_str(interaction_id).is_err() {
+        anyhow::bail!("--interaction-id must be a UUID");
+    }
+    let queue_id = resolve_annotation_queue_id(cfg, queue).await?;
+    let export = fetch_annotated_interaction_export(cfg, &queue_id, interaction_id).await?;
+    let bytes = serialize_annotation_export(&export, format)?;
+
+    if let Some(path) = out {
+        write_annotation_export(Path::new(path), &bytes, force)?;
+        eprintln!("Exported annotated interaction to {path}");
+    } else {
+        std::io::stdout().write_all(&bytes)?;
+    }
+    Ok(())
 }
 
 /// Uses the raw client rather than the typed one: a queue with no schema yet answers with
@@ -1444,6 +1676,221 @@ mod tests {
         );
         cleanup_env();
         std::env::remove_var("DD_TOKEN_STORAGE");
+    }
+
+    #[tokio::test]
+    async fn test_annotations_export_fetches_all_pages() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let queue_id = "13851556-a8c7-41c1-be75-03eb665a132f";
+        let interaction_id = "23851556-a8c7-41c1-be75-03eb665a132f";
+        let path = format!(
+            "/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotated-interactions/{interaction_id}"
+        );
+        let annotated_interaction = serde_json::json!({
+            "interaction_id": interaction_id,
+            "queue_id": queue_id,
+            "queue_name": "quality-review",
+            "can_annotate": true,
+            "annotations": [{"label": "quality", "value": "good"}],
+        });
+        let first_body = serde_json::json!({
+            "data": {
+                "id": interaction_id,
+                "type": "annotated_interaction_data",
+                "attributes": {
+                    "annotated_interaction": annotated_interaction,
+                    "interaction_data": {
+                        "type": "session",
+                        "events": [{"content": {"span_id": "span-1"}}],
+                        "next_cursor": "cursor-1",
+                    }
+                }
+            }
+        });
+        let second_body = serde_json::json!({
+            "data": {
+                "id": interaction_id,
+                "type": "annotated_interaction_data",
+                "attributes": {
+                    "annotated_interaction": annotated_interaction,
+                    "interaction_data": {
+                        "type": "session",
+                        "events": [{"content": {"span_id": "span-2", "expected_output": "ok"}}]
+                    }
+                }
+            }
+        });
+        let _first = server
+            .mock("GET", path.as_str())
+            .match_query(mockito::Matcher::Exact("limit=500".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(first_body.to_string())
+            .create_async()
+            .await;
+        let _second = server
+            .mock("GET", path.as_str())
+            .match_query(mockito::Matcher::Exact("limit=500&cursor=cursor-1".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(second_body.to_string())
+            .create_async()
+            .await;
+
+        let export = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id)
+            .await
+            .expect("multi-page export should succeed");
+
+        assert_eq!(export["annotated_interaction"], annotated_interaction);
+        assert_eq!(export["interaction_data"]["type"], "session");
+        assert_eq!(
+            export["interaction_data"]["events"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            export["interaction_data"]["events"][1]["content"]["expected_output"],
+            "ok"
+        );
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_export_resolves_exact_queue_name() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let queue_id = "13851556-a8c7-41c1-be75-03eb665a132f";
+        let interaction_id = "23851556-a8c7-41c1-be75-03eb665a132f";
+        let _queues = server
+            .mock("GET", "/api/v2/llm-obs/v1/annotation-queues")
+            .match_query(mockito::Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "data": [{
+                        "id": queue_id,
+                        "type": "queues",
+                        "attributes": {"queue_id": queue_id, "name": "quality-review"}
+                    }]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let interaction_path = format!(
+            "/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotated-interactions/{interaction_id}"
+        );
+        let _interaction = server
+            .mock("GET", interaction_path.as_str())
+            .match_query(mockito::Matcher::Exact("limit=500".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "data": {"attributes": {
+                        "annotated_interaction": {"interaction_id": interaction_id},
+                        "interaction_data": {"type": "experiment_trace", "events": []}
+                    }}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let temp = TempDir::new("annotation_export");
+        let output = temp.path().join("interaction.jsonl");
+
+        super::annotations_export(
+            &cfg,
+            "quality-review",
+            interaction_id,
+            "jsonl",
+            output.to_str(),
+            false,
+        )
+        .await
+        .expect("named queue export should succeed");
+
+        let exported: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(output).expect("export should be readable"),
+        )
+        .expect("export should contain JSON");
+        assert_eq!(exported["interaction_data"]["type"], "experiment_trace");
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_export_rejects_repeated_cursor() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let queue_id = "13851556-a8c7-41c1-be75-03eb665a132f";
+        let interaction_id = "23851556-a8c7-41c1-be75-03eb665a132f";
+        let path = format!(
+            "/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotated-interactions/{interaction_id}"
+        );
+        let body = serde_json::json!({
+            "data": {"attributes": {
+                "annotated_interaction": {"interaction_id": interaction_id},
+                "interaction_data": {
+                    "type": "trace",
+                    "events": [],
+                    "next_cursor": "same-cursor"
+                }
+            }}
+        });
+        let _first = server
+            .mock("GET", path.as_str())
+            .match_query(mockito::Matcher::Exact("limit=500".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body.to_string())
+            .create_async()
+            .await;
+        let _second = server
+            .mock("GET", path.as_str())
+            .match_query(mockito::Matcher::Exact(
+                "limit=500&cursor=same-cursor".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body.to_string())
+            .create_async()
+            .await;
+
+        let error = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id)
+            .await
+            .expect_err("repeated cursor should fail");
+        assert!(error.to_string().contains("repeated pagination cursor"));
+        cleanup_env();
+    }
+
+    #[test]
+    fn test_annotation_export_refuses_overwrite_without_force() {
+        let temp = TempDir::new("annotation_export_overwrite");
+        let output = temp.path().join("interaction.jsonl");
+        std::fs::write(&output, b"existing\n").unwrap();
+
+        let error = super::write_annotation_export(&output, b"replacement\n", false)
+            .expect_err("existing output should be protected");
+
+        assert!(error.to_string().contains("--force"));
+        assert_eq!(std::fs::read(&output).unwrap(), b"existing\n");
+        super::write_annotation_export(&output, b"replacement\n", true)
+            .expect("--force should replace the output");
+        assert_eq!(std::fs::read(&output).unwrap(), b"replacement\n");
+    }
+
+    #[test]
+    fn test_parse_annotated_interaction_data_page_rejects_missing_attributes() {
+        let error = super::parse_annotated_interaction_data_page(serde_json::json!({"data": {}}))
+            .expect_err("missing attributes should fail");
+        assert!(error.to_string().contains("data.attributes"));
     }
 
     #[tokio::test]

--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -630,17 +630,7 @@ fn parse_annotated_interaction_data_page(
         .map_err(|e| anyhow::anyhow!("invalid annotated interaction response: {e}"))
 }
 
-async fn resolve_annotation_queue_id(cfg: &Config, queue: &str) -> Result<String> {
-    if uuid::Uuid::parse_str(queue).is_ok() {
-        return Ok(queue.to_string());
-    }
-    if queue.is_empty() {
-        anyhow::bail!("--queue cannot be empty");
-    }
-
-    let response = raw_client::raw_get(cfg, "/api/v2/llm-obs/v1/annotation-queues", &[])
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to resolve annotation queue '{queue}': {e:?}"))?;
+fn select_annotation_queue_id(response: &serde_json::Value, queue: &str) -> Result<String> {
     let queues = response
         .get("data")
         .and_then(serde_json::Value::as_array)
@@ -670,6 +660,52 @@ async fn resolve_annotation_queue_id(cfg: &Config, queue: &str) -> Result<String
     }
 }
 
+async fn resolve_annotation_queue_id(cfg: &Config, queue: &str) -> Result<String> {
+    if uuid::Uuid::parse_str(queue).is_ok() {
+        return Ok(queue.to_string());
+    }
+    if queue.is_empty() {
+        anyhow::bail!("--queue cannot be empty");
+    }
+
+    let response = raw_client::raw_get(cfg, "/api/v2/llm-obs/v1/annotation-queues", &[])
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to resolve annotation queue '{queue}'; ensure the caller has the llm_observability_read scope and access to the queue: {e:?}"
+            )
+        })?;
+    select_annotation_queue_id(&response, queue)
+}
+
+fn merge_annotated_interaction_page(
+    annotated_interaction: &mut Option<serde_json::Value>,
+    interaction_type: &mut Option<String>,
+    events: &mut Vec<serde_json::Value>,
+    page: AnnotatedInteractionDataPage,
+) -> Result<Option<String>> {
+    if let Some(existing) = annotated_interaction.as_ref() {
+        if existing != &page.annotated_interaction {
+            anyhow::bail!("annotated interaction changed while the export was being fetched");
+        }
+    } else {
+        *annotated_interaction = Some(page.annotated_interaction);
+    }
+    if let Some(existing) = interaction_type.as_ref() {
+        if existing != &page.interaction_data.interaction_type {
+            anyhow::bail!("interaction type changed while the export was being fetched");
+        }
+    } else {
+        *interaction_type = Some(page.interaction_data.interaction_type);
+    }
+
+    events.extend(page.interaction_data.events);
+    Ok(page
+        .interaction_data
+        .next_cursor
+        .filter(|value| !value.is_empty()))
+}
+
 async fn fetch_annotated_interaction_export(
     cfg: &Config,
     queue_id: &str,
@@ -691,29 +727,18 @@ async fn fetch_annotated_interaction_export(
         }
         let response = raw_client::raw_get(cfg, &path, &query)
             .await
-            .map_err(|e| anyhow::anyhow!("failed to fetch annotated interaction data: {e:?}"))?;
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to fetch annotated interaction data; ensure the caller has the llm_observability_read scope and access to the queue: {e:?}"
+                )
+            })?;
         let page = parse_annotated_interaction_data_page(response)?;
-
-        if let Some(existing) = &annotated_interaction {
-            if existing != &page.annotated_interaction {
-                anyhow::bail!("annotated interaction changed while the export was being fetched");
-            }
-        } else {
-            annotated_interaction = Some(page.annotated_interaction);
-        }
-        if let Some(existing) = &interaction_type {
-            if existing != &page.interaction_data.interaction_type {
-                anyhow::bail!("interaction type changed while the export was being fetched");
-            }
-        } else {
-            interaction_type = Some(page.interaction_data.interaction_type);
-        }
-
-        events.extend(page.interaction_data.events);
-        let Some(next_cursor) = page
-            .interaction_data
-            .next_cursor
-            .filter(|value| !value.is_empty())
+        let Some(next_cursor) = merge_annotated_interaction_page(
+            &mut annotated_interaction,
+            &mut interaction_type,
+            &mut events,
+            page,
+        )?
         else {
             break;
         };
@@ -732,6 +757,22 @@ async fn fetch_annotated_interaction_export(
             "events": events,
         },
     }))
+}
+
+fn output_annotation_export(
+    cfg: &Config,
+    export: &serde_json::Value,
+    format: Option<&str>,
+    out: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    if let Some(path) = out {
+        let bytes = serialize_annotation_export(export, format.unwrap_or("json"))?;
+        write_annotation_export(Path::new(path), &bytes, force)?;
+        eprintln!("Exported annotated interaction to {path}");
+        return Ok(());
+    }
+    formatter::output(cfg, export)
 }
 
 fn serialize_annotation_export(value: &serde_json::Value, format: &str) -> Result<Vec<u8>> {
@@ -808,7 +849,7 @@ pub async fn annotations_export(
     cfg: &Config,
     queue: &str,
     interaction_id: &str,
-    format: &str,
+    format: Option<&str>,
     out: Option<&str>,
     force: bool,
 ) -> Result<()> {
@@ -817,15 +858,8 @@ pub async fn annotations_export(
     }
     let queue_id = resolve_annotation_queue_id(cfg, queue).await?;
     let export = fetch_annotated_interaction_export(cfg, &queue_id, interaction_id).await?;
-    let bytes = serialize_annotation_export(&export, format)?;
 
-    if let Some(path) = out {
-        write_annotation_export(Path::new(path), &bytes, force)?;
-        eprintln!("Exported annotated interaction to {path}");
-    } else {
-        std::io::stdout().write_all(&bytes)?;
-    }
-    Ok(())
+    output_annotation_export(cfg, &export, format, out, force)
 }
 
 /// Uses the raw client rather than the typed one: a queue with no schema yet answers with
@@ -1809,7 +1843,7 @@ mod tests {
             &cfg,
             "quality-review",
             interaction_id,
-            "jsonl",
+            Some("jsonl"),
             output.to_str(),
             false,
         )
@@ -1891,6 +1925,190 @@ mod tests {
         let error = super::parse_annotated_interaction_data_page(serde_json::json!({"data": {}}))
             .expect_err("missing attributes should fail");
         assert!(error.to_string().contains("data.attributes"));
+    }
+
+    #[test]
+    fn test_select_annotation_queue_id_rejects_invalid_queue_responses() {
+        let missing_data = super::select_annotation_queue_id(&serde_json::json!({}), "review")
+            .expect_err("missing data should fail");
+        assert!(missing_data.to_string().contains("missing data"));
+
+        let not_found =
+            super::select_annotation_queue_id(&serde_json::json!({"data": []}), "review")
+                .expect_err("unknown queue should fail");
+        assert!(not_found.to_string().contains("no annotation queue"));
+
+        let invalid_id = super::select_annotation_queue_id(
+            &serde_json::json!({"data": [{
+                "id": "not-a-uuid",
+                "attributes": {"name": "review"}
+            }]}),
+            "review",
+        )
+        .expect_err("invalid queue ID should fail");
+        assert!(invalid_id.to_string().contains("invalid queue ID"));
+
+        let duplicate = super::select_annotation_queue_id(
+            &serde_json::json!({"data": [
+                {"id": "13851556-a8c7-41c1-be75-03eb665a132f", "attributes": {"name": "review"}},
+                {"id": "23851556-a8c7-41c1-be75-03eb665a132f", "attributes": {"name": "review"}}
+            ]}),
+            "review",
+        )
+        .expect_err("duplicate queue names should fail");
+        assert!(duplicate.to_string().contains("multiple annotation queues"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_annotation_queue_id_rejects_empty_name() {
+        let cfg = test_config("http://unused.local");
+        let error = super::resolve_annotation_queue_id(&cfg, "")
+            .await
+            .expect_err("empty queue name should fail before a request");
+        assert!(error.to_string().contains("--queue cannot be empty"));
+    }
+
+    #[test]
+    fn test_merge_annotated_interaction_page_rejects_changes_between_pages() {
+        let mut annotation = Some(serde_json::json!({"interaction_id": "one"}));
+        let mut interaction_type = Some("trace".to_string());
+        let mut events = Vec::new();
+        let changed_annotation = super::AnnotatedInteractionDataPage {
+            annotated_interaction: serde_json::json!({"interaction_id": "two"}),
+            interaction_data: super::InteractionDataPage {
+                interaction_type: "trace".to_string(),
+                events: vec![],
+                next_cursor: None,
+            },
+        };
+        let error = super::merge_annotated_interaction_page(
+            &mut annotation,
+            &mut interaction_type,
+            &mut events,
+            changed_annotation,
+        )
+        .expect_err("changed annotation should fail");
+        assert!(error.to_string().contains("annotated interaction changed"));
+
+        let changed_type = super::AnnotatedInteractionDataPage {
+            annotated_interaction: serde_json::json!({"interaction_id": "one"}),
+            interaction_data: super::InteractionDataPage {
+                interaction_type: "session".to_string(),
+                events: vec![],
+                next_cursor: None,
+            },
+        };
+        let error = super::merge_annotated_interaction_page(
+            &mut annotation,
+            &mut interaction_type,
+            &mut events,
+            changed_type,
+        )
+        .expect_err("changed interaction type should fail");
+        assert!(error.to_string().contains("interaction type changed"));
+    }
+
+    #[test]
+    fn test_annotation_export_output_honors_standard_jq_filter() {
+        let mut cfg = test_config("http://unused.local");
+        cfg.jq = Some("[".to_string());
+        let error = super::output_annotation_export(
+            &cfg,
+            &serde_json::json!({"interaction_data": {"events": []}}),
+            None,
+            None,
+            false,
+        )
+        .expect_err("invalid global jq filter should be applied and rejected");
+        assert!(error.to_string().contains("jq"));
+    }
+
+    #[test]
+    fn test_annotation_export_rejects_unsupported_file_format() {
+        let error = super::serialize_annotation_export(&serde_json::json!({}), "yaml")
+            .expect_err("unsupported file format should fail");
+        assert!(error.to_string().contains("unsupported export format"));
+    }
+
+    #[test]
+    fn test_annotation_export_rejects_path_without_file_name() {
+        let error = super::temporary_export_path(std::path::Path::new("/"), 0)
+            .expect_err("directory path should fail");
+        assert!(error.to_string().contains("must name a file"));
+    }
+
+    #[test]
+    fn test_annotation_export_file_defaults_to_json() {
+        let cfg = test_config("http://unused.local");
+        let temp = TempDir::new("annotation_export_default_json");
+        let output = temp.path().join("interaction.json");
+        super::output_annotation_export(
+            &cfg,
+            &serde_json::json!({"interaction_data": {"events": []}}),
+            None,
+            output.to_str(),
+            false,
+        )
+        .expect("file export should default to JSON");
+        let contents = std::fs::read_to_string(output).expect("export should be readable");
+        assert!(
+            contents.starts_with("{\n"),
+            "JSON export should be pretty-printed"
+        );
+    }
+
+    #[test]
+    fn test_annotation_export_reports_file_creation_failure() {
+        let temp = TempDir::new("annotation_export_missing_parent");
+        let output = temp.path().join("missing").join("interaction.json");
+        let error = super::write_annotation_export(&output, b"{}\n", false)
+            .expect_err("missing parent directory should fail");
+        assert!(error.to_string().contains("failed to create export"));
+    }
+
+    #[tokio::test]
+    async fn test_annotation_export_api_error_names_required_scope() {
+        let _lock = lock_env().await;
+        let mut server = mockito::Server::new_async().await;
+        let cfg = test_config(&server.url());
+        let queue_id = "13851556-a8c7-41c1-be75-03eb665a132f";
+        let interaction_id = "23851556-a8c7-41c1-be75-03eb665a132f";
+        let path = format!(
+            "/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotated-interactions/{interaction_id}"
+        );
+        let _request = server
+            .mock("GET", path.as_str())
+            .match_query(mockito::Matcher::Exact("limit=500".into()))
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"errors":["forbidden"]}"#)
+            .create_async()
+            .await;
+
+        let error = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id)
+            .await
+            .expect_err("API rejection should include remediation");
+        assert!(error.to_string().contains("llm_observability_read"));
+        assert!(error.to_string().contains("access to the queue"));
+        cleanup_env();
+    }
+
+    #[tokio::test]
+    async fn test_annotations_export_rejects_invalid_interaction_id() {
+        let cfg = test_config("http://unused.local");
+        let error = super::annotations_export(
+            &cfg,
+            "13851556-a8c7-41c1-be75-03eb665a132f",
+            "not-a-uuid",
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect_err("invalid interaction ID should fail before a request");
+        assert!(error
+            .to_string()
+            .contains("--interaction-id must be a UUID"));
     }
 
     #[tokio::test]

--- a/src/commands/llm_obs.rs
+++ b/src/commands/llm_obs.rs
@@ -17,9 +17,8 @@ use crate::util;
 use crate::util_ext;
 
 use std::collections::HashSet;
-use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 fn make_api(cfg: &Config) -> AgentObservabilityAPI {
     crate::make_api!(AgentObservabilityAPI, cfg)
@@ -615,6 +614,8 @@ struct InteractionDataPage {
     interaction_type: String,
     events: Vec<serde_json::Value>,
     #[serde(default)]
+    content: Option<serde_json::Value>,
+    #[serde(default)]
     next_cursor: Option<String>,
 }
 
@@ -660,7 +661,11 @@ fn select_annotation_queue_id(response: &serde_json::Value, queue: &str) -> Resu
     }
 }
 
-async fn resolve_annotation_queue_id(cfg: &Config, queue: &str) -> Result<String> {
+async fn resolve_annotation_queue_id(
+    cfg: &Config,
+    queue: &str,
+    headers: &[(&str, &str)],
+) -> Result<String> {
     if uuid::Uuid::parse_str(queue).is_ok() {
         return Ok(queue.to_string());
     }
@@ -668,9 +673,14 @@ async fn resolve_annotation_queue_id(cfg: &Config, queue: &str) -> Result<String
         anyhow::bail!("--queue cannot be empty");
     }
 
-    let response = raw_client::raw_get(cfg, "/api/v2/llm-obs/v1/annotation-queues", &[])
-        .await
-        .map_err(|e| {
+    let response = raw_client::raw_get_with_headers(
+        cfg,
+        "/api/v2/llm-obs/v1/annotation-queues",
+        &[],
+        headers,
+    )
+    .await
+    .map_err(|e| {
             anyhow::anyhow!(
                 "failed to resolve annotation queue '{queue}'; ensure the caller has the llm_observability_read scope and access to the queue: {e:?}"
             )
@@ -681,6 +691,7 @@ async fn resolve_annotation_queue_id(cfg: &Config, queue: &str) -> Result<String
 fn merge_annotated_interaction_page(
     annotated_interaction: &mut Option<serde_json::Value>,
     interaction_type: &mut Option<String>,
+    interaction_content: &mut Option<serde_json::Value>,
     events: &mut Vec<serde_json::Value>,
     page: AnnotatedInteractionDataPage,
 ) -> Result<Option<String>> {
@@ -698,6 +709,15 @@ fn merge_annotated_interaction_page(
     } else {
         *interaction_type = Some(page.interaction_data.interaction_type);
     }
+    if let Some(content) = page.interaction_data.content {
+        if let Some(existing) = interaction_content.as_ref() {
+            if existing != &content {
+                anyhow::bail!("interaction content changed while the export was being fetched");
+            }
+        } else {
+            *interaction_content = Some(content);
+        }
+    }
 
     events.extend(page.interaction_data.events);
     Ok(page
@@ -710,6 +730,7 @@ async fn fetch_annotated_interaction_export(
     cfg: &Config,
     queue_id: &str,
     interaction_id: &str,
+    headers: &[(&str, &str)],
 ) -> Result<serde_json::Value> {
     let path = format!(
         "/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotated-interactions/{interaction_id}"
@@ -718,6 +739,7 @@ async fn fetch_annotated_interaction_export(
     let mut seen_cursors = HashSet::new();
     let mut annotated_interaction: Option<serde_json::Value> = None;
     let mut interaction_type: Option<String> = None;
+    let mut interaction_content: Option<serde_json::Value> = None;
     let mut events = Vec::new();
 
     loop {
@@ -725,7 +747,7 @@ async fn fetch_annotated_interaction_export(
         if let Some(ref value) = cursor {
             query.push(("cursor", value.as_str()));
         }
-        let response = raw_client::raw_get(cfg, &path, &query)
+        let response = raw_client::raw_get_with_headers(cfg, &path, &query, headers)
             .await
             .map_err(|e| {
                 anyhow::anyhow!(
@@ -736,6 +758,7 @@ async fn fetch_annotated_interaction_export(
         let Some(next_cursor) = merge_annotated_interaction_page(
             &mut annotated_interaction,
             &mut interaction_type,
+            &mut interaction_content,
             &mut events,
             page,
         )?
@@ -748,14 +771,19 @@ async fn fetch_annotated_interaction_export(
         cursor = Some(next_cursor);
     }
 
+    let mut interaction_data = serde_json::json!({
+        "type": interaction_type
+            .ok_or_else(|| anyhow::anyhow!("response did not contain an interaction type"))?,
+        "events": events,
+    });
+    if let Some(content) = interaction_content {
+        interaction_data["content"] = content;
+    }
+
     Ok(serde_json::json!({
         "annotated_interaction": annotated_interaction
             .ok_or_else(|| anyhow::anyhow!("response did not contain an annotated interaction"))?,
-        "interaction_data": {
-            "type": interaction_type
-                .ok_or_else(|| anyhow::anyhow!("response did not contain an interaction type"))?,
-            "events": events,
-        },
+        "interaction_data": interaction_data,
     }))
 }
 
@@ -785,70 +813,74 @@ fn serialize_annotation_export(value: &serde_json::Value, format: &str) -> Resul
     Ok(bytes)
 }
 
-fn temporary_export_path(path: &Path, attempt: u8) -> Result<PathBuf> {
-    let name = path
+fn write_annotation_export(path: &Path, bytes: &[u8], force: bool) -> Result<()> {
+    let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| anyhow::anyhow!("output path must name a file"))?;
-    Ok(path.with_file_name(format!(".{name}.pup-{}-{attempt}.tmp", std::process::id())))
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temporary = tempfile::Builder::new()
+        .prefix(&format!(".{file_name}.pup-"))
+        .tempfile_in(parent)
+        .map_err(|e| anyhow::anyhow!("failed to create export beside '{}': {e}", path.display()))?;
+
+    temporary.write_all(bytes)?;
+    temporary.as_file().sync_all()?;
+
+    let result = if force {
+        temporary.persist(path)
+    } else {
+        temporary.persist_noclobber(path)
+    };
+    match result {
+        Ok(_) => Ok(()),
+        Err(error) if !force && error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            anyhow::bail!(
+                "output file '{}' already exists; pass --force to overwrite it",
+                path.display()
+            )
+        }
+        Err(error) => Err(anyhow::anyhow!(
+            "failed to write export '{}': {}",
+            path.display(),
+            error.error
+        )),
+    }
 }
 
-fn write_annotation_export(path: &Path, bytes: &[u8], force: bool) -> Result<()> {
-    if path.exists() && !force {
-        anyhow::bail!(
-            "output file '{}' already exists; pass --force to overwrite it",
-            path.display()
-        );
-    }
+fn validate_annotation_export_headers(headers: &[(String, String)]) -> Result<()> {
+    const PROTECTED_HEADERS: &[&str] = &[
+        "accept",
+        "authorization",
+        "connection",
+        "content-length",
+        "dd-api-key",
+        "dd-application-key",
+        "host",
+        "proxy-authorization",
+        "transfer-encoding",
+        "user-agent",
+    ];
 
-    let mut temporary = None;
-    for attempt in 0..100 {
-        let candidate = temporary_export_path(path, attempt)?;
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
+    for (name, _) in headers {
+        if PROTECTED_HEADERS
+            .iter()
+            .any(|protected| name.eq_ignore_ascii_case(protected))
         {
-            use std::os::unix::fs::OpenOptionsExt;
-            options.mode(0o600);
-        }
-        match options.open(&candidate) {
-            Ok(file) => {
-                temporary = Some((candidate, file));
-                break;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => {
-                return Err(anyhow::anyhow!(
-                    "failed to create export beside '{}': {error}",
-                    path.display()
-                ))
-            }
+            anyhow::bail!("--header cannot set protected header '{name}'");
         }
     }
-    let (temporary_path, mut file) =
-        temporary.ok_or_else(|| anyhow::anyhow!("could not allocate a temporary export file"))?;
-
-    let result = (|| -> Result<()> {
-        file.write_all(bytes)?;
-        file.sync_all()?;
-        drop(file);
-        #[cfg(windows)]
-        if force && path.exists() {
-            std::fs::remove_file(path)?;
-        }
-        std::fs::rename(&temporary_path, path)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = std::fs::remove_file(&temporary_path);
-    }
-    result.map_err(|e| anyhow::anyhow!("failed to write export '{}': {e}", path.display()))
+    Ok(())
 }
 
 pub async fn annotations_export(
     cfg: &Config,
     queue: &str,
     interaction_id: &str,
+    headers: &[String],
     format: Option<&str>,
     out: Option<&str>,
     force: bool,
@@ -856,8 +888,18 @@ pub async fn annotations_export(
     if uuid::Uuid::parse_str(interaction_id).is_err() {
         anyhow::bail!("--interaction-id must be a UUID");
     }
-    let queue_id = resolve_annotation_queue_id(cfg, queue).await?;
-    let export = fetch_annotated_interaction_export(cfg, &queue_id, interaction_id).await?;
+    let headers = headers
+        .iter()
+        .map(|header| crate::commands::api::parse_header_str(header))
+        .collect::<Result<Vec<_>>>()?;
+    validate_annotation_export_headers(&headers)?;
+    let header_refs = headers
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+    let queue_id = resolve_annotation_queue_id(cfg, queue, &header_refs).await?;
+    let export =
+        fetch_annotated_interaction_export(cfg, &queue_id, interaction_id, &header_refs).await?;
 
     output_annotation_export(cfg, &export, format, out, force)
 }
@@ -1729,6 +1771,9 @@ mod tests {
             "can_annotate": true,
             "annotations": [{"label": "quality", "value": "good"}],
         });
+        let interaction_content = serde_json::json!({
+            "blocks": [{"type": "text", "text": "stored interaction content"}]
+        });
         let first_body = serde_json::json!({
             "data": {
                 "id": interaction_id,
@@ -1738,6 +1783,7 @@ mod tests {
                     "interaction_data": {
                         "type": "session",
                         "events": [{"content": {"span_id": "span-1"}}],
+                        "content": interaction_content,
                         "next_cursor": "cursor-1",
                     }
                 }
@@ -1751,7 +1797,8 @@ mod tests {
                     "annotated_interaction": annotated_interaction,
                     "interaction_data": {
                         "type": "session",
-                        "events": [{"content": {"span_id": "span-2", "expected_output": "ok"}}]
+                        "events": [{"content": {"span_id": "span-2", "expected_output": "ok"}}],
+                        "content": interaction_content,
                     }
                 }
             }
@@ -1759,6 +1806,7 @@ mod tests {
         let _first = server
             .mock("GET", path.as_str())
             .match_query(mockito::Matcher::Exact("limit=500".into()))
+            .match_header("test-drive-scion-s60", "1")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(first_body.to_string())
@@ -1767,18 +1815,25 @@ mod tests {
         let _second = server
             .mock("GET", path.as_str())
             .match_query(mockito::Matcher::Exact("limit=500&cursor=cursor-1".into()))
+            .match_header("test-drive-scion-s60", "1")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(second_body.to_string())
             .create_async()
             .await;
 
-        let export = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id)
-            .await
-            .expect("multi-page export should succeed");
+        let export = super::fetch_annotated_interaction_export(
+            &cfg,
+            queue_id,
+            interaction_id,
+            &[("test-drive-scion-s60", "1")],
+        )
+        .await
+        .expect("multi-page export should succeed");
 
         assert_eq!(export["annotated_interaction"], annotated_interaction);
         assert_eq!(export["interaction_data"]["type"], "session");
+        assert_eq!(export["interaction_data"]["content"], interaction_content);
         assert_eq!(
             export["interaction_data"]["events"]
                 .as_array()
@@ -1803,6 +1858,7 @@ mod tests {
         let _queues = server
             .mock("GET", "/api/v2/llm-obs/v1/annotation-queues")
             .match_query(mockito::Matcher::Missing)
+            .match_header("test-drive-scion-s60", "1")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -1823,6 +1879,7 @@ mod tests {
         let _interaction = server
             .mock("GET", interaction_path.as_str())
             .match_query(mockito::Matcher::Exact("limit=500".into()))
+            .match_header("test-drive-scion-s60", "1")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -1843,6 +1900,7 @@ mod tests {
             &cfg,
             "quality-review",
             interaction_id,
+            &["test-drive-scion-s60: 1".to_string()],
             Some("jsonl"),
             output.to_str(),
             false,
@@ -1897,7 +1955,7 @@ mod tests {
             .create_async()
             .await;
 
-        let error = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id)
+        let error = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id, &[])
             .await
             .expect_err("repeated cursor should fail");
         assert!(error.to_string().contains("repeated pagination cursor"));
@@ -1962,7 +2020,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_annotation_queue_id_rejects_empty_name() {
         let cfg = test_config("http://unused.local");
-        let error = super::resolve_annotation_queue_id(&cfg, "")
+        let error = super::resolve_annotation_queue_id(&cfg, "", &[])
             .await
             .expect_err("empty queue name should fail before a request");
         assert!(error.to_string().contains("--queue cannot be empty"));
@@ -1972,18 +2030,21 @@ mod tests {
     fn test_merge_annotated_interaction_page_rejects_changes_between_pages() {
         let mut annotation = Some(serde_json::json!({"interaction_id": "one"}));
         let mut interaction_type = Some("trace".to_string());
+        let mut interaction_content = None;
         let mut events = Vec::new();
         let changed_annotation = super::AnnotatedInteractionDataPage {
             annotated_interaction: serde_json::json!({"interaction_id": "two"}),
             interaction_data: super::InteractionDataPage {
                 interaction_type: "trace".to_string(),
                 events: vec![],
+                content: None,
                 next_cursor: None,
             },
         };
         let error = super::merge_annotated_interaction_page(
             &mut annotation,
             &mut interaction_type,
+            &mut interaction_content,
             &mut events,
             changed_annotation,
         )
@@ -1995,12 +2056,14 @@ mod tests {
             interaction_data: super::InteractionDataPage {
                 interaction_type: "session".to_string(),
                 events: vec![],
+                content: None,
                 next_cursor: None,
             },
         };
         let error = super::merge_annotated_interaction_page(
             &mut annotation,
             &mut interaction_type,
+            &mut interaction_content,
             &mut events,
             changed_type,
         )
@@ -2032,9 +2095,42 @@ mod tests {
 
     #[test]
     fn test_annotation_export_rejects_path_without_file_name() {
-        let error = super::temporary_export_path(std::path::Path::new("/"), 0)
+        let error = super::write_annotation_export(std::path::Path::new("/"), b"{}\n", false)
             .expect_err("directory path should fail");
         assert!(error.to_string().contains("must name a file"));
+    }
+
+    #[test]
+    fn test_annotation_export_rejects_protected_headers() {
+        for name in [
+            "Accept",
+            "AUTHORIZATION",
+            "Connection",
+            "Content-Length",
+            "DD-API-KEY",
+            "dd-application-key",
+            "Host",
+            "Proxy-Authorization",
+            "Transfer-Encoding",
+            "User-Agent",
+        ] {
+            let error = super::validate_annotation_export_headers(&[(
+                name.to_string(),
+                "value".to_string(),
+            )])
+            .expect_err("protected headers should be rejected");
+            assert!(error.to_string().contains("protected header"));
+            assert!(error.to_string().contains(name));
+        }
+    }
+
+    #[test]
+    fn test_annotation_export_accepts_request_routing_headers() {
+        super::validate_annotation_export_headers(&[
+            ("test-drive-scion-s60".to_string(), "1".to_string()),
+            ("x-datadog-routing".to_string(), "staging".to_string()),
+        ])
+        .expect("request-routing headers should be accepted");
     }
 
     #[test]
@@ -2085,7 +2181,7 @@ mod tests {
             .create_async()
             .await;
 
-        let error = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id)
+        let error = super::fetch_annotated_interaction_export(&cfg, queue_id, interaction_id, &[])
             .await
             .expect_err("API rejection should include remediation");
         assert!(error.to_string().contains("llm_observability_read"));
@@ -2100,6 +2196,7 @@ mod tests {
             &cfg,
             "13851556-a8c7-41c1-be75-03eb665a132f",
             "not-a-uuid",
+            &[],
             None,
             None,
             false,
@@ -2109,6 +2206,23 @@ mod tests {
         assert!(error
             .to_string()
             .contains("--interaction-id must be a UUID"));
+    }
+
+    #[tokio::test]
+    async fn test_annotations_export_rejects_malformed_header() {
+        let cfg = test_config("http://unused.local");
+        let error = super::annotations_export(
+            &cfg,
+            "13851556-a8c7-41c1-be75-03eb665a132f",
+            "23851556-a8c7-41c1-be75-03eb665a132f",
+            &["missing-colon".to_string()],
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect_err("malformed header should fail before a request");
+        assert!(error.to_string().contains("expected KEY:VALUE"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9487,6 +9487,11 @@ enum LlmObsActions {
         #[command(subcommand)]
         action: LlmObsSpansActions,
     },
+    /// Export an annotated interaction with its complete interaction data
+    Annotations {
+        #[command(subcommand)]
+        action: LlmObsAnnotationsActions,
+    },
     /// Manage LLM Observability annotation queues
     #[command(name = "annotation-queues")]
     AnnotationQueues {
@@ -9526,6 +9531,28 @@ enum LlmObsActions {
         limit: Option<u32>,
         #[arg(long, help = "Pagination cursor from a prior call")]
         cursor: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum LlmObsAnnotationsActions {
+    /// Export one annotated interaction and all of its event data
+    Export {
+        #[arg(long, help = "Annotation queue ID or exact queue name")]
+        queue: String,
+        #[arg(long, help = "Interaction ID")]
+        interaction_id: String,
+        #[arg(
+            long,
+            default_value = "jsonl",
+            value_parser = ["json", "jsonl"],
+            help = "Export format: json or jsonl"
+        )]
+        format: String,
+        #[arg(long, help = "Output file; writes to stdout when omitted")]
+        out: Option<String>,
+        #[arg(long, help = "Overwrite an existing output file")]
+        force: bool,
     },
 }
 
@@ -17508,6 +17535,25 @@ async fn main_inner() -> anyhow::Result<()> {
                             .await?;
                         }
                     },
+                },
+                LlmObsActions::Annotations { action } => match action {
+                    LlmObsAnnotationsActions::Export {
+                        queue,
+                        interaction_id,
+                        format,
+                        out,
+                        force,
+                    } => {
+                        commands::llm_obs::annotations_export(
+                            &cfg,
+                            &queue,
+                            &interaction_id,
+                            &format,
+                            out.as_deref(),
+                            force,
+                        )
+                        .await?;
+                    }
                 },
                 LlmObsActions::EvalConfig { action } => match action {
                     LlmObsEvalConfigActions::Get { eval_name } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9544,14 +9544,14 @@ enum LlmObsAnnotationsActions {
         interaction_id: String,
         #[arg(
             long,
-            default_value = "jsonl",
             value_parser = ["json", "jsonl"],
-            help = "Export format: json or jsonl"
+            requires = "out",
+            help = "Output-file format: json (default) or jsonl; requires --out"
         )]
-        format: String,
+        format: Option<String>,
         #[arg(long, help = "Output file; writes to stdout when omitted")]
         out: Option<String>,
-        #[arg(long, help = "Overwrite an existing output file")]
+        #[arg(long, requires = "out", help = "Overwrite an existing output file")]
         force: bool,
     },
 }
@@ -17548,7 +17548,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             &cfg,
                             &queue,
                             &interaction_id,
-                            &format,
+                            format.as_deref(),
                             out.as_deref(),
                             force,
                         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -9543,6 +9543,13 @@ enum LlmObsAnnotationsActions {
         #[arg(long, help = "Interaction ID")]
         interaction_id: String,
         #[arg(
+            short = 'H',
+            long = "header",
+            value_name = "KEY:VALUE",
+            help = "Add a request-routing HTTP header to every export request (repeatable)"
+        )]
+        header: Vec<String>,
+        #[arg(
             long,
             value_parser = ["json", "jsonl"],
             requires = "out",
@@ -17540,6 +17547,7 @@ async fn main_inner() -> anyhow::Result<()> {
                     LlmObsAnnotationsActions::Export {
                         queue,
                         interaction_id,
+                        header,
                         format,
                         out,
                         force,
@@ -17548,6 +17556,7 @@ async fn main_inner() -> anyhow::Result<()> {
                             &cfg,
                             &queue,
                             &interaction_id,
+                            &header,
                             format.as_deref(),
                             out.as_deref(),
                             force,

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -35,8 +35,13 @@ impl std::error::Error for HttpError {}
 // return deeply-nested flame-graph trees that exceed it. serde_stacker grows
 // the thread stack on demand so disabling the limit can't blow it.
 async fn parse_response_json(resp: reqwest::Response) -> anyhow::Result<serde_json::Value> {
-    use serde::Deserialize;
     let bytes = resp.bytes().await?;
+    parse_json_bytes(&bytes)
+}
+
+fn parse_json_bytes(bytes: &[u8]) -> anyhow::Result<serde_json::Value> {
+    use serde::Deserialize;
+
     // Some endpoints return a success status (e.g. 200) with an empty body, such
     // as GET /api/v2/on-call/pages/{id} which responds with content-length: 0.
     // Treat an empty or whitespace-only body as JSON null rather than failing
@@ -44,7 +49,7 @@ async fn parse_response_json(resp: reqwest::Response) -> anyhow::Result<serde_js
     if bytes.iter().all(u8::is_ascii_whitespace) {
         return Ok(serde_json::Value::Null);
     }
-    let mut de = serde_json::Deserializer::from_slice(&bytes);
+    let mut de = serde_json::Deserializer::from_slice(bytes);
     de.disable_recursion_limit();
     let de = serde_stacker::Deserializer::new(&mut de);
     Ok(serde_json::Value::deserialize(de)?)
@@ -419,33 +424,28 @@ pub async fn raw_get(
     path: &str,
     query: &[(&str, &str)],
 ) -> anyhow::Result<serde_json::Value> {
-    let url = format!("{}{}", cfg.api_base_url(), path);
-    let client = reqwest::Client::new();
-    let mut req = client.get(&url);
+    raw_get_with_headers(cfg, path, query, &[]).await
+}
 
-    req = apply_auth(req, cfg, "GET", path)?;
-
-    if !query.is_empty() {
-        req = req.query(query);
-    }
-
-    let resp = req
-        .header("Accept", "application/json")
-        .header("User-Agent", useragent::get())
-        .send()
-        .await?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(HttpError {
-            status: status.as_u16(),
-            method: "GET".into(),
-            url,
-            body,
-        }
-        .into());
-    }
-    parse_response_json(resp).await
+/// Makes an authenticated GET request with additional caller-supplied headers.
+pub async fn raw_get_with_headers(
+    cfg: &Config,
+    path: &str,
+    query: &[(&str, &str)],
+    extra_headers: &[(&str, &str)],
+) -> anyhow::Result<serde_json::Value> {
+    let response = raw_request(
+        cfg,
+        "GET",
+        path,
+        query,
+        None,
+        None,
+        "application/json",
+        extra_headers,
+    )
+    .await?;
+    parse_json_bytes(&response.bytes)
 }
 
 /// Makes an authenticated PATCH request directly via reqwest.

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -8,6 +8,47 @@
 
 use clap::CommandFactory;
 
+#[test]
+fn test_llm_obs_annotations_export_parses() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "llm-obs",
+        "annotations",
+        "export",
+        "--queue",
+        "quality-review",
+        "--interaction-id",
+        "23851556-a8c7-41c1-be75-03eb665a132f",
+        "--format",
+        "jsonl",
+        "--out",
+        "interaction.jsonl",
+        "--force",
+    ])
+    .expect("LLM Observability annotation export should parse");
+
+    let crate::Commands::LlmObs { action } = cli.command else {
+        panic!("expected Commands::LlmObs");
+    };
+    let crate::LlmObsActions::Annotations { action } = action else {
+        panic!("expected LlmObsActions::Annotations");
+    };
+    let crate::LlmObsAnnotationsActions::Export {
+        queue,
+        interaction_id,
+        format,
+        out,
+        force,
+    } = action;
+    assert_eq!(queue, "quality-review");
+    assert_eq!(interaction_id, "23851556-a8c7-41c1-be75-03eb665a132f");
+    assert_eq!(format, "jsonl");
+    assert_eq!(out.as_deref(), Some("interaction.jsonl"));
+    assert!(force);
+}
+
 // -------------------------------------------------------------------------
 // Notebook discovery
 // -------------------------------------------------------------------------

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -44,9 +44,66 @@ fn test_llm_obs_annotations_export_parses() {
     } = action;
     assert_eq!(queue, "quality-review");
     assert_eq!(interaction_id, "23851556-a8c7-41c1-be75-03eb665a132f");
-    assert_eq!(format, "jsonl");
+    assert_eq!(format.as_deref(), Some("jsonl"));
     assert_eq!(out.as_deref(), Some("interaction.jsonl"));
     assert!(force);
+}
+
+#[test]
+fn test_llm_obs_annotations_export_defaults_to_standard_json_output() {
+    use clap::Parser;
+
+    let cli = crate::Cli::try_parse_from([
+        "pup",
+        "llm-obs",
+        "annotations",
+        "export",
+        "--queue",
+        "quality-review",
+        "--interaction-id",
+        "23851556-a8c7-41c1-be75-03eb665a132f",
+    ])
+    .expect("annotation export should parse without file flags");
+
+    let crate::Commands::LlmObs { action } = cli.command else {
+        panic!("expected Commands::LlmObs");
+    };
+    let crate::LlmObsActions::Annotations { action } = action else {
+        panic!("expected LlmObsActions::Annotations");
+    };
+    let crate::LlmObsAnnotationsActions::Export {
+        format, out, force, ..
+    } = action;
+    assert!(format.is_none());
+    assert!(out.is_none());
+    assert!(!force);
+}
+
+#[test]
+fn test_llm_obs_annotations_export_file_flags_require_out() {
+    use clap::Parser;
+
+    for flag in ["--format", "--force"] {
+        let mut args = vec![
+            "pup",
+            "llm-obs",
+            "annotations",
+            "export",
+            "--queue",
+            "quality-review",
+            "--interaction-id",
+            "23851556-a8c7-41c1-be75-03eb665a132f",
+            flag,
+        ];
+        if flag == "--format" {
+            args.push("jsonl");
+        }
+        let error = match crate::Cli::try_parse_from(args) {
+            Ok(_) => panic!("file-only flags should require --out"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("--out"));
+    }
 }
 
 // -------------------------------------------------------------------------

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -21,6 +21,10 @@ fn test_llm_obs_annotations_export_parses() {
         "quality-review",
         "--interaction-id",
         "23851556-a8c7-41c1-be75-03eb665a132f",
+        "-H",
+        "test-drive-scion-s60: 1",
+        "--header",
+        "x-request-id: export-test",
         "--format",
         "jsonl",
         "--out",
@@ -38,12 +42,17 @@ fn test_llm_obs_annotations_export_parses() {
     let crate::LlmObsAnnotationsActions::Export {
         queue,
         interaction_id,
+        header,
         format,
         out,
         force,
     } = action;
     assert_eq!(queue, "quality-review");
     assert_eq!(interaction_id, "23851556-a8c7-41c1-be75-03eb665a132f");
+    assert_eq!(
+        header,
+        ["test-drive-scion-s60: 1", "x-request-id: export-test"]
+    );
     assert_eq!(format.as_deref(), Some("jsonl"));
     assert_eq!(out.as_deref(), Some("interaction.jsonl"));
     assert!(force);


### PR DESCRIPTION
## Summary

Add a Pup command that exports an annotated LLM Observability interaction together with its complete interaction data.

## Changes

- Add pup llm-obs annotations export with queue ID or exact-name resolution
- Fetch and combine every cursor page while preserving stored interaction content
- Support standard stdout formatting plus atomic JSON and JSONL file exports
- Forward validated request-routing headers for Rapid test drives
- Reuse the shared authenticated raw HTTP transport
- Document the command and add positive and negative coverage

## Testing

- cargo test -- --test-threads=1 (1,834 passed)
- cargo clippy -- -D warnings
- cargo fmt --all -- --check
- git diff --check