### PR TITLE
feat(table): let commands define concise table columns

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1245,6 +1245,9 @@ Scalar table results are rendered in a `VALUE` column instead of producing an em
 
 Table cells use compact previews for long strings, arrays, nested objects, and null values.
 
+Common resource lists use concise, opinionated columns; unknown shapes keep the generic
+priority-and-fallback selection.
+
 ### CSV and TSV Output
 ```bash
 pup monitors list --output=csv

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1245,8 +1245,8 @@ Scalar table results are rendered in a `VALUE` column instead of producing an em
 
 Table cells use compact previews for long strings, arrays, nested objects, and null values.
 
-Common resource lists use concise, opinionated columns; unknown shapes keep the generic
-priority-and-fallback selection.
+Commands that know their response shape provide concise, opinionated columns; generic
+API and formatter input keeps the priority-and-fallback selection.
 
 ### CSV and TSV Output
 ```bash

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -180,6 +180,20 @@ echo "$results" | pup format --output table
 echo "$results" | pup format --count 2 --command "foo list"
 ```
 
+Extensions can also tell the table formatter where the result rows live and which
+columns are useful. `--rows-at` accepts an RFC 6901 JSON Pointer into the response,
+and `--row-at` optionally selects a value within every result row. `--columns`
+accepts a comma-separated or repeated list of flattened field names. These hints
+only affect table output; JSON, YAML, CSV, and TSV retain the complete response.
+
+```bash
+pup api v1/monitor/search --silent |
+  pup format --rows-at /monitors --columns id,name,status,type,tags
+```
+
+When the user supplies `--jq`, the filtered value is rendered as-is and these
+table defaults are bypassed.
+
 ### Combine them
 
 A fully consistent extension that adds zero auth or formatting code:

--- a/src/commands/dashboards.rs
+++ b/src/commands/dashboards.rs
@@ -10,13 +10,26 @@ use crate::raw_client;
 use crate::util;
 use crate::util_ext;
 
+const DASHBOARD_LIST_COLUMNS: &[&str] = &[
+    "id",
+    "title",
+    "layout_type",
+    "author_handle",
+    "modified_at",
+    "url",
+];
+
 pub async fn list(cfg: &Config) -> Result<()> {
     let api = crate::make_api!(DashboardsAPI, cfg);
     let resp = api
         .list_dashboards(ListDashboardsOptionalParams::default())
         .await
         .map_err(|e| anyhow::anyhow!("failed to list dashboards: {e:?}"))?;
-    formatter::output(cfg, &resp)
+    formatter::output_with_table(
+        cfg,
+        &resp,
+        formatter::TableOptions::new(DASHBOARD_LIST_COLUMNS).rows_at("/dashboards"),
+    )
 }
 
 pub async fn get(cfg: &Config, id: &str) -> Result<()> {

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -5,6 +5,16 @@ use std::io::Read;
 use crate::config::Config;
 use crate::formatter::{self, Metadata};
 
+#[derive(Default)]
+pub struct FormatOptions<'a> {
+    pub count: Option<usize>,
+    pub command: Option<String>,
+    pub next_action: Option<String>,
+    pub rows_at: Option<&'a str>,
+    pub row_at: Option<&'a str>,
+    pub columns: &'a [String],
+}
+
 /// Render JSON through pup's formatter.
 ///
 /// Reads a JSON document from stdin (default) or `--input FILE`, then prints it
@@ -12,17 +22,14 @@ use crate::formatter::{self, Metadata};
 /// agent mode. This lets an extension in any language produce JSON and reuse pup's
 /// table/yaml/csv/tsv rendering and agent envelope instead of reimplementing them.
 ///
+/// `rows_at`, `row_at`, and `columns` provide table-only presentation hints. They do not
+/// project or otherwise change JSON, YAML, CSV, or TSV output.
+///
 /// The optional metadata flags populate the agent-mode envelope and are ignored
 /// for non-agent, non-JSON formats.
-pub fn run(
-    cfg: &Config,
-    input: Option<&str>,
-    count: Option<usize>,
-    command: Option<String>,
-    next_action: Option<String>,
-) -> Result<()> {
+pub fn run(cfg: &Config, input: Option<&str>, options: FormatOptions<'_>) -> Result<()> {
     let raw = read_input(input, std::io::stdin().lock())?;
-    render(cfg, &raw, count, command, next_action)
+    render(cfg, &raw, options)
 }
 
 /// Read the JSON document from a file (`Some(path)` other than `"-"`) or from the
@@ -37,18 +44,20 @@ fn read_input(input: Option<&str>, reader: impl Read) -> Result<String> {
 }
 
 /// Parse `raw` as JSON and print it through the shared formatter.
-fn render(
-    cfg: &Config,
-    raw: &str,
-    count: Option<usize>,
-    command: Option<String>,
-    next_action: Option<String>,
-) -> Result<()> {
+fn render(cfg: &Config, raw: &str, options: FormatOptions<'_>) -> Result<()> {
     if raw.trim().is_empty() {
         anyhow::bail!("no JSON input provided (pipe JSON to stdin or pass --input FILE)");
     }
 
     let value: Value = serde_json::from_str(raw).context("input is not valid JSON")?;
+    let FormatOptions {
+        count,
+        command,
+        next_action,
+        rows_at,
+        row_at,
+        columns,
+    } = options;
 
     // Only build a metadata envelope when at least one field is supplied; otherwise
     // pass None so the output matches `pup api` / other commands with no metadata.
@@ -63,12 +72,26 @@ fn render(
         None
     };
 
-    formatter::format_and_print(
+    let columns: Vec<&str> = columns
+        .iter()
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|column| !column.is_empty())
+        .collect();
+    let mut table = formatter::TableOptions::new(&columns);
+    if let Some(pointer) = rows_at {
+        table = table.rows_at(pointer);
+    }
+    if let Some(pointer) = row_at {
+        table = table.row_at(pointer);
+    }
+    formatter::format_and_print_with_table(
         &value,
         &cfg.output_format,
         cfg.agent_mode,
         meta.as_ref(),
         cfg.jq.as_deref(),
+        table,
     )
 }
 
@@ -110,7 +133,7 @@ mod tests {
         // The primary documented path: JSON piped via stdin, rendered as a table.
         let cfg = cfg_with(OutputFormat::Table, false);
         let raw = read_input(None, Cursor::new(b"[{\"id\":1}]".to_vec())).unwrap();
-        let result = render(&cfg, &raw, None, None, None);
+        let result = render(&cfg, &raw, FormatOptions::default());
         assert!(result.is_ok(), "stdin render failed: {:?}", result.err());
     }
 
@@ -134,7 +157,7 @@ mod tests {
     fn test_run_reads_file_input_json() {
         let path = write_temp_json("pup_format_input.json", r#"[{"id":1,"name":"x"}]"#);
         let cfg = cfg_with(OutputFormat::Json, false);
-        let result = run(&cfg, path.to_str(), None, None, None);
+        let result = run(&cfg, path.to_str(), FormatOptions::default());
         std::fs::remove_file(&path).ok();
         assert!(
             result.is_ok(),
@@ -147,16 +170,69 @@ mod tests {
     fn test_run_table_format_from_file() {
         let path = write_temp_json("pup_format_table.json", r#"[{"id":1,"name":"x"}]"#);
         let cfg = cfg_with(OutputFormat::Table, false);
-        let result = run(&cfg, path.to_str(), None, None, None);
+        let result = run(&cfg, path.to_str(), FormatOptions::default());
         std::fs::remove_file(&path).ok();
         assert!(result.is_ok(), "table format failed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_render_table_with_explicit_rows_and_columns() {
+        let cfg = cfg_with(OutputFormat::Table, false);
+        let columns = vec!["name".to_string(), "id".to_string()];
+        let result = render(
+            &cfg,
+            r#"{"results":[{"data":{"id":1,"name":"alpha","details":"omit"}}]}"#,
+            FormatOptions {
+                rows_at: Some("/results"),
+                row_at: Some("/data"),
+                columns: &columns,
+                ..FormatOptions::default()
+            },
+        );
+        assert!(result.is_ok(), "table hints failed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_render_table_rejects_missing_rows_path() {
+        let cfg = cfg_with(OutputFormat::Table, false);
+        let result = render(
+            &cfg,
+            r#"{"results":[]}"#,
+            FormatOptions {
+                rows_at: Some("/missing"),
+                ..FormatOptions::default()
+            },
+        );
+        assert!(result.is_err(), "missing table row path should fail");
+    }
+
+    #[test]
+    fn test_non_table_output_ignores_table_hints() {
+        let cfg = cfg_with(OutputFormat::Json, false);
+        let result = render(
+            &cfg,
+            r#"{"results":[]}"#,
+            FormatOptions {
+                rows_at: Some("/missing"),
+                ..FormatOptions::default()
+            },
+        );
+        assert!(result.is_ok(), "JSON should ignore table hints");
     }
 
     #[test]
     fn test_run_agent_envelope_with_metadata() {
         let path = write_temp_json("pup_format_agent.json", r#"{"data":[]}"#);
         let cfg = cfg_with(OutputFormat::Json, true);
-        let result = run(&cfg, path.to_str(), Some(0), Some("format".into()), None);
+        let result = run(
+            &cfg,
+            path.to_str(),
+            FormatOptions {
+                count: Some(0),
+                command: Some("format".into()),
+                ..FormatOptions::default()
+            },
+        );
         std::fs::remove_file(&path).ok();
         assert!(result.is_ok(), "agent envelope failed: {:?}", result.err());
     }
@@ -165,7 +241,7 @@ mod tests {
     fn test_run_invalid_json_errors() {
         let path = write_temp_json("pup_format_bad.json", "{not json");
         let cfg = cfg_with(OutputFormat::Json, false);
-        let result = run(&cfg, path.to_str(), None, None, None);
+        let result = run(&cfg, path.to_str(), FormatOptions::default());
         std::fs::remove_file(&path).ok();
         assert!(result.is_err(), "expected error for invalid JSON");
     }
@@ -174,7 +250,7 @@ mod tests {
     fn test_run_empty_input_errors() {
         let path = write_temp_json("pup_format_empty.json", "   \n");
         let cfg = cfg_with(OutputFormat::Json, false);
-        let result = run(&cfg, path.to_str(), None, None, None);
+        let result = run(&cfg, path.to_str(), FormatOptions::default());
         std::fs::remove_file(&path).ok();
         assert!(result.is_err(), "expected error for empty input");
     }
@@ -185,9 +261,7 @@ mod tests {
         let result = run(
             &cfg,
             Some("/nonexistent/pup-format/x.json"),
-            None,
-            None,
-            None,
+            FormatOptions::default(),
         );
         assert!(result.is_err(), "expected error for missing file");
     }

--- a/src/commands/incidents.rs
+++ b/src/commands/incidents.rs
@@ -11,6 +11,15 @@ use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
+const INCIDENT_LIST_COLUMNS: &[&str] = &[
+    "attributes.public_id",
+    "attributes.title",
+    "attributes.severity",
+    "attributes.state",
+    "attributes.customer_impacted",
+    "attributes.created",
+];
+
 // ---------------------------------------------------------------------------
 // Helper: build an IncidentsAPI with bearer-token support
 // ---------------------------------------------------------------------------
@@ -33,7 +42,13 @@ pub async fn list(cfg: &Config, query: Option<String>, limit: i64) -> Result<()>
         .search_incidents(q, params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to list incidents: {:?}", e))?;
-    formatter::output(cfg, &resp)?;
+    formatter::output_with_table(
+        cfg,
+        &resp,
+        formatter::TableOptions::new(INCIDENT_LIST_COLUMNS)
+            .rows_at("/data/attributes/incidents")
+            .row_at("/data"),
+    )?;
     Ok(())
 }
 

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -13,6 +13,14 @@ use crate::raw_client;
 use crate::util;
 use crate::util_ext;
 
+const LOG_SEARCH_COLUMNS: &[&str] = &[
+    "attributes.timestamp",
+    "attributes.service",
+    "attributes.status",
+    "attributes.host",
+    "attributes.message",
+];
+
 const SAVED_VIEWS_PATH: &str = "/api/v1/logs/views";
 const PATTERNS_PATH: &str = "/api/v1/logs-analytics/cluster?type=logs";
 
@@ -393,12 +401,13 @@ pub async fn search(cfg: &Config, args: SearchArgs) -> Result<()> {
     } else {
         None
     };
-    formatter::format_and_print(
+    formatter::format_and_print_with_table(
         &resp,
         &cfg.output_format,
         cfg.agent_mode,
         meta.as_ref(),
         cfg.jq.as_deref(),
+        formatter::TableOptions::new(LOG_SEARCH_COLUMNS).rows_at("/data"),
     )?;
     Ok(())
 }

--- a/src/commands/monitors.rs
+++ b/src/commands/monitors.rs
@@ -10,6 +10,18 @@ use crate::formatter::{self, Metadata};
 use crate::util;
 use crate::util_ext;
 
+const MONITOR_LIST_COLUMNS: &[&str] = &[
+    "id",
+    "name",
+    "overall_state",
+    "type",
+    "priority",
+    "tags",
+    "modified",
+];
+const MONITOR_SEARCH_COLUMNS: &[&str] =
+    &["id", "name", "status", "type", "tags", "last_triggered_ts"];
+
 pub async fn list(
     cfg: &Config,
     name: Option<String>,
@@ -48,12 +60,13 @@ pub async fn list(
         command: Some("monitors list".to_string()),
         next_action: None,
     };
-    formatter::format_and_print(
+    formatter::format_and_print_with_table(
         &monitors,
         &cfg.output_format,
         cfg.agent_mode,
         Some(&meta),
         cfg.jq.as_deref(),
+        formatter::TableOptions::new(MONITOR_LIST_COLUMNS),
     )?;
     Ok(())
 }
@@ -172,7 +185,11 @@ pub async fn search(
         .search_monitors(params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to search monitors: {:?}", e))?;
-    formatter::output(cfg, &resp)
+    formatter::output_with_table(
+        cfg,
+        &resp,
+        formatter::TableOptions::new(MONITOR_SEARCH_COLUMNS).rows_at("/monitors"),
+    )
 }
 
 pub async fn delete(cfg: &Config, monitor_id: i64) -> Result<()> {

--- a/src/commands/slos.rs
+++ b/src/commands/slos.rs
@@ -14,6 +14,8 @@ use crate::raw_client;
 use crate::util;
 use crate::util_ext;
 
+const SLO_LIST_COLUMNS: &[&str] = &["id", "name", "type", "tags", "thresholds", "modified_at"];
+
 pub async fn list(
     cfg: &Config,
     query: Option<String>,
@@ -43,7 +45,11 @@ pub async fn list(
         .list_slos(params)
         .await
         .map_err(|e| anyhow::anyhow!("failed to list SLOs: {e:?}"))?;
-    formatter::output(cfg, &resp)
+    formatter::output_with_table(
+        cfg,
+        &resp,
+        formatter::TableOptions::new(SLO_LIST_COLUMNS).rows_at("/data"),
+    )
 }
 
 pub async fn get(cfg: &Config, id: &str) -> Result<()> {

--- a/src/commands/users.rs
+++ b/src/commands/users.rs
@@ -10,6 +10,15 @@ use crate::config::Config;
 use crate::formatter;
 use crate::util;
 
+const USER_LIST_COLUMNS: &[&str] = &[
+    "id",
+    "attributes.name",
+    "attributes.email",
+    "attributes.status",
+    "attributes.created_at",
+    "attributes.modified_at",
+];
+
 pub async fn list(cfg: &Config, page_size: i64, page_number: i64) -> Result<()> {
     let api = crate::make_api!(UsersAPI, cfg);
     let resp = api
@@ -20,7 +29,11 @@ pub async fn list(cfg: &Config, page_size: i64, page_number: i64) -> Result<()> 
         )
         .await
         .map_err(|e| anyhow::anyhow!("failed to list users: {e:?}"))?;
-    formatter::output(cfg, &resp)
+    formatter::output_with_table(
+        cfg,
+        &resp,
+        formatter::TableOptions::new(USER_LIST_COLUMNS).rows_at("/data"),
+    )
 }
 
 pub async fn get(cfg: &Config, id: &str) -> Result<()> {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -315,7 +315,7 @@ fn format_table_to_string_with_order(
     data: &serde_json::Value,
     output_order: OutputOrder,
 ) -> Result<String> {
-    let table_data = unwrap_data(data);
+    let table_data = unwrap_table_data(data);
     match table_data {
         serde_json::Value::Array(values)
             if values
@@ -332,64 +332,24 @@ fn format_table_to_string_with_order(
 
 fn format_horizontal_table(data: &serde_json::Value, output_order: OutputOrder) -> Result<String> {
     let raw_rows = extract_rows(data);
-    let owned_rows: Vec<serde_json::Value> = raw_rows.iter().map(|r| flatten_row(r)).collect();
+    let owned_rows: Vec<serde_json::Value> = raw_rows
+        .iter()
+        .map(|row| flatten_row(unwrap_table_row(row)))
+        .collect();
     let rows: Vec<&serde_json::Value> = owned_rows.iter().collect();
 
     if rows.is_empty() {
         return Ok("No results found".to_string());
     }
 
-    // Collect headers from all rows
-    let mut headers: Vec<String> = Vec::new();
-    let mut header_set = std::collections::HashSet::new();
-    for row in &rows {
-        if let serde_json::Value::Object(map) = row {
-            for key in map.keys() {
-                if header_set.insert(key.clone()) {
-                    headers.push(key.clone());
-                }
-            }
-        }
-    }
-
-    // Prioritize common fields (including flattened log attribute fields)
-    let priority = [
-        "id",
-        "title",
-        "name",
-        "type",
-        "status",
-        "state",
-        "severity",
-        "created_at",
-        "updated_at",
-        "created",
-        "modified",
-        "attributes.timestamp",
-        "attributes.service",
-        "attributes.host",
-        "attributes.status",
-        "attributes.message",
-    ];
-    let mut final_headers: Vec<String> = Vec::new();
-    if output_order == OutputOrder::Default {
-        for &p in &priority {
-            if header_set.contains(p) {
-                final_headers.push(p.to_string());
-            }
-        }
-        for h in &headers {
-            if final_headers.len() >= 12 {
-                break;
-            }
-            if !final_headers.contains(h) {
-                final_headers.push(h.clone());
-            }
-        }
+    let final_headers = if output_order == OutputOrder::Default {
+        select_list_headers(&rows, 12)
     } else {
-        final_headers.extend(headers.into_iter().take(12));
+        collect_headers(&rows).0.into_iter().take(12).collect()
+    };
+    if final_headers.is_empty() {
+        return format_scalar_table(raw_rows);
     }
-
     let mut table = comfy_table::Table::new();
     table.set_header(&final_headers);
 
@@ -441,6 +401,213 @@ fn format_scalar_table<'a>(
         return Ok("No results found".to_string());
     }
     Ok(table.to_string())
+}
+
+fn collect_headers(
+    rows: &[&serde_json::Value],
+) -> (Vec<String>, std::collections::HashSet<String>) {
+    let mut headers = Vec::new();
+    let mut header_set = std::collections::HashSet::new();
+    for row in rows {
+        if let serde_json::Value::Object(map) = row {
+            for key in map.keys() {
+                if header_set.insert(key.clone()) {
+                    headers.push(key.clone());
+                }
+            }
+        }
+    }
+    (headers, header_set)
+}
+
+fn select_list_headers(rows: &[&serde_json::Value], max: usize) -> Vec<String> {
+    let (headers, header_set) = collect_headers(rows);
+    if let Some(mut headers) = shape_preset_headers(&header_set) {
+        headers.truncate(max);
+        return headers;
+    }
+
+    let priority = [
+        "id",
+        "public_id",
+        "title",
+        "name",
+        "type",
+        "overall_state",
+        "status",
+        "state",
+        "severity",
+        "created_at",
+        "updated_at",
+        "created",
+        "modified",
+        "attributes.timestamp",
+        "attributes.service",
+        "attributes.host",
+        "attributes.status",
+        "attributes.message",
+    ];
+    let mut final_headers = Vec::new();
+    for &p in &priority {
+        if final_headers.len() >= max {
+            break;
+        }
+        if header_set.contains(p) {
+            final_headers.push(p.to_string());
+        }
+    }
+    for header in headers {
+        if final_headers.len() >= max {
+            break;
+        }
+        if !final_headers.contains(&header) {
+            final_headers.push(header);
+        }
+    }
+    final_headers
+}
+
+fn shape_preset_headers(header_set: &std::collections::HashSet<String>) -> Option<Vec<String>> {
+    const PRESETS: &[(&[&str], &[&str])] = &[
+        // Logs
+        (
+            &["attributes.timestamp", "attributes.message"],
+            &[
+                "attributes.timestamp",
+                "attributes.service",
+                "attributes.status",
+                "attributes.host",
+                "attributes.message",
+            ],
+        ),
+        // Monitors
+        (
+            &["id", "name", "overall_state"],
+            &[
+                "id",
+                "name",
+                "overall_state",
+                "type",
+                "priority",
+                "tags",
+                "modified",
+            ],
+        ),
+        // Monitor search results
+        (
+            &["id", "name", "status", "type", "tags"],
+            &["id", "name", "status", "type", "tags", "last_triggered_ts"],
+        ),
+        // Incidents
+        (
+            &[
+                "attributes.title",
+                "attributes.severity",
+                "attributes.state",
+            ],
+            &[
+                "attributes.public_id",
+                "attributes.title",
+                "attributes.severity",
+                "attributes.state",
+                "attributes.customer_impacted",
+                "attributes.created",
+            ],
+        ),
+        // Dashboards
+        (
+            &["id", "title", "layout_type"],
+            &[
+                "id",
+                "title",
+                "layout_type",
+                "author_handle",
+                "modified_at",
+                "url",
+            ],
+        ),
+        // SLOs
+        (
+            &["id", "name", "thresholds"],
+            &["id", "name", "type", "tags", "thresholds", "modified_at"],
+        ),
+        // Users
+        (
+            &["id", "attributes.email", "attributes.status"],
+            &[
+                "id",
+                "attributes.name",
+                "attributes.email",
+                "attributes.status",
+                "attributes.created_at",
+                "attributes.modified_at",
+            ],
+        ),
+    ];
+
+    PRESETS.iter().find_map(|(required, columns)| {
+        required
+            .iter()
+            .all(|header| header_set.contains(*header))
+            .then(|| available_columns(columns, header_set))
+    })
+}
+
+fn available_columns(
+    columns: &[&str],
+    header_set: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    columns
+        .iter()
+        .filter(|header| header_set.contains(**header))
+        .map(|header| (*header).to_string())
+        .collect()
+}
+
+fn unwrap_table_data(value: &serde_json::Value) -> &serde_json::Value {
+    let value = unwrap_data(value);
+    match value {
+        serde_json::Value::Object(map) => collection_envelope_rows(map)
+            .or_else(|| search_result_rows(value))
+            .unwrap_or(value),
+        _ => value,
+    }
+}
+
+fn collection_envelope_rows(
+    map: &serde_json::Map<String, serde_json::Value>,
+) -> Option<&serde_json::Value> {
+    if map.contains_key("id") {
+        return None;
+    }
+
+    let mut arrays = map
+        .values()
+        .filter(|field| matches!(field, serde_json::Value::Array(_)));
+    let rows = arrays.next()?;
+    arrays.next().is_none().then_some(rows)
+}
+
+fn search_result_rows(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    let resource_type = value.get("type")?.as_str()?;
+    if !resource_type.ends_with("_search_results") {
+        return None;
+    }
+    let attributes = value.get("attributes")?.as_object()?;
+    let mut arrays = attributes
+        .values()
+        .filter(|field| matches!(field, serde_json::Value::Array(_)));
+    let rows = arrays.next()?;
+    arrays.next().is_none().then_some(rows)
+}
+
+fn unwrap_table_row(value: &serde_json::Value) -> &serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) if map.len() == 1 && map.contains_key("data") => {
+            unwrap_data(value)
+        }
+        _ => value,
+    }
 }
 
 fn print_yaml(data: &serde_json::Value) -> Result<()> {
@@ -795,6 +962,216 @@ mod tests {
             format_table_to_string(&serde_json::json!([])).unwrap(),
             "No results found"
         );
+    }
+
+    #[test]
+    fn test_monitor_shape_uses_opinionated_columns() {
+        let row = serde_json::json!({
+            "id": 123,
+            "name": "API latency",
+            "overall_state": "Alert",
+            "type": "query alert",
+            "priority": 1,
+            "tags": ["service:api"],
+            "modified": "2026-08-28T12:00:00Z",
+            "query": "avg(last_5m):avg:latency{*} > 1",
+            "message": "not useful in a list view"
+        });
+        assert_eq!(
+            select_list_headers(&[&flatten_row(&row)], 12),
+            [
+                "id",
+                "name",
+                "overall_state",
+                "type",
+                "priority",
+                "tags",
+                "modified"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_known_api_shapes_have_column_presets() {
+        let cases: &[(&[&str], &[&str])] = &[
+            (
+                &[
+                    "attributes.timestamp",
+                    "attributes.message",
+                    "attributes.service",
+                ],
+                &[
+                    "attributes.timestamp",
+                    "attributes.service",
+                    "attributes.message",
+                ],
+            ),
+            (
+                &[
+                    "attributes.public_id",
+                    "attributes.title",
+                    "attributes.severity",
+                    "attributes.state",
+                ],
+                &[
+                    "attributes.public_id",
+                    "attributes.title",
+                    "attributes.severity",
+                    "attributes.state",
+                ],
+            ),
+            (
+                &["id", "title", "layout_type", "url", "description"],
+                &["id", "title", "layout_type", "url"],
+            ),
+            (
+                &["id", "name", "type", "tags", "thresholds", "query"],
+                &["id", "name", "type", "tags", "thresholds"],
+            ),
+            (
+                &[
+                    "id",
+                    "attributes.name",
+                    "attributes.email",
+                    "attributes.status",
+                ],
+                &[
+                    "id",
+                    "attributes.name",
+                    "attributes.email",
+                    "attributes.status",
+                ],
+            ),
+        ];
+
+        for (available, expected) in cases {
+            let header_set = available
+                .iter()
+                .map(|header| (*header).to_string())
+                .collect();
+            assert_eq!(shape_preset_headers(&header_set).unwrap(), *expected);
+        }
+    }
+
+    #[test]
+    fn test_common_collection_wrappers_render_as_lists() {
+        for collection in ["dashboards", "monitors", "users"] {
+            let data = serde_json::Value::Object(
+                [(
+                    collection.to_string(),
+                    serde_json::json!([{"id": "abc", "name": "API"}]),
+                )]
+                .into_iter()
+                .collect(),
+            );
+            let rendered = format_table_to_string(&data).unwrap();
+            assert!(
+                rendered.contains("| id  | name |"),
+                "collection: {collection}"
+            );
+        }
+
+        let monitors = serde_json::json!({
+            "monitors": [{"id": 42, "name": "API"}],
+            "counts": {"status": []},
+            "metadata": {"total_count": 1},
+            "total": 1
+        });
+        let rendered = format_table_to_string(&monitors).unwrap();
+        assert!(rendered.contains("| 42 | API  |"));
+    }
+
+    #[test]
+    fn test_collection_fields_on_resources_are_not_unwrapped() {
+        let resource = serde_json::json!({
+            "id": "group-1",
+            "name": "Owners",
+            "users": [{"id": "user-1"}]
+        });
+        assert_eq!(unwrap_table_data(&resource), &resource);
+
+        let envelope = serde_json::json!({
+            "widgets": [{"id": "widget-1"}],
+            "meta": {"total": 1}
+        });
+        assert_eq!(
+            unwrap_table_data(&envelope),
+            &serde_json::json!([{"id": "widget-1"}])
+        );
+    }
+
+    #[test]
+    fn test_incident_search_wrapper_requires_array_results() {
+        let response = serde_json::json!({
+            "type": "incidents_search_results",
+            "attributes": {"incidents": [{"id": "incident-1"}]}
+        });
+        assert_eq!(
+            unwrap_table_data(&response),
+            &serde_json::json!([{"id": "incident-1"}])
+        );
+
+        for value in [
+            serde_json::json!({
+                "type": "incident",
+                "attributes": {"incidents": [{"id": "related-1"}]}
+            }),
+            serde_json::json!({
+                "type": "incidents_search_results",
+                "attributes": {"incidents": {"id": "not-a-list"}}
+            }),
+        ] {
+            assert_eq!(unwrap_table_data(&value), &value);
+        }
+    }
+
+    #[test]
+    fn test_row_with_data_and_siblings_is_not_unwrapped() {
+        let row = serde_json::json!({"data": {"id": 1}, "meta": "keep"});
+        assert_eq!(unwrap_table_row(&row), &row);
+    }
+
+    #[test]
+    fn test_generic_column_selection_caps_fallback_fields() {
+        let row = serde_json::json!({
+            "extra_1": 1,
+            "status": "ok",
+            "name": "api",
+            "id": 42,
+            "extra_2": 2,
+        });
+        assert_eq!(
+            select_list_headers(&[&row], 4),
+            ["id", "name", "status", "extra_1"]
+        );
+        assert!(select_list_headers(&[], 4).is_empty());
+    }
+
+    #[test]
+    fn test_column_budget_caps_priority_and_preset_fields() {
+        let priority = serde_json::json!({
+            "id": 42,
+            "title": "API",
+            "name": "api",
+            "status": "ok"
+        });
+        assert_eq!(select_list_headers(&[&priority], 2), ["id", "title"]);
+
+        let monitor = serde_json::json!({
+            "id": 42,
+            "name": "API",
+            "overall_state": "OK",
+            "type": "query alert"
+        });
+        assert_eq!(select_list_headers(&[&monitor], 2), ["id", "name"]);
+        assert!(select_list_headers(&[&monitor], 0).is_empty());
+    }
+
+    #[test]
+    fn test_rows_without_columns_render_object_previews() {
+        let rendered = format_table_to_string(&serde_json::json!([{}, {}])).unwrap();
+        assert!(rendered.contains("| VALUE      |"));
+        assert_eq!(rendered.matches("| {0 fields} |").count(), 2);
     }
 
     #[test]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -10,6 +10,68 @@ enum OutputOrder {
     Preserve,
 }
 
+/// Command-provided guidance for rendering a concise table.
+///
+/// These options affect table output only. Other output formats continue to
+/// serialize the complete response.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TableOptions<'a> {
+    rows_at: Option<&'a str>,
+    row_at: Option<&'a str>,
+    columns: &'a [&'a str],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TableInput<'a> {
+    Generic,
+    Explicit(TableOptions<'a>),
+    AsIs,
+}
+
+impl<'a> From<TableOptions<'a>> for TableInput<'a> {
+    fn from(options: TableOptions<'a>) -> Self {
+        if options.rows_at.is_none() && options.row_at.is_none() && options.columns.is_empty() {
+            Self::Generic
+        } else {
+            Self::Explicit(options)
+        }
+    }
+}
+
+impl<'a> TableInput<'a> {
+    fn options(self) -> Option<TableOptions<'a>> {
+        match self {
+            Self::Explicit(options) => Some(options),
+            Self::Generic | Self::AsIs => None,
+        }
+    }
+
+    fn has_row_hints(self) -> bool {
+        self.options()
+            .is_some_and(|options| options.row_at.is_some() || !options.columns.is_empty())
+    }
+}
+
+impl<'a> TableOptions<'a> {
+    pub const fn new(columns: &'a [&'a str]) -> Self {
+        Self {
+            rows_at: None,
+            row_at: None,
+            columns,
+        }
+    }
+
+    pub const fn rows_at(mut self, pointer: &'a str) -> Self {
+        self.rows_at = Some(pointer);
+        self
+    }
+
+    pub const fn row_at(mut self, pointer: &'a str) -> Self {
+        self.row_at = Some(pointer);
+        self
+    }
+}
+
 /// Agent mode metadata envelope.
 #[derive(Serialize)]
 pub struct Metadata {
@@ -154,7 +216,35 @@ pub fn format_and_print<T: Serialize>(
     meta: Option<&Metadata>,
     jq: Option<&str>,
 ) -> Result<()> {
-    format_and_print_with_order(data, format, agent_mode, meta, jq, OutputOrder::Default)
+    format_and_print_with_order(
+        data,
+        format,
+        agent_mode,
+        meta,
+        jq,
+        TableInput::Generic,
+        OutputOrder::Default,
+    )
+}
+
+/// Format and print data with command-provided table guidance.
+pub fn format_and_print_with_table<T: Serialize>(
+    data: &T,
+    format: &OutputFormat,
+    agent_mode: bool,
+    meta: Option<&Metadata>,
+    jq: Option<&str>,
+    table: TableOptions<'_>,
+) -> Result<()> {
+    format_and_print_with_order(
+        data,
+        format,
+        agent_mode,
+        meta,
+        jq,
+        table.into(),
+        OutputOrder::Default,
+    )
 }
 
 fn format_and_print_with_order<T: Serialize>(
@@ -163,6 +253,7 @@ fn format_and_print_with_order<T: Serialize>(
     agent_mode: bool,
     meta: Option<&Metadata>,
     jq: Option<&str>,
+    table_input: TableInput<'_>,
     output_order: OutputOrder,
 ) -> Result<()> {
     // Serialize once; all renderers and the filter operate on this Value.
@@ -170,6 +261,8 @@ fn format_and_print_with_order<T: Serialize>(
     if let Some(expr) = jq {
         value = filter::apply_jq(value, expr)?;
     }
+    let output_order = effective_output_order(format, jq, output_order);
+    let table_input = effective_table_input(format, jq, table_input);
 
     if agent_mode && *format == OutputFormat::Json {
         // A --jq filter rewrites the payload, so the caller's count/truncated
@@ -205,13 +298,18 @@ fn format_and_print_with_order<T: Serialize>(
         OutputOrder::Default => match format {
             OutputFormat::Json => print_json(&value),
             OutputFormat::Yaml => print_yaml(&value),
-            OutputFormat::Table => print_table(&value),
+            OutputFormat::Table => print_table_with_options(&value, table_input),
             OutputFormat::Csv => print_csv(&value),
             OutputFormat::Tsv => print_tsv(&value),
         }?,
         OutputOrder::Preserve => {
-            let rendered =
-                format_value_to_string_with_order(&value, format, false, OutputOrder::Preserve)?;
+            let rendered = format_value_to_string_with_options(
+                &value,
+                format,
+                false,
+                OutputOrder::Preserve,
+                table_input,
+            )?;
             if !rendered.is_empty() {
                 print!("{rendered}");
                 if !rendered.ends_with('\n') {
@@ -229,6 +327,32 @@ fn format_and_print_with_order<T: Serialize>(
     Ok(())
 }
 
+fn effective_output_order(
+    format: &OutputFormat,
+    jq: Option<&str>,
+    output_order: OutputOrder,
+) -> OutputOrder {
+    if jq.is_some() && *format == OutputFormat::Table {
+        OutputOrder::Preserve
+    } else {
+        output_order
+    }
+}
+
+fn effective_table_input<'a>(
+    format: &OutputFormat,
+    jq: Option<&str>,
+    table_input: TableInput<'a>,
+) -> TableInput<'a> {
+    if jq.is_some() && *format == OutputFormat::Table {
+        // A jq expression explicitly reshapes the response. Render that result as-is
+        // instead of applying the command's defaults to a now-different shape.
+        TableInput::AsIs
+    } else {
+        table_input
+    }
+}
+
 /// Convenience: format and print using config settings (respects -o flag, agent mode, and --jq).
 pub fn output<T: Serialize>(cfg: &crate::config::Config, data: &T) -> Result<()> {
     format_and_print(
@@ -240,6 +364,22 @@ pub fn output<T: Serialize>(cfg: &crate::config::Config, data: &T) -> Result<()>
     )
 }
 
+/// Convenience wrapper for commands that know their useful table rows and columns.
+pub fn output_with_table<T: Serialize>(
+    cfg: &crate::config::Config,
+    data: &T,
+    table: TableOptions<'_>,
+) -> Result<()> {
+    format_and_print_with_table(
+        data,
+        &cfg.output_format,
+        cfg.agent_mode,
+        None,
+        cfg.jq.as_deref(),
+        table,
+    )
+}
+
 /// Format query results without changing the caller's object-key order.
 pub fn output_preserving_order<T: Serialize>(cfg: &crate::config::Config, data: &T) -> Result<()> {
     format_and_print_with_order(
@@ -248,6 +388,7 @@ pub fn output_preserving_order<T: Serialize>(cfg: &crate::config::Config, data: 
         cfg.agent_mode,
         None,
         cfg.jq.as_deref(),
+        TableInput::AsIs,
         OutputOrder::Preserve,
     )
 }
@@ -265,14 +406,21 @@ pub fn format_value_to_string(
     format: &OutputFormat,
     agent_mode: bool,
 ) -> Result<String> {
-    format_value_to_string_with_order(data, format, agent_mode, OutputOrder::Default)
+    format_value_to_string_with_options(
+        data,
+        format,
+        agent_mode,
+        OutputOrder::Default,
+        TableInput::Generic,
+    )
 }
 
-fn format_value_to_string_with_order(
+fn format_value_to_string_with_options(
     data: &serde_json::Value,
     format: &OutputFormat,
     agent_mode: bool,
     output_order: OutputOrder,
+    table_input: TableInput<'_>,
 ) -> Result<String> {
     if agent_mode && *format == OutputFormat::Json {
         let envelope = build_agent_envelope_with_order(data, None, output_order)?;
@@ -290,7 +438,7 @@ fn format_value_to_string_with_order(
             let ordered_data = order_json_value(data, output_order);
             Ok(serde_norway::to_string(&ordered_data)?)
         }
-        OutputFormat::Table => format_table_to_string_with_order(data, output_order),
+        OutputFormat::Table => format_table_to_string_with_options(data, output_order, table_input),
         OutputFormat::Csv => format_csv_to_string_with_order(data, output_order),
         OutputFormat::Tsv => format_tsv_to_string_with_order(data, output_order),
     }
@@ -307,16 +455,22 @@ pub fn eprint_formatted(
     Ok(())
 }
 
+#[cfg(test)]
 fn format_table_to_string(data: &serde_json::Value) -> Result<String> {
-    format_table_to_string_with_order(data, OutputOrder::Default)
+    format_table_to_string_with_options(data, OutputOrder::Default, TableInput::Generic)
 }
 
-fn format_table_to_string_with_order(
+fn format_table_to_string_with_options(
     data: &serde_json::Value,
     output_order: OutputOrder,
+    table_input: TableInput<'_>,
 ) -> Result<String> {
-    let table_data = unwrap_table_data(data);
+    let table_data = select_table_data(data, table_input)?;
+    let has_row_hints = table_input.has_row_hints();
     match table_data {
+        serde_json::Value::Array(_) if has_row_hints => {
+            format_horizontal_table(table_data, output_order, table_input)
+        }
         serde_json::Value::Array(values)
             if values
                 .iter()
@@ -324,50 +478,153 @@ fn format_table_to_string_with_order(
         {
             format_scalar_table(values.iter())
         }
-        serde_json::Value::Array(_) => format_horizontal_table(table_data, output_order),
+        serde_json::Value::Array(_) => {
+            format_horizontal_table(table_data, output_order, table_input)
+        }
+        serde_json::Value::Object(_) if has_row_hints => {
+            format_horizontal_table(table_data, output_order, table_input)
+        }
         serde_json::Value::Object(_) => format_vertical_table(table_data),
+        _ if has_row_hints => {
+            anyhow::bail!("table row and column hints require an array or object response")
+        }
         value => format_scalar_table(std::iter::once(value)),
     }
 }
 
-fn format_horizontal_table(data: &serde_json::Value, output_order: OutputOrder) -> Result<String> {
-    let raw_rows = extract_rows(data);
-    let owned_rows: Vec<serde_json::Value> = raw_rows
-        .iter()
-        .map(|row| flatten_row(unwrap_table_row(row)))
-        .collect();
-    let rows: Vec<&serde_json::Value> = owned_rows.iter().collect();
+fn select_table_data<'a>(
+    data: &'a serde_json::Value,
+    table_input: TableInput<'_>,
+) -> Result<&'a serde_json::Value> {
+    match table_input {
+        TableInput::Generic => Ok(unwrap_data(data)),
+        TableInput::Explicit(options) => match options.rows_at {
+            Some(pointer) => data.pointer(pointer).ok_or_else(|| {
+                anyhow::anyhow!("table row path {pointer:?} was not found in the response")
+            }),
+            None => Ok(data),
+        },
+        TableInput::AsIs => Ok(data),
+    }
+}
 
-    if rows.is_empty() {
+fn format_horizontal_table(
+    data: &serde_json::Value,
+    output_order: OutputOrder,
+    table_input: TableInput<'_>,
+) -> Result<String> {
+    let raw_rows = match data {
+        serde_json::Value::Array(rows) => rows.iter().collect(),
+        serde_json::Value::Object(_) => vec![data],
+        _ => Vec::new(),
+    };
+    let selected_rows = select_table_rows(raw_rows, table_input)?;
+    if selected_rows.is_empty() {
         return Ok("No results found".to_string());
     }
 
+    let requested_columns = table_input
+        .options()
+        .map(|options| options.columns)
+        .unwrap_or_default();
+    if !requested_columns.is_empty() {
+        let headers = select_requested_headers(&selected_rows, requested_columns)?;
+        return Ok(render_horizontal_rows(
+            &selected_rows,
+            &headers,
+            flattened_value,
+        ));
+    }
+
+    let owned_rows: Vec<serde_json::Value> =
+        selected_rows.iter().map(|row| flatten_row(row)).collect();
+    let rows: Vec<&serde_json::Value> = owned_rows.iter().collect();
     let final_headers = if output_order == OutputOrder::Default {
         select_list_headers(&rows, 12)
     } else {
         collect_headers(&rows).0.into_iter().take(12).collect()
     };
     if final_headers.is_empty() {
-        return format_scalar_table(raw_rows);
+        return format_scalar_table(selected_rows);
     }
-    let mut table = comfy_table::Table::new();
-    table.set_header(&final_headers);
 
-    for row in &rows {
-        let cells: Vec<String> = final_headers
+    Ok(render_horizontal_rows(&rows, &final_headers, object_value))
+}
+
+fn render_horizontal_rows(
+    rows: &[&serde_json::Value],
+    headers: &[String],
+    value_at: for<'a> fn(&'a serde_json::Value, &str) -> Option<&'a serde_json::Value>,
+) -> String {
+    let mut table = comfy_table::Table::new();
+    table.set_header(headers);
+
+    for row in rows {
+        let cells: Vec<String> = headers
             .iter()
-            .map(|h| {
-                if let serde_json::Value::Object(map) = row {
-                    format_cell(map.get(h.as_str()))
-                } else {
-                    String::new()
-                }
-            })
+            .map(|header| format_cell(value_at(row, header)))
             .collect();
         table.add_row(cells);
     }
 
-    Ok(table.to_string())
+    table.to_string()
+}
+
+fn select_table_rows<'a>(
+    rows: Vec<&'a serde_json::Value>,
+    table_input: TableInput<'_>,
+) -> Result<Vec<&'a serde_json::Value>> {
+    let Some(pointer) = table_input.options().and_then(|options| options.row_at) else {
+        return Ok(rows);
+    };
+    rows.into_iter()
+        .enumerate()
+        .map(|(index, row)| {
+            row.pointer(pointer).ok_or_else(|| {
+                anyhow::anyhow!("table row path {pointer:?} was not found in result row {index}")
+            })
+        })
+        .collect()
+}
+
+fn select_requested_headers(
+    rows: &[&serde_json::Value],
+    requested: &[&str],
+) -> Result<Vec<String>> {
+    let mut selected = Vec::new();
+    for column in requested {
+        if rows
+            .iter()
+            .any(|row| flattened_value(row, column).is_some())
+            && !selected.iter().any(|item| item == column)
+        {
+            selected.push((*column).to_string());
+        }
+    }
+    if selected.is_empty() {
+        anyhow::bail!(
+            "none of the requested table columns are present in the response: {}",
+            requested.join(", ")
+        );
+    }
+    Ok(selected)
+}
+
+fn flattened_value<'a>(row: &'a serde_json::Value, column: &str) -> Option<&'a serde_json::Value> {
+    let object = row.as_object()?;
+    if let Some(value) = object.get(column) {
+        return Some(value);
+    }
+
+    let mut value = row;
+    for part in column.split('.') {
+        value = value.as_object()?.get(part)?;
+    }
+    Some(value)
+}
+
+fn object_value<'a>(row: &'a serde_json::Value, column: &str) -> Option<&'a serde_json::Value> {
+    row.as_object()?.get(column)
 }
 
 fn format_vertical_table(data: &serde_json::Value) -> Result<String> {
@@ -422,11 +679,6 @@ fn collect_headers(
 
 fn select_list_headers(rows: &[&serde_json::Value], max: usize) -> Vec<String> {
     let (headers, header_set) = collect_headers(rows);
-    if let Some(mut headers) = shape_preset_headers(&header_set) {
-        headers.truncate(max);
-        return headers;
-    }
-
     let priority = [
         "id",
         "public_id",
@@ -465,149 +717,6 @@ fn select_list_headers(rows: &[&serde_json::Value], max: usize) -> Vec<String> {
         }
     }
     final_headers
-}
-
-fn shape_preset_headers(header_set: &std::collections::HashSet<String>) -> Option<Vec<String>> {
-    const PRESETS: &[(&[&str], &[&str])] = &[
-        // Logs
-        (
-            &["attributes.timestamp", "attributes.message"],
-            &[
-                "attributes.timestamp",
-                "attributes.service",
-                "attributes.status",
-                "attributes.host",
-                "attributes.message",
-            ],
-        ),
-        // Monitors
-        (
-            &["id", "name", "overall_state"],
-            &[
-                "id",
-                "name",
-                "overall_state",
-                "type",
-                "priority",
-                "tags",
-                "modified",
-            ],
-        ),
-        // Monitor search results
-        (
-            &["id", "name", "status", "type", "tags"],
-            &["id", "name", "status", "type", "tags", "last_triggered_ts"],
-        ),
-        // Incidents
-        (
-            &[
-                "attributes.title",
-                "attributes.severity",
-                "attributes.state",
-            ],
-            &[
-                "attributes.public_id",
-                "attributes.title",
-                "attributes.severity",
-                "attributes.state",
-                "attributes.customer_impacted",
-                "attributes.created",
-            ],
-        ),
-        // Dashboards
-        (
-            &["id", "title", "layout_type"],
-            &[
-                "id",
-                "title",
-                "layout_type",
-                "author_handle",
-                "modified_at",
-                "url",
-            ],
-        ),
-        // SLOs
-        (
-            &["id", "name", "thresholds"],
-            &["id", "name", "type", "tags", "thresholds", "modified_at"],
-        ),
-        // Users
-        (
-            &["id", "attributes.email", "attributes.status"],
-            &[
-                "id",
-                "attributes.name",
-                "attributes.email",
-                "attributes.status",
-                "attributes.created_at",
-                "attributes.modified_at",
-            ],
-        ),
-    ];
-
-    PRESETS.iter().find_map(|(required, columns)| {
-        required
-            .iter()
-            .all(|header| header_set.contains(*header))
-            .then(|| available_columns(columns, header_set))
-    })
-}
-
-fn available_columns(
-    columns: &[&str],
-    header_set: &std::collections::HashSet<String>,
-) -> Vec<String> {
-    columns
-        .iter()
-        .filter(|header| header_set.contains(**header))
-        .map(|header| (*header).to_string())
-        .collect()
-}
-
-fn unwrap_table_data(value: &serde_json::Value) -> &serde_json::Value {
-    let value = unwrap_data(value);
-    match value {
-        serde_json::Value::Object(map) => collection_envelope_rows(map)
-            .or_else(|| search_result_rows(value))
-            .unwrap_or(value),
-        _ => value,
-    }
-}
-
-fn collection_envelope_rows(
-    map: &serde_json::Map<String, serde_json::Value>,
-) -> Option<&serde_json::Value> {
-    if map.contains_key("id") {
-        return None;
-    }
-
-    let mut arrays = map
-        .values()
-        .filter(|field| matches!(field, serde_json::Value::Array(_)));
-    let rows = arrays.next()?;
-    arrays.next().is_none().then_some(rows)
-}
-
-fn search_result_rows(value: &serde_json::Value) -> Option<&serde_json::Value> {
-    let resource_type = value.get("type")?.as_str()?;
-    if !resource_type.ends_with("_search_results") {
-        return None;
-    }
-    let attributes = value.get("attributes")?.as_object()?;
-    let mut arrays = attributes
-        .values()
-        .filter(|field| matches!(field, serde_json::Value::Array(_)));
-    let rows = arrays.next()?;
-    arrays.next().is_none().then_some(rows)
-}
-
-fn unwrap_table_row(value: &serde_json::Value) -> &serde_json::Value {
-    match value {
-        serde_json::Value::Object(map) if map.len() == 1 && map.contains_key("data") => {
-            unwrap_data(value)
-        }
-        _ => value,
-    }
 }
 
 fn print_yaml(data: &serde_json::Value) -> Result<()> {
@@ -652,8 +761,16 @@ fn flatten_row(value: &serde_json::Value) -> serde_json::Value {
     }
 }
 
+#[cfg(test)]
 fn print_table(data: &serde_json::Value) -> Result<()> {
-    println!("{}", format_table_to_string(data)?);
+    print_table_with_options(data, TableInput::Generic)
+}
+
+fn print_table_with_options(data: &serde_json::Value, table_input: TableInput<'_>) -> Result<()> {
+    println!(
+        "{}",
+        format_table_to_string_with_options(data, OutputOrder::Default, table_input)?
+    );
     Ok(())
 }
 
@@ -965,7 +1082,7 @@ mod tests {
     }
 
     #[test]
-    fn test_monitor_shape_uses_opinionated_columns() {
+    fn test_generic_columns_do_not_guess_resource_shapes() {
         let row = serde_json::json!({
             "id": 123,
             "name": "API latency",
@@ -977,158 +1094,174 @@ mod tests {
             "query": "avg(last_5m):avg:latency{*} > 1",
             "message": "not useful in a list view"
         });
-        assert_eq!(
-            select_list_headers(&[&flatten_row(&row)], 12),
-            [
-                "id",
-                "name",
-                "overall_state",
-                "type",
-                "priority",
-                "tags",
-                "modified"
-            ]
-        );
-    }
-
-    #[test]
-    fn test_known_api_shapes_have_column_presets() {
-        let cases: &[(&[&str], &[&str])] = &[
-            (
-                &[
-                    "attributes.timestamp",
-                    "attributes.message",
-                    "attributes.service",
-                ],
-                &[
-                    "attributes.timestamp",
-                    "attributes.service",
-                    "attributes.message",
-                ],
-            ),
-            (
-                &[
-                    "attributes.public_id",
-                    "attributes.title",
-                    "attributes.severity",
-                    "attributes.state",
-                ],
-                &[
-                    "attributes.public_id",
-                    "attributes.title",
-                    "attributes.severity",
-                    "attributes.state",
-                ],
-            ),
-            (
-                &["id", "title", "layout_type", "url", "description"],
-                &["id", "title", "layout_type", "url"],
-            ),
-            (
-                &["id", "name", "type", "tags", "thresholds", "query"],
-                &["id", "name", "type", "tags", "thresholds"],
-            ),
-            (
-                &[
-                    "id",
-                    "attributes.name",
-                    "attributes.email",
-                    "attributes.status",
-                ],
-                &[
-                    "id",
-                    "attributes.name",
-                    "attributes.email",
-                    "attributes.status",
-                ],
-            ),
-        ];
-
-        for (available, expected) in cases {
-            let header_set = available
-                .iter()
-                .map(|header| (*header).to_string())
-                .collect();
-            assert_eq!(shape_preset_headers(&header_set).unwrap(), *expected);
-        }
-    }
-
-    #[test]
-    fn test_common_collection_wrappers_render_as_lists() {
-        for collection in ["dashboards", "monitors", "users"] {
-            let data = serde_json::Value::Object(
-                [(
-                    collection.to_string(),
-                    serde_json::json!([{"id": "abc", "name": "API"}]),
-                )]
-                .into_iter()
-                .collect(),
-            );
-            let rendered = format_table_to_string(&data).unwrap();
+        let row = flatten_row(&row);
+        let headers = select_list_headers(&[&row], 12);
+        for expected in ["query", "message"] {
             assert!(
-                rendered.contains("| id  | name |"),
-                "collection: {collection}"
+                headers.iter().any(|header| header == expected),
+                "generic formatting should retain {expected}: {headers:?}"
             );
         }
-
-        let monitors = serde_json::json!({
-            "monitors": [{"id": 42, "name": "API"}],
-            "counts": {"status": []},
-            "metadata": {"total_count": 1},
-            "total": 1
-        });
-        let rendered = format_table_to_string(&monitors).unwrap();
-        assert!(rendered.contains("| 42 | API  |"));
     }
 
     #[test]
-    fn test_collection_fields_on_resources_are_not_unwrapped() {
-        let resource = serde_json::json!({
-            "id": "group-1",
-            "name": "Owners",
-            "users": [{"id": "user-1"}]
+    fn test_command_table_options_select_rows_and_columns() {
+        let data = serde_json::json!({
+            "monitors": [{
+                "id": 123,
+                "name": "API latency",
+                "overall_state": "Alert",
+                "query": "avg(last_5m):avg:latency{*} > 1"
+            }],
+            "metadata": {"total_count": 1}
         });
-        assert_eq!(unwrap_table_data(&resource), &resource);
+        let table = TableOptions::new(&["name", "id", "priority"]).rows_at("/monitors");
+        let rendered =
+            format_table_to_string_with_options(&data, OutputOrder::Default, table.into()).unwrap();
+        let header = rendered.lines().find(|line| line.contains("name")).unwrap();
 
-        let envelope = serde_json::json!({
-            "widgets": [{"id": "widget-1"}],
-            "meta": {"total": 1}
-        });
-        assert_eq!(
-            unwrap_table_data(&envelope),
-            &serde_json::json!([{"id": "widget-1"}])
-        );
+        assert!(header.contains("| name        | id  |"), "{rendered}");
+        assert!(!header.contains("priority"), "{rendered}");
+        assert!(!rendered.contains("overall_state"), "{rendered}");
+        assert!(!rendered.contains("query"), "{rendered}");
+        assert!(rendered.contains("API latency"), "{rendered}");
     }
 
     #[test]
-    fn test_incident_search_wrapper_requires_array_results() {
-        let response = serde_json::json!({
-            "type": "incidents_search_results",
-            "attributes": {"incidents": [{"id": "incident-1"}]}
+    fn test_command_table_options_select_nested_row_values() {
+        let data = serde_json::json!({
+            "data": {
+                "attributes": {
+                    "incidents": [{
+                        "data": {
+                            "id": "incident-1",
+                            "attributes": {
+                                "title": "API outage",
+                                "state": "active"
+                            }
+                        }
+                    }]
+                }
+            }
         });
-        assert_eq!(
-            unwrap_table_data(&response),
-            &serde_json::json!([{"id": "incident-1"}])
-        );
+        let table = TableOptions::new(&["attributes.title", "id"])
+            .rows_at("/data/attributes/incidents")
+            .row_at("/data");
+        let rendered =
+            format_table_to_string_with_options(&data, OutputOrder::Default, table.into()).unwrap();
 
-        for value in [
-            serde_json::json!({
-                "type": "incident",
-                "attributes": {"incidents": [{"id": "related-1"}]}
-            }),
-            serde_json::json!({
-                "type": "incidents_search_results",
-                "attributes": {"incidents": {"id": "not-a-list"}}
-            }),
-        ] {
-            assert_eq!(unwrap_table_data(&value), &value);
+        assert!(rendered.contains("attributes.title"), "{rendered}");
+        assert!(rendered.contains("API outage"), "{rendered}");
+        assert!(rendered.contains("incident-1"), "{rendered}");
+        assert!(!rendered.contains("data.attributes"), "{rendered}");
+    }
+
+    #[test]
+    fn test_command_table_options_reject_missing_rows() {
+        let data = serde_json::json!({"items": []});
+        let table = TableOptions::new(&["id"]).rows_at("/monitors");
+        let error = format_table_to_string_with_options(&data, OutputOrder::Default, table.into())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("/monitors"), "{error}");
+    }
+
+    #[test]
+    fn test_command_table_options_reject_missing_nested_row() {
+        let data = serde_json::json!([{"attributes": {"title": "API outage"}}]);
+        let table = TableOptions::new(&["attributes.title"]).row_at("/data");
+        let error = format_table_to_string_with_options(&data, OutputOrder::Default, table.into())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("result row 0"), "{error}");
+    }
+
+    #[test]
+    fn test_command_table_options_reject_unknown_columns() {
+        let data = serde_json::json!([{"id": 123, "name": "API latency"}]);
+        let table = TableOptions::new(&["missing"]);
+        let error = format_table_to_string_with_options(&data, OutputOrder::Default, table.into())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("missing"), "{error}");
+    }
+
+    #[test]
+    fn test_command_table_options_apply_to_single_object() {
+        let data = serde_json::json!({
+            "id": 123,
+            "attributes": {"title": "API latency", "query": "omit"}
+        });
+        let table = TableOptions::new(&["attributes.title", "id"]);
+        let rendered =
+            format_table_to_string_with_options(&data, OutputOrder::Default, table.into()).unwrap();
+
+        let header = rendered
+            .lines()
+            .find(|line| line.contains("attributes.title"))
+            .unwrap();
+        assert!(header.contains("| attributes.title | id  |"), "{rendered}");
+        assert!(rendered.contains("API latency"), "{rendered}");
+        assert!(!rendered.contains("query"), "{rendered}");
+    }
+
+    #[test]
+    fn test_command_table_options_reject_scalar_input() {
+        let table = TableOptions::new(&["id"]);
+        let error = format_table_to_string_with_options(
+            &serde_json::json!(42),
+            OutputOrder::Default,
+            table.into(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("require an array or object"), "{error}");
+    }
+
+    #[test]
+    fn test_empty_table_options_keep_generic_data_unwrapping() {
+        let data = serde_json::json!({"data": [{"id": 123}]});
+        let rendered = format_table_to_string_with_options(
+            &data,
+            OutputOrder::Default,
+            TableOptions::default().into(),
+        )
+        .unwrap();
+
+        assert!(rendered.contains("id"), "{rendered}");
+        assert!(!rendered.contains("FIELD"), "{rendered}");
+    }
+
+    #[test]
+    fn test_jq_table_projection_bypasses_command_table_options() {
+        let data = serde_json::json!([{"value": 42, "name": "answer"}]);
+        let jq = ".[] | {data: .value, label: .name}";
+        let projected = filter::apply_jq(data, jq).unwrap();
+        let output_order =
+            effective_output_order(&OutputFormat::Table, Some(jq), OutputOrder::Default);
+        let command_table = TableOptions::new(&["missing"]).rows_at("/missing");
+        let table_input =
+            effective_table_input(&OutputFormat::Table, Some(jq), command_table.into());
+        let rendered =
+            format_table_to_string_with_options(&projected, output_order, table_input).unwrap();
+        for expected in ["data", "42", "label", "answer"] {
+            assert!(
+                rendered.contains(expected),
+                "missing {expected}: {rendered}"
+            );
         }
     }
 
     #[test]
-    fn test_row_with_data_and_siblings_is_not_unwrapped() {
-        let row = serde_json::json!({"data": {"id": 1}, "meta": "keep"});
-        assert_eq!(unwrap_table_row(&row), &row);
+    fn test_data_named_column_is_not_unwrapped() {
+        let rows = serde_json::json!([{"data": 42}]);
+        let rendered =
+            format_table_to_string_with_options(&rows, OutputOrder::Preserve, TableInput::AsIs)
+                .unwrap();
+        let header = rendered.lines().find(|line| line.contains("data")).unwrap();
+        assert!(header.contains("data"), "missing DDSQL column: {rendered}");
+        assert!(rendered.contains("42"), "missing DDSQL value: {rendered}");
     }
 
     #[test]
@@ -1148,7 +1281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_column_budget_caps_priority_and_preset_fields() {
+    fn test_column_budget_caps_priority_fields() {
         let priority = serde_json::json!({
             "id": 42,
             "title": "API",
@@ -1515,9 +1648,14 @@ mod tests {
         }]);
 
         for format in [OutputFormat::Json, OutputFormat::Yaml, OutputFormat::Table] {
-            let rendered =
-                format_value_to_string_with_order(&data, &format, false, OutputOrder::Preserve)
-                    .unwrap();
+            let rendered = format_value_to_string_with_options(
+                &data,
+                &format,
+                false,
+                OutputOrder::Preserve,
+                TableInput::AsIs,
+            )
+            .unwrap();
             let zebra = rendered.find("zebra").unwrap();
             let alpha = rendered.find("alpha").unwrap();
             let middle = rendered.find("middle").unwrap();
@@ -1527,20 +1665,22 @@ mod tests {
             );
         }
 
-        let csv = format_value_to_string_with_order(
+        let csv = format_value_to_string_with_options(
             &data,
             &OutputFormat::Csv,
             false,
             OutputOrder::Preserve,
+            TableInput::AsIs,
         )
         .unwrap();
         assert_eq!(csv.lines().next(), Some("zebra,alpha,middle"));
 
-        let tsv = format_value_to_string_with_order(
+        let tsv = format_value_to_string_with_options(
             &data,
             &OutputFormat::Tsv,
             false,
             OutputOrder::Preserve,
+            TableInput::AsIs,
         )
         .unwrap();
         assert_eq!(tsv.lines().next(), Some("zebra\talpha\tmiddle"));
@@ -1554,11 +1694,12 @@ mod tests {
             "middle": 3
         }]);
 
-        let rendered = format_value_to_string_with_order(
+        let rendered = format_value_to_string_with_options(
             &data,
             &OutputFormat::Json,
             true,
             OutputOrder::Preserve,
+            TableInput::AsIs,
         )
         .unwrap();
         let zebra = rendered.find("zebra").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1468,6 +1468,7 @@ enum Commands {
     ///
     /// EXAMPLES:
     ///   pup api v2/monitors --silent | pup format --output table
+    ///   pup api v1/monitor/search --silent | pup format --rows-at /monitors --columns id,name,status
     ///   echo '[{"id":1}]' | pup format --output csv
     #[cfg(not(target_arch = "wasm32"))]
     #[command(visible_alias = "fmt", verbatim_doc_comment)]
@@ -1484,6 +1485,15 @@ enum Commands {
         /// Set metadata.next_action in the agent-mode envelope
         #[arg(long, value_name = "STR")]
         next_action: Option<String>,
+        /// Select table rows using an RFC 6901 JSON Pointer (for example, /data)
+        #[arg(long, value_name = "POINTER")]
+        rows_at: Option<String>,
+        /// Select each table row's value using an RFC 6901 JSON Pointer
+        #[arg(long, value_name = "POINTER")]
+        row_at: Option<String>,
+        /// Show these table columns in this order (comma-separated or repeated)
+        #[arg(long, value_name = "FIELD", value_delimiter = ',')]
+        columns: Vec<String>,
     },
     /// Manage tag governance
     ///
@@ -12980,7 +12990,9 @@ fn resolve_output_format(
 mod resolve_output_format_tests {
     use super::reject_jq_with_markdown;
     use super::resolve_output_format;
+    use super::{Cli, Commands};
     use crate::config::OutputFormat;
+    use clap::Parser;
 
     #[test]
     fn jq_flag_with_markdown_is_rejected() {
@@ -13020,6 +13032,36 @@ mod resolve_output_format_tests {
             got.is_err(),
             "a malformed --output value must be a hard error"
         );
+    }
+
+    #[test]
+    fn format_table_hints_parse_comma_separated_and_repeated_columns() {
+        let cli = Cli::try_parse_from([
+            "pup",
+            "format",
+            "--rows-at",
+            "/results",
+            "--row-at",
+            "/data",
+            "--columns",
+            "id,name",
+            "--columns",
+            "status",
+        ])
+        .unwrap();
+        let Commands::Format {
+            rows_at,
+            row_at,
+            columns,
+            ..
+        } = cli.command
+        else {
+            panic!("expected format command");
+        };
+
+        assert_eq!(rows_at.as_deref(), Some("/results"));
+        assert_eq!(row_at.as_deref(), Some("/data"));
+        assert_eq!(columns, ["id", "name", "status"]);
     }
 }
 
@@ -17406,8 +17448,22 @@ async fn main_inner() -> anyhow::Result<()> {
             count,
             command,
             next_action,
+            rows_at,
+            row_at,
+            columns,
         } => {
-            commands::format::run(&cfg, input.as_deref(), count, command, next_action)?;
+            commands::format::run(
+                &cfg,
+                input.as_deref(),
+                commands::format::FormatOptions {
+                    count,
+                    command,
+                    next_action,
+                    rows_at: rows_at.as_deref(),
+                    row_at: row_at.as_deref(),
+                    columns: &columns,
+                },
+            )?;
         }
         // --- Skills ---
         #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Motivation

Picking useful columns is endpoint knowledge. The generic formatter can guess from field names, but that gets risky fast: unrelated resources can have similar shapes, and treating an arbitrary array field as a collection can discard the rest of the response.

Commands already know what they fetched, so they’re a better place to decide which rows and columns are useful.

## Changes

Commands can now pass table-specific presentation hints into the formatter:

- where collection rows live in the response
- where the displayable value lives inside each row
- which columns to show, and in what order

Logs, monitors and monitor search results, incidents, dashboards, SLOs, and users now provide their own concise table columns.

Extensions can do the same without being written in Rust:

```bash
pup api v1/monitor/search --silent |
  pup format \
    --rows-at /monitors \
    --columns id,name,status,type,tags
```

`pup format` supports `--rows-at`, `--row-at`, and `--columns`. These only affect table output; JSON, YAML, CSV, and TSV retain the complete response.

Generic API and formatter input keeps the existing priority-and-fallback behavior. When `--jq` supplies a new table shape, that result is rendered as-is instead of applying the command’s defaults.

Before:

```text
id  name         type         modified     message      overall_state  priority  query       tags
42  API latency  query alert  2026-09-10…  Notify @ops  Alert          1         avg(…) > 1  [env:prod]
```

After:

```text
id  name         overall_state  type         priority  tags        modified
42  API latency  Alert          query alert  1         [env:prod]  2026-09-10…
```

## QA

- Run `pup monitors list --output table` and confirm state and priority appear ahead of configuration details.
- Run `pup incidents list --output table` and confirm the nested incident resources render with the configured columns.
- Pipe monitor search output through `pup format --rows-at /monitors --columns id,name,status` and confirm only those columns appear.
- Run `pup tags get "host-name" --output table` and confirm the response remains a vertical resource containing both `host` and `tags`.
- Apply a `--jq` projection that includes a normally hidden field and confirm the projected shape wins.

## Blast Radius

Human-readable table output for the commands listed above, plus opt-in presentation hints for `pup format`. Other output formats ignore the hints.
