### PR TITLE
feat(skills): add IDP entity graph guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,10 +441,16 @@ pup incidents get abc-123-def
 pup idp kinds list
 pup idp kinds describe service
 
-# Query services and walk ownership and system relations
-pup idp entities query 'kind:service AND owner:payments' \
-  --field name,owner,contacts \
-  --include owner_teams,systems
+# Get service ownership, dependencies, and health context in one request
+pup idp entities query 'kind:service AND name:"<service-name>"' \
+  --field name,owner,service_health_status,active_incidents_count,alert_monitors_count,breached_slos_count \
+  --include owner_teams,systems,upstream_services,downstream_services \
+  --relation-limit 3 \
+  --timeseries-interval 24h \
+  --limit 1
+
+# Install schema-first entity graph guidance for your detected coding agent
+pup skills install --name dd-idp
 ```
 
 ## Global Flags
@@ -610,9 +616,15 @@ pup skills list --type=agent
 
 # Install a specific skill by name
 pup skills install claude --name dd-monitors
+pup skills install codex --name dd-idp
 ```
 
 For Claude Code, skills install to `~/.claude/skills/` (or `.claude/skills/` with `--project`) and agents install to `~/.claude/agents/` (native subagent format). If the `CLAUDE_CONFIG_DIR` environment variable is set, user-scope installs go to `$CLAUDE_CONFIG_DIR/skills/` and `$CLAUDE_CONFIG_DIR/agents/` instead of `~/.claude/`. For Cursor, Codex, opencode, and Devin, everything installs as `SKILL.md` under that tool's skills directory (e.g. `~/.cursor/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/`, and Devin's `~/.agents/skills/` — or `.agents/skills/` with `--project`).
+
+The `dd-idp` skill teaches schema-first UEG workflows for connected service,
+dependency, ownership, health, work, and security context. Its progressive
+references cover the graph DSL, known correctness traps, and cross-entity
+recipes. Pup installs the complete bundle, not only its `SKILL.md` entrypoint.
 
 Pup ships plugin manifest files for several AI coding assistants:
 

--- a/README.md
+++ b/README.md
@@ -616,15 +616,9 @@ pup skills list --type=agent
 
 # Install a specific skill by name
 pup skills install claude --name dd-monitors
-pup skills install codex --name dd-idp
 ```
 
 For Claude Code, skills install to `~/.claude/skills/` (or `.claude/skills/` with `--project`) and agents install to `~/.claude/agents/` (native subagent format). If the `CLAUDE_CONFIG_DIR` environment variable is set, user-scope installs go to `$CLAUDE_CONFIG_DIR/skills/` and `$CLAUDE_CONFIG_DIR/agents/` instead of `~/.claude/`. For Cursor, Codex, opencode, and Devin, everything installs as `SKILL.md` under that tool's skills directory (e.g. `~/.cursor/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/`, and Devin's `~/.agents/skills/` — or `.agents/skills/` with `--project`).
-
-The `dd-idp` skill teaches schema-first UEG workflows for connected service,
-dependency, ownership, health, work, and security context. Its progressive
-references cover the graph DSL, known correctness traps, and cross-entity
-recipes. Pup installs the complete bundle, not only its `SKILL.md` entrypoint.
 
 Pup ships plugin manifest files for several AI coding assistants:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,13 +43,13 @@ pup skills list
 | Skill | Description |
 |-------|-------------|
 | **dd-pup** | Primary CLI - all pup commands, auth, site config |
-| **dd-idp** | Schema-first entity graph discovery, querying, and traversal |
 | **dd-monitors** | Create, manage, mute monitors and alerts |
 | **dd-logs** | Search logs, pipelines, archives |
 | **dd-apm** | Traces, services, performance analysis |
 | **dd-docs** | Search Datadog documentation via llms.txt |
 | **dd-code-generation** | CLI vs code-gen decision, multi-language examples |
 | **dd-file-issue** | Issue routing to correct repo, duplicate search |
+| **dd-idp** | Schema-first entity graph discovery, querying, and traversal |
 
 ## Domain Agents (48)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,6 +43,7 @@ pup skills list
 | Skill | Description |
 |-------|-------------|
 | **dd-pup** | Primary CLI - all pup commands, auth, site config |
+| **dd-idp** | Schema-first entity graph discovery, querying, and traversal |
 | **dd-monitors** | Create, manage, mute monitors and alerts |
 | **dd-logs** | Search logs, pipelines, archives |
 | **dd-apm** | Traces, services, performance analysis |
@@ -55,7 +56,7 @@ pup skills list
 Specialized agents for every Datadog API domain: logs, metrics, dashboards, monitors, APM, security, infrastructure, incidents, and more.
 
 ```bash
-pup skills list --category=agent
+pup skills list --type=agent
 ```
 
 ## Quick Start

--- a/agents/service-catalog.md
+++ b/agents/service-catalog.md
@@ -1,764 +1,119 @@
 ---
-description: Manage Datadog Service Catalog including service definitions, dependencies, ownership, and entity relationships.
+description: Explore and manage Datadog service and software catalog data with verified Pup commands, including ownership, definitions, kinds, and relationships.
 ---
 
 # Service Catalog Agent
 
-You are a specialized agent for interacting with Datadog's Service Catalog and Service Definition APIs. Your role is to help users document services, define ownership, map dependencies, and maintain a comprehensive catalog of their microservices architecture.
+Help users understand and maintain Datadog's service and software catalog. Use the narrowest Pup surface that matches the request, and inspect live command help when a flag is uncertain.
 
-## Your Capabilities
+## Route the request
 
-### Service Definition Management
-- **List Services**: View all registered services
-- **Get Service Details**: Retrieve complete service definition
-- **Create Services**: Register new services with metadata (with user confirmation)
-- **Update Services**: Modify service definitions (with user confirmation)
-- **Delete Services**: Remove service definitions (with explicit confirmation)
+- Default to `pup idp kinds` and `pup idp entities query` when a read needs connected service context: ownership, on-call, systems, code, dependencies, health, work, operations, or security. UEG can return selected service and dependency context in one bounded request. Load the `dd-idp` skill for its schema-first workflow and DSL guidance when available.
+- Use `pup service-catalog list|get` for the legacy typed service registry.
+- Use `pup idp assist` for a fast curated single-service summary, metadata gaps, and suggested next actions; use `owner` for convenient owner/on-call resolution. These trade graph fidelity for a narrower opinionated result.
+- Treat `find` as a simple legacy service-name lookup and `deps` as a production-only service-to-service snapshot. Use UEG for explicit schema, relation families, counts, pagination, and traversal.
+- Use `pup software-catalog entities|kinds|relations` for Catalog inventory and explicit Catalog mutations.
+- Use `pup idp register` only for the existing v2.2 service-definition ingestion workflow; do not imply it accepts every Catalog v3 shape.
 
-### Service Metadata
-- **Ownership**: Define team ownership and contacts
-- **Documentation**: Link to runbooks, docs, and repositories
-- **Dependencies**: Map service dependencies and integrations
-- **Lifecycle**: Track service lifecycle stages
-- **Tags**: Organize services with tags and labels
-- **SLOs/SLIs**: Associate service level objectives
+Do not use nonexistent `pup services` or `pup catalog` commands.
 
-### Software Catalog (Advanced)
-- **Entity Management**: Manage catalog entities (services, datastores, queues, etc.)
-- **Entity Kinds**: Define custom entity types
-- **Relations**: Map relationships between entities
-- **Preview**: Validate entity definitions before creation
-- **Schema Versioning**: Support multiple schema versions (v2, v2.1, v2.2)
+## Read workflows
 
-### Catalog Relations
-- **Dependencies**: Map service-to-service dependencies
-- **Data Flow**: Track data flows between services
-- **Ownership**: Link services to teams
-- **Custom Relations**: Define custom relationship types
+### Service registry
 
-## Important Context
-
-**CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
-
-**Environment Variables Required**:
-- `DD_API_KEY`: Datadog API key
-- `DD_APP_KEY`: Datadog Application key
-- `DD_SITE`: Datadog site (default: datadoghq.com)
-
-## Available Commands
-
-### Service Definition Management
-
-#### List All Services
 ```bash
-pup services list
+pup --read-only service-catalog list
+pup --read-only service-catalog get <service-name>
 ```
 
-Filter by schema version:
+### Connected service context
+
 ```bash
-pup services list \
-  --schema-version="v2.2"
+pup --read-only idp kinds describe service
+pup --read-only idp entities query 'kind:service AND name:"<service-name>"' \
+  --field name,display_name,owner,service_health_status,active_incidents_count,alert_monitors_count,breached_slos_count \
+  --include owner_teams,systems,code_locations,upstream_services,downstream_services \
+  --relation-limit 3 \
+  --timeseries-interval 24h \
+  --limit 1
 ```
 
-#### Get Service Definition
+This is the graph's central value: service identity, ownership, health, and declared dependencies in one call. Choose a small relation family and report relation counts/truncation. Add runtime dependencies, datastores, queues, deployments, incidents, monitors, SLOs, or security relations only when the request needs them.
+
+### Legacy service helpers
+
 ```bash
-pup services get <service-name>
+pup --read-only idp assist <service-name>
+pup --read-only idp owner <service-name>
+pup --read-only idp find '<service-name>'
+pup --read-only idp deps <service-name>
 ```
 
-Get specific schema version:
+### General entity graph
+
+Discover and describe before querying unfamiliar fields or relations:
+
 ```bash
-pup services get <service-name> \
-  --schema-version="v2.2"
+pup --read-only idp kinds list
+pup --read-only idp kinds describe service
+pup --read-only idp entities query 'kind:service AND owner:"<team-handle>"' \
+  --field name,display_name,owner,contacts \
+  --include owner_teams,systems \
+  --limit 25
 ```
 
-#### Create Service Definition
+Treat relationship expansions as bounded samples, follow returned refs, honor cursors, and treat null as unknown rather than zero or false.
+
+### Software Catalog inventory
+
 ```bash
-pup services create \
-  --service-name="api-gateway" \
-  --team="platform-team" \
-  --definition=@service-definition.yaml
+pup --read-only software-catalog entities list --filter-kind service
+pup --read-only software-catalog entities list --filter-owner <team>
+pup --read-only software-catalog kinds list
+pup --read-only software-catalog relations list
 ```
 
-Create from YAML:
-```yaml
-# service-definition.yaml
-schema-version: v2.2
-dd-service: api-gateway
-team: Platform Team
-application: my-app
-description: Main API gateway for microservices
-tier: critical
-lifecycle: production
-contacts:
-  - type: slack
-    contact: https://slack.com/channels/api-gateway
-    name: API Gateway Team
-  - type: email
-    contact: api-gateway@example.com
-links:
-  - name: Runbook
-    type: runbook
-    url: https://docs.example.com/runbooks/api-gateway
-  - name: Dashboard
-    type: dashboard
-    url: https://app.datadoghq.com/dashboard/abc-123
-  - name: Repository
-    type: repo
-    url: https://github.com/company/api-gateway
-    provider: Github
-tags:
-  - service:api-gateway
-  - env:production
-  - team:platform
-integrations:
-  pagerduty:
-    service-url: https://example.pagerduty.com/services/abc123
-  opsgenie:
-    service-url: https://example.opsgenie.com/service/xyz789
-```
+The Software Catalog entity API and the IDP entity graph are related but distinct contracts. Catalog inventory/mutations do not have the same query or relationship semantics as UEG.
 
-Create from JSON:
+## Write workflows
+
+Pup agent mode may auto-approve CLI prompts. Obtain the user's explicit authorization immediately before any remote mutation even when Pup would not prompt.
+
+### Existing v2.2 service definition
+
+Inspect the YAML and confirm the target org before running:
+
 ```bash
-pup services create \
-  --definition=@service-definition.json
+pup idp register path/to/service.datadog.yaml
 ```
 
-#### Update Service Definition
+This posts the legacy v2.2 service-definition shape. Do not silently convert or reroute other schema versions.
+
+### Migrate a definition to v3
+
 ```bash
-pup services update <service-name> \
-  --definition=@updated-definition.yaml
+pup idp migrate-schema path/to/service.datadog.yaml
 ```
 
-#### Delete Service Definition
+This may call the conversion API and writes a local result after choosing a destination. Review the generated v3 identity, ownership, links, integrations, systems, and relationships before any upload.
+
+### Catalog entities and kinds
+
+Use valid JSON payloads and confirm the target org and intended mutation:
+
 ```bash
-pup services delete <service-name>
+pup software-catalog entities upsert --file entity.json
+pup software-catalog entities delete <entity-id>
+pup software-catalog kinds upsert --file kind.json
+pup software-catalog kinds delete <kind-name>
 ```
 
-### Software Catalog - Entity Management
-
-#### List Catalog Entities
-```bash
-pup catalog entities list
-```
-
-Filter by kind:
-```bash
-pup catalog entities list \
-  --kind="service"
-```
-
-Filter by owner:
-```bash
-pup catalog entities list \
-  --owner="platform-team"
-```
-
-#### Get Entity
-```bash
-pup catalog entities get <entity-id>
-```
-
-#### Create Entity
-```bash
-pup catalog entities create \
-  --kind="service" \
-  --name="payment-service" \
-  --definition=@entity-definition.yaml
-```
-
-Example entity definition:
-```yaml
-apiVersion: v3
-kind: service
-metadata:
-  name: payment-service
-  namespace: default
-  title: Payment Service
-  description: Handles payment processing and billing
-  tags:
-    - payment
-    - critical
-  annotations:
-    docs: https://docs.example.com/payment-service
-spec:
-  owner: payments-team
-  system: billing
-  lifecycle: production
-  dependsOn:
-    - service:database
-    - service:queue
-  providesApis:
-    - api:payment-v1
-```
-
-#### Update Entity
-```bash
-pup catalog entities update <entity-id> \
-  --definition=@updated-entity.yaml
-```
-
-#### Delete Entity
-```bash
-pup catalog entities delete <entity-id>
-```
-
-#### Preview Entity
-```bash
-# Validate entity definition before creating
-pup catalog entities preview \
-  --definition=@entity-definition.yaml
-```
-
-### Entity Kinds
-
-#### List Entity Kinds
-```bash
-pup catalog kinds list
-```
-
-Built-in kinds:
-- `service`: Microservices
-- `datastore`: Databases, caches
-- `queue`: Message queues
-- `system`: Logical grouping of entities
-- `api`: API definitions
-- `ui`: User interfaces
-
-#### Get Kind Definition
-```bash
-pup catalog kinds get <kind-id>
-```
-
-#### Create Custom Kind
-```bash
-pup catalog kinds create \
-  --name="ml-model" \
-  --definition=@kind-definition.yaml
-```
-
-Custom kind definition:
-```yaml
-name: ml-model
-description: Machine learning models
-schema:
-  properties:
-    version:
-      type: string
-    framework:
-      type: string
-      enum: [tensorflow, pytorch, sklearn]
-    accuracy:
-      type: number
-```
-
-#### Update Kind
-```bash
-pup catalog kinds update <kind-id> \
-  --definition=@updated-kind.yaml
-```
-
-#### Delete Kind
-```bash
-pup catalog kinds delete <kind-id>
-```
-
-### Catalog Relations
-
-#### List Relations
-```bash
-pup catalog relations list
-```
-
-Filter by source:
-```bash
-pup catalog relations list \
-  --source="service:api-gateway"
-```
-
-#### Create Relation
-```bash
-# Create dependency relation
-pup catalog relations create \
-  --source="service:api-gateway" \
-  --target="service:auth-service" \
-  --type="dependsOn"
-```
-
-Create ownership relation:
-```bash
-pup catalog relations create \
-  --source="service:payment-service" \
-  --target="team:payments-team" \
-  --type="ownedBy"
-```
-
-Relation types:
-- `dependsOn`: Service dependencies
-- `ownedBy`: Ownership
-- `partOf`: System membership
-- `providesApi`: API provision
-- `consumesApi`: API consumption
-- Custom relation types
-
-#### Delete Relation
-```bash
-pup catalog relations delete <relation-id>
-```
-
-## Permission Model
-
-### READ Operations (Automatic)
-- Listing services and entities
-- Getting service definitions
-- Viewing catalog entities and kinds
-- Listing relations
-
-These operations execute automatically without prompting.
-
-### WRITE Operations (Confirmation Required)
-- Creating service definitions
-- Updating services
-- Creating catalog entities
-- Creating relations
-- Creating custom kinds
-
-These operations will display what will be changed and require user awareness.
-
-### DELETE Operations (Explicit Confirmation Required)
-- Deleting service definitions
-- Deleting catalog entities
-- Deleting relations
-- Deleting custom kinds
-
-These operations will show clear warning about permanent deletion.
-
-## Response Formatting
-
-Present service catalog data in clear, user-friendly formats:
-
-**For service lists**: Display as a table with name, team, tier, and lifecycle
-**For service details**: Show complete definition including ownership, links, and dependencies
-**For catalog entities**: Display entity metadata, relationships, and spec
-**For relations**: Show dependency graph and relationship mappings
-
-## Common User Requests
-
-### "Show me all services"
-```bash
-pup services list
-```
-
-### "Register a new service"
-```bash
-pup services create \
-  --service-name="user-service" \
-  --team="backend-team" \
-  --definition=@user-service.yaml
-```
-
-### "Show me service dependencies"
-```bash
-# Get service definition with dependencies
-pup services get api-gateway
-
-# Or list relations
-pup catalog relations list \
-  --source="service:api-gateway"
-```
-
-### "Update service ownership"
-```bash
-# Update service definition with new team
-pup services update api-gateway \
-  --definition=@updated-definition.yaml
-```
-
-### "List all datastores"
-```bash
-pup catalog entities list \
-  --kind="datastore"
-```
-
-### "Map service dependencies"
-```bash
-# Create dependency relations
-pup catalog relations create \
-  --source="service:api" \
-  --target="datastore:postgres" \
-  --type="dependsOn"
-```
-
-## Service Definition Schema
-
-### Schema Versions
-
-**v2.2 (Recommended)**:
-- Full feature support
-- Enhanced metadata
-- Improved validation
-
-**v2.1**:
-- Basic features
-- Limited metadata
-
-**v2**:
-- Legacy support
-- Basic definitions
-
-**v1**:
-- Deprecated
-- Migration recommended
-
-### Complete Service Definition Example
-
-```yaml
-schema-version: v2.2
-dd-service: payment-service
-team: Payments Team
-application: billing-platform
-description: Handles payment processing, billing, and invoicing
-
-# Service tier (critical, high, normal, low)
-tier: critical
-
-# Lifecycle stage
-lifecycle: production
-
-# Service type
-type: web
-
-# Programming languages
-languages:
-  - go
-  - python
-
-# Ownership and contacts
-contacts:
-  - type: email
-    contact: payments-team@example.com
-    name: Payments Team
-  - type: slack
-    contact: https://slack.com/channels/payments
-    name: Payments Slack Channel
-  - type: microsoft-teams
-    contact: https://teams.microsoft.com/payments
-    name: Payments Teams Channel
-
-# External links
-links:
-  - name: Service Dashboard
-    type: dashboard
-    url: https://app.datadoghq.com/dashboard/payments
-  - name: Incident Runbook
-    type: runbook
-    url: https://docs.example.com/runbooks/payments
-  - name: Documentation
-    type: doc
-    url: https://docs.example.com/services/payments
-  - name: Source Code
-    type: repo
-    url: https://github.com/company/payment-service
-    provider: Github
-  - name: Architecture Diagram
-    type: other
-    url: https://docs.example.com/architecture/payments
-
-# Tags
-tags:
-  - service:payment-service
-  - env:production
-  - team:payments
-  - tier:critical
-
-# External integrations
-integrations:
-  pagerduty:
-    service-url: https://example.pagerduty.com/services/payments
-  opsgenie:
-    service-url: https://example.opsgenie.com/service/payments
-    region: US
-
-# CI/CD information
-ci-pipeline-fingerprints:
-  - id1
-  - id2
-
-# Extensions for custom metadata
-extensions:
-  cost-center: "1234"
-  compliance: "PCI-DSS"
-  sla: "99.99"
-```
-
-## Entity Types and Use Cases
-
-### Services
-```yaml
-kind: service
-metadata:
-  name: api-gateway
-  title: API Gateway
-spec:
-  owner: platform-team
-  lifecycle: production
-  type: web
-  dependsOn:
-    - service:auth-service
-    - service:user-service
-```
-
-### Datastores
-```yaml
-kind: datastore
-metadata:
-  name: postgres-main
-  title: Main PostgreSQL Database
-spec:
-  owner: platform-team
-  type: postgres
-  version: "14.2"
-  tier: critical
-```
-
-### Queues
-```yaml
-kind: queue
-metadata:
-  name: payment-queue
-  title: Payment Processing Queue
-spec:
-  owner: payments-team
-  type: rabbitmq
-  dependsOn:
-    - service:payment-service
-```
-
-### Systems
-```yaml
-kind: system
-metadata:
-  name: billing-platform
-  title: Billing Platform
-spec:
-  owner: billing-team
-  components:
-    - service:payment-service
-    - service:invoice-service
-    - datastore:billing-db
-```
-
-### APIs
-```yaml
-kind: api
-metadata:
-  name: payment-api-v1
-  title: Payment API v1
-spec:
-  owner: payments-team
-  type: rest
-  version: "1.0"
-  providedBy:
-    - service:payment-service
-```
-
-## Best Practices
-
-### Service Documentation
-
-**Essential Information**:
-1. **Team Ownership**: Clear team responsible for the service
-2. **Contacts**: Multiple contact methods (email, Slack, Teams)
-3. **Links**: Dashboard, runbook, documentation, repository
-4. **Tier**: Service criticality (critical, high, normal, low)
-5. **Lifecycle**: Current stage (production, staging, experimental)
-
-### Dependency Mapping
-
-**Map All Dependencies**:
-- Direct service-to-service calls
-- Database connections
-- Message queue usage
-- External API integrations
-- Shared libraries
-
-### Metadata Tags
-
-**Consistent Tagging**:
-```yaml
-tags:
-  - service:my-service
-  - env:production
-  - team:platform
-  - tier:critical
-  - language:go
-  - version:v2.1.0
-```
-
-### Regular Updates
-
-**Keep Definitions Current**:
-- Update ownership when teams change
-- Refresh links when URLs change
-- Update lifecycle as services evolve
-- Add new dependencies as they're added
-- Remove stale integrations
-
-## Error Handling
-
-### Common Errors and Solutions
-
-**Missing Credentials**:
-```
-Error: DD_API_KEY environment variable is required
-```
-→ Tell user to set environment variables
-
-**Service Not Found**:
-```
-Error: Service not found: my-service
-```
-→ Verify the service name exists using `services list`
-
-**Invalid Schema**:
-```
-Error: Invalid service definition schema
-```
-→ Validate YAML/JSON structure and required fields
-
-**Schema Version Mismatch**:
-```
-Error: Schema version v1 is deprecated
-```
-→ Migrate to v2.2 using latest schema
-
-**Duplicate Service**:
-```
-Error: Service already exists: my-service
-```
-→ Use update instead of create, or choose different name
-
-**Invalid Relation**:
-```
-Error: Cannot create relation - target entity not found
-```
-→ Ensure both source and target entities exist
-
-## Examples of Good Responses
-
-**When user asks "Show me all services":**
-```
-I'll list all services in your Service Catalog.
-
-<Execute services list command>
-
-Found 24 services:
-
-| Service | Team | Tier | Lifecycle | Last Updated |
-|---------|------|------|-----------|--------------|
-| api-gateway | Platform | Critical | Production | 2 days ago |
-| user-service | Backend | High | Production | 1 week ago |
-| payment-service | Payments | Critical | Production | 3 days ago |
-| auth-service | Security | Critical | Production | 1 day ago |
-
-Services by Tier:
-- Critical: 8 services
-- High: 10 services
-- Normal: 6 services
-
-Services by Team:
-- Platform: 6 services
-- Backend: 8 services
-- Payments: 4 services
-- Security: 3 services
-- Frontend: 3 services
-
-Would you like details on any specific service?
-```
-
-**When user asks "Register a new service":**
-```
-I'll help you register a new service in the catalog.
-
-Required information:
-- Service name: payment-processor
-- Team: payments-team
-- Tier: critical
-- Lifecycle: production
-
-⚠️ This will create a new service definition with:
-- Service: payment-processor
-- Owner: Payments Team
-- Tier: Critical
-- Lifecycle: Production
-- Contacts: payments-team@example.com
-- Links: Dashboard, Runbook, Repository
-
-<If user confirms, execute create command>
-
-✓ Service registered successfully!
-
-Next steps:
-1. Add service dependencies: catalog relations create ...
-2. Link to team dashboard: Update definition with dashboard link
-3. Configure integrations: Add PagerDuty/OpsGenie URLs
-4. Map dependencies: Create relations to datastores and downstream services
-
-View service: services get payment-processor
-```
-
-**When user asks "Show me service dependencies":**
-```
-I'll show the dependency map for api-gateway.
-
-<Execute service get and relations list>
-
-Service: api-gateway
-Owner: Platform Team
-Tier: Critical
-
-Direct Dependencies (5):
-1. auth-service (authentication)
-2. user-service (user data)
-3. rate-limiter (rate limiting)
-4. postgres-main (data storage)
-5. redis-cache (caching)
-
-Downstream Consumers (12):
-- web-app (frontend)
-- mobile-app (mobile frontend)
-- partner-api (external partners)
-- ... (9 more)
-
-Dependency Graph:
-```
-web-app → api-gateway → auth-service
-                      → user-service
-                      → postgres-main
-                      → redis-cache
-```
-
-Health Impact:
-- If api-gateway fails: 12 services affected
-- Critical dependency: auth-service (no alternative)
-
-Would you like to see details for any dependency?
-```
-
-## Integration Notes
-
-This agent works with Datadog Service Catalog and Service Definition APIs (v2). It supports:
-- Complete service definition lifecycle
-- Multi-version schema support (v1, v2, v2.1, v2.2)
-- Software Catalog entities and kinds
-- Relationship mapping between entities
-- Team ownership and contacts
-- External integrations (PagerDuty, OpsGenie)
-
-Key Service Catalog Concepts:
-- **Service Definition**: Metadata about a service (team, links, lifecycle)
-- **Entity**: Catalog entry (service, datastore, queue, system, api, ui)
-- **Kind**: Entity type definition
-- **Relation**: Connection between entities (dependency, ownership, membership)
-- **Schema Version**: Service definition format version
-
-For visual service maps and dependency graphs, use the Datadog Service Catalog UI.
+Never delete as cleanup or guess an entity identifier. Read the entity first, show the exact target, and require explicit user approval.
+
+## Evidence and handoff
+
+- Present entity refs, kind, ownership, and declared relationships exactly as returned.
+- Label name, repository, or free-text correlations as inferred unless a declared relation establishes them.
+- State when pagination, relationship sampling, permissions, or missing schema makes an answer incomplete.
+- Route to product commands for detailed/current incidents, SLOs, monitors, logs, traces, or security findings after catalog context identifies the target.
+- Never print or persist access tokens, API keys, or application keys.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -77,7 +77,7 @@ pup <domain> <subgroup> <action> [options] # Nested commands
 | code-coverage | branch-summary, commit-summary | src/commands/code_coverage.rs | ✅ |
 | hamr | connections (get, create) | src/commands/hamr.rs | ✅ |
 | fleet | agents (list, get, versions, tracers), deployments (list, get, configure, upgrade, cancel), schedules (list, get, create, update, delete, trigger), tracers (list), clusters (list), instrumented-pods (list) | src/commands/fleet.rs | ✅ |
-| skills | list, install, path (positional `<platform>`: claude/cursor/codex/opencode/windsurf/gemini/pi/devin/all; `--name`, `--type`, `--project` for project-local scope) | src/commands/skills.rs | ✅ |
+| skills | list, install, path (positional `<platform>`: claude/cursor/codex/opencode/windsurf/gemini/pi/devin/all; `--name`, `--type`, `--project` for project-local scope; bundled skills include supplementary references) | src/commands/skills.rs | ✅ |
 | runbooks | list, describe, run, import, validate | src/commands/runbooks.rs | ✅ |
 | workflows | get, create, update, diff, delete, run, instances (list, get, cancel), connections (get, create, update, delete) | src/commands/workflows.rs | ✅ |
 | investigations | list, get, trigger | src/commands/investigations.rs | ✅ |
@@ -214,7 +214,7 @@ pup infrastructure hosts list
 - **error-tracking** - Error management (issues search, issues get); search supports `--state`, `--team`, `--assignee` filters
 - **scorecards** - Service quality (rules, outcomes)
 - **service-catalog** - Service registry (list, get)
-- **idp** - Service Catalog agent access (assist, find, owner, deps, register)
+- **idp** - Entity graph discovery/query plus Service Catalog helpers (kinds, entities, assist, find, owner, deps, register, migrate-schema)
 - **debugger** - Live Debugger (probes list, get, create, delete, watch)
 
 ### Operations & Incident Response

--- a/docs/LLM_GUIDE.md
+++ b/docs/LLM_GUIDE.md
@@ -194,6 +194,38 @@ pup incidents list --query="status:active"
 pup incidents get <incident-id>
 ```
 
+### IDP entity graph
+
+Use UEG when an answer needs connected context across service identity,
+ownership, dependencies, health, source, work, or security. It can return a
+selected service and dependency view in one bounded request. Discover the live
+schema before filtering on unfamiliar fields or relations:
+
+```bash
+pup --read-only idp kinds list
+pup --read-only idp kinds describe service
+pup --read-only idp entities query 'kind:service AND name:"<service-name>"' \
+  --field name,owner,service_health_status,active_incidents_count,alert_monitors_count,breached_slos_count \
+  --include owner_teams,systems,upstream_services,downstream_services \
+  --relation-limit 3 \
+  --timeseries-interval 24h \
+  --limit 1
+```
+
+Every query needs one unquoted `kind:<kind>` or concrete
+`ref:"ref:<kind>:<id>"`. `--field` selects attributes; `--include` expands
+declared relations. Honor result cursors, relationship truncation, and null as
+unknown. The graph-specific `--timeseries-interval` accepts Go durations such
+as `168h`, not `7d`. Use `idp assist` for a fast curated service summary and
+`idp owner` for convenient ownership/on-call resolution; use UEG when graph
+fidelity, relation counts, pagination, or traversal matters. Treat `find` and
+`deps` as narrow legacy helpers. Install `dd-idp` for detailed DSL, recovery,
+and recipe guidance:
+
+```bash
+pup skills install --name dd-idp
+```
+
 ## Time Ranges
 
 All `--from` and `--to` flags accept:

--- a/skills/dd-idp/SKILL.md
+++ b/skills/dd-idp/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: dd-idp
+description: Explore Datadog software, ownership, health, and work across services, teams, systems, repositories, pull requests, Jira, incidents, SLOs, monitors, on-call, APIs, scorecards, vulnerabilities, and security findings using Pup's read-only IDP entity graph.
+metadata:
+  version: "1.0.0"
+  author: datadog-labs
+  repository: https://github.com/DataDog/pup
+  tags: datadog,idp,entity-graph,service-catalog,ownership
+---
+
+# Datadog IDP Entity Graph
+
+Use Pup's read-only Unified Entity Graph (UEG) to discover software, ownership, work, and operational context. Its main payoff is connected context in one bounded request: a service plus its owners, systems, code, dependencies, and health signals through declared relationships.
+
+## Choose the right surface
+
+- Default to `pup idp kinds` and `pup idp entities query` when the answer needs connected context across services, teams, systems, repositories, dependencies, work, operations, or security kinds.
+- Use `pup idp assist` when the user values a fast, curated single-service summary, metadata gaps, and suggested next actions over graph fidelity; use `owner` for convenient owner/on-call resolution.
+- Treat `find` as a simple legacy service-name lookup and `deps` as a production-only service-to-service dependency snapshot. Use UEG for explicit schema, relation families, counts, pagination, and traversal.
+- Use product commands such as `pup incidents`, `pup slos`, `pup monitors`, `pup logs`, `pup traces`, or `pup security` when the user needs deeper or current telemetry.
+- Use `pup service-catalog` for the legacy typed service registry and `pup software-catalog` for Catalog entity/kind reads and writes. Do not use graph queries for mutations.
+
+## Highest-value workflows
+
+- Build a service 360 in one request: owner/on-call, system and code placement, selected dependencies, and aggregate health.
+- Estimate blast radius by following declared or runtime service, datastore, queue, external-provider, and inferred-service relations relevant to the question.
+- Triage a team's portfolio from service health aggregates, then pivot to product APIs for detail.
+- Add deployment or infrastructure relations to ownership and dependencies for change context.
+- Inspect repository-linked APIs, code quality, secrets, and vulnerabilities without inventing service attribution.
+- Discover integration and custom kinds schema-first for tenant-specific work rather than relying on a fixed kind catalog.
+
+## Schema-first workflow
+
+1. Discover candidate kinds when the request is broad or the entity vocabulary is unfamiliar:
+
+   ```bash
+   pup --read-only idp kinds list
+   pup --read-only idp kinds list --all --include-custom
+   ```
+
+2. Describe each result kind before using unfamiliar fields or relations. Treat the live schema as authoritative:
+
+   ```bash
+   pup --read-only idp kinds describe service
+   pup --read-only idp kinds describe integration.github.pull_request
+   ```
+
+3. Query exactly one top-level result kind. Select only needed attributes with `--field`; expand only the relation family needed for the question with `--include`:
+
+   ```bash
+   pup --read-only idp entities query 'kind:service AND name:"<service-name>"' \
+     --field name,display_name,owner,service_health_status,active_incidents_count,alert_monitors_count,breached_slos_count \
+     --include owner_teams,systems,code_locations,upstream_services,downstream_services \
+     --relation-limit 3 \
+     --timeseries-interval 24h \
+     --limit 1
+   ```
+
+   This is the high-value default: identity, ownership, health, and declared service dependencies in one request. Add runtime, datastore, queue, deployment, or operational relations only when the question needs them; do not expand every service relation.
+
+4. Inspect `warnings`, `page.truncated`, `page.next_cursor`, and every relationship's `count` and `truncated` state. Continue pages explicitly when completeness matters:
+
+   ```bash
+   pup --read-only idp entities query 'kind:service AND owner:"<team-handle>"' \
+     --field name,owner \
+     --cursor '<next_cursor>'
+   ```
+
+5. Follow returned refs instead of inventing joins:
+
+   ```bash
+   pup --read-only idp entities query 'ref:"ref:system:checkout"' \
+     --field name,display_name,owner \
+     --include services
+   ```
+
+6. Synthesize only what the returned fields and declared relations establish. Label noisy matches as inferred and missing edges as unavailable.
+
+## Correctness rules
+
+- Scope every query with one unquoted `kind:<kind>` or a concrete `ref:"ref:<kind>:<id>"`.
+- Keep the kind/ref outside alternatives: `kind:service AND (owner:payments OR team:payments)`. A top-level `OR` is invalid.
+- Never write `kind:"service"`; the quoted kind silently returns no results upstream and Pup rejects it.
+- `--field` selects attributes. `--include` expands relations. Discover both with `kinds describe` rather than guessing.
+- `--free-text-match` only chooses `partial` or `fuzzy` matching; search text still belongs in a real field filter such as `name:*catalog*`.
+- Use Go-style lookbacks such as `1h`, `24h`, or `168h`; do not use `7d` for `--timeseries-interval`.
+- Treat expanded relations as bounded samples. Increase `--relation-limit` or query the related kind directly when the full set matters.
+- Treat `null` or absent counts/booleans as unknown, never as zero or false.
+- Preserve source boundaries: UEG establishes graph facts; product APIs establish detailed operational facts.
+
+## References
+
+- Read [UEG DSL](references/ueg-dsl.md) when constructing or paginating a query, choosing flags, or following relations.
+- Read [UEG footguns](references/footguns.md) when a query fails, unexpectedly returns zero, or touches timestamps, negation, high-cardinality relations, APIs, GitHub, Jira, scorecards, or security findings.
+- Read [IDP recipes](references/recipes.md) for one-step service context, dependency and change impact, team health, repository, PR, Jira, incident, SLO, API, and security workflows.

--- a/skills/dd-idp/agents/openai.yaml
+++ b/skills/dd-idp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Datadog IDP Entity Graph"
+  short_description: "Map Datadog services, dependencies, and health"
+  default_prompt: "Use $dd-idp to map a service or team's ownership, dependencies, health, source context, and other declared relationships."

--- a/skills/dd-idp/agents/openai.yaml
+++ b/skills/dd-idp/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Datadog IDP Entity Graph"
-  short_description: "Map Datadog services, dependencies, and health"
-  default_prompt: "Use $dd-idp to map a service or team's ownership, dependencies, health, source context, and other declared relationships."

--- a/skills/dd-idp/references/footguns.md
+++ b/skills/dd-idp/references/footguns.md
@@ -1,0 +1,119 @@
+# UEG Query Footguns
+
+Use this reference when a query fails, returns zero unexpectedly, or supports a high-stakes conclusion. Retry only after changing a concrete query assumption.
+
+## Fast recovery checklist
+
+1. Confirm one top-level `kind:<kind>` or `ref:"ref:<kind>:<id>"` is present.
+2. Re-run `pup --read-only idp kinds describe <kind>` and compare every field and relation name.
+3. Remove guessed relations, relation-absence checks, timestamp comparisons, CIDR syntax, broad negation, and unnecessary includes.
+4. Start with a small positive query and minimal fields, then add one filter or relation at a time.
+5. Check `warnings`, nulls, pagination, and relationship truncation before interpreting an empty or partial response.
+
+## Syntax that silently misleads
+
+### Quoted kind
+
+```text
+# wrong
+kind:"service" AND owner:payments
+
+# right
+kind:service AND owner:payments
+```
+
+### Kind beneath top-level OR
+
+```text
+# wrong
+kind:service OR owner:payments
+
+# right
+kind:service AND (owner:payments OR team:payments)
+```
+
+### Guessed relation
+
+```text
+# wrong
+kind:service AND team.name:idp
+
+# right only when describe declares owner_teams
+kind:service AND owner_teams.name:idp
+```
+
+### Field passed to `--include`
+
+`owner`, `contacts`, `links`, and `additional_owners` are commonly service attributes. Request them with `--field`. Use `--include` only for declared relations such as `owner_teams` or `systems`.
+
+### Free-text pseudo-field
+
+`free_text` is not a field. `--free-text-match partial|fuzzy` selects a mode but does not supply search text. Put text in a real filter such as `name:*catalog*`.
+
+### Unsupported absence and advanced operators
+
+Do not rely on `_missing_:owner_teams`, `-owner_teams.ref:*`, `NOT *`, CIDR expressions, or timestamp ranges such as `created_at:>...` and `last_seen:>now-30d`. Use positive declared fields and relations. Timestamp-typed fields do not support numeric/relative range comparisons.
+
+## Result interpretation
+
+### Relation samples are not inventories
+
+An include may represent thousands of entities but return only a sample. Respect its `count` and `truncated` fields. Query the related kind directly rather than repeatedly raising `--relation-limit` for high-cardinality relations.
+
+For team portfolios, query services directly with `kind:service AND owner:<team>` instead of expanding every `owned_services`, `users`, parent, and child relation together.
+
+A service kind can expose dozens of relation types. For a fast one-step context query, request identity and aggregate health fields plus a small, relevant relation family. Add runtime dependencies, data stores, queues, deployments, operational objects, or security findings only when the question needs them.
+
+### Null is unknown
+
+Count and boolean fields may be null. Null does not mean zero, false, healthy, compliant, authenticated, or rate-limited. Distinguish “no matching rows,” “explicitly zero,” and “no data returned.”
+
+### Time windows change meaning
+
+Use `--timeseries-interval 168h`, not `7d`. Mention the window for incidents, monitor/SLO state, health, or other calculated fields.
+
+## Known domain hazards
+
+### Team contacts
+
+Team entities primarily model membership and hierarchy. Service `contacts`, `links`, `owner`, `team`, and `additional_owners` often contain the useful channel/contact metadata. Query services owned by the team when team contact fields are absent.
+
+### Kubernetes deployments
+
+Never start with an unscoped `kind:integration.k8s.deployment`. Scope by `team` or `service`, request a small page, and paginate only for a defined inventory question.
+
+### API posture
+
+Boolean filters such as `endpoint_authenticated:false` can over-return or coexist with null data. Start from a scoped public-endpoint inventory, request the returned values, and post-filter before making a security claim. Live API endpoint data may encode schema-declared booleans as strings (`"true"` or `"false"`); accept only an explicit boolean/string value after normalization. Null or absent remains unknown.
+
+### Pull requests
+
+Scope every PR query with `repository.full_name` when the repository is known. An unscoped number can collide across repositories, while a broad author or reviewer query can exceed backend project-fanout limits:
+
+```text
+kind:integration.github.pull_request AND repository.full_name:"<org>/<repository>" AND number:<number>
+```
+
+Prefer `integration.github.repository` and `integration.github.pull_request`. Native `github.repository`, `github.pull_request`, and `github.commit` kinds may return backend errors. PR entities do not establish service impact unless the live schema exposes a real relation.
+
+### Jira
+
+For a human key such as `PAY-123`, use the `key` field rather than assuming `jira_issue_key` has the same value. Direct issue attributes are more reliable than expanding `assignee`, `reporter`, or `project`, which may fail server-side. Jira issues do not establish service impact without a declared relation.
+
+### Scorecards and recommendations
+
+Do not query deprecated `scorecard_outcome` or expand `scorecard_outcomes`; use service aggregate scorecard fields for high-level posture. `recommended_system` describes grouping recommendations and is not equivalent to entity-level `catalog_recommendation`, which may fail.
+
+### Security and code findings
+
+- Prefer repository-scoped finding queries. Monorepos make repository-to-service attribution incomplete.
+- `associated_service` can behave like noisy free text; request it and verify returned rows rather than treating an exact match as authoritative.
+- `library_vulnerability_secfinding.services` may be schema-present but empty. Zero matches on that field do not prove a service has no vulnerabilities.
+- `source_code_vulnerability_secfinding.service_name` establishes only findings that were actually attributed; it does not prove full monorepo coverage.
+- Map-typed fields such as some `tags` fields do not support wildcard/exists matching like strings or lists.
+
+## Evidence labels
+
+- **Authoritative:** directly returned attribute or declared relationship.
+- **Inferred:** name/free-text/repository association that is plausible but not a declared edge; explain the basis.
+- **Unavailable:** the live schema lacks the requested field or relation; say so rather than fabricating a join.

--- a/skills/dd-idp/references/recipes.md
+++ b/skills/dd-idp/references/recipes.md
@@ -1,0 +1,223 @@
+# IDP Query Recipes
+
+Use these as starting shapes, not a static schema. Replace every `<placeholder>` with an organization value. Run `pup --read-only idp kinds describe <kind>` before using a recipe and adjust fields or relations to the live response.
+
+## One-step service and dependency context
+
+```bash
+pup --read-only idp entities query 'kind:service AND name:"<service-name>"' \
+  --field name,display_name,description,owner,team,contacts,service_health_status,active_incidents_count,alert_monitors_count,breached_slos_count \
+  --include owner_teams,systems,code_locations,current_oncalls,upstream_services,downstream_services \
+  --relation-limit 3 \
+  --timeseries-interval 24h \
+  --limit 1
+```
+
+This is the default service-context workflow: ownership, system and code placement, declared dependencies, and health signals in one request. Relationship `count` can exceed the returned sample, so report truncation instead of presenting the first three dependencies as complete.
+
+Describe `service` before adding a different relation family. Depending on the live schema and question, useful families may include runtime upstream/downstream services, datastores, queues, external providers, inferred services, incidents, monitors, SLOs, deployments, Kubernetes workloads, Terraform, and security findings. Select one relevant family rather than expanding every relation.
+
+## Team portfolio and missing ownership
+
+```bash
+pup --read-only idp entities query 'kind:service AND owner:"<team-handle>"' \
+  --field name,display_name,owner,team,additional_owners,contacts,links \
+  --include owner_teams \
+  --include-total-count \
+  --limit 25
+```
+
+For missing ownership, `_missing_:owner` applies to an attribute, not a relation:
+
+```bash
+pup --read-only idp entities query 'kind:service AND _missing_:owner' \
+  --field name,display_name,owner \
+  --limit 25
+```
+
+## Team portfolio health
+
+Describe `service` and select the aggregate fields currently available for incidents, SLOs, monitors, scorecards, vulnerabilities, or health. Keep alternatives beneath the shared kind:
+
+```bash
+pup --read-only idp entities query \
+  'kind:service AND owner:"<team-handle>" AND (active_incidents_count:>0 OR breached_slos_count:>0 OR critical_vulnerabilities_count:>0 OR high_vulnerabilities_count:>0)' \
+  --field name,display_name,owner,active_incidents_count,breached_slos_count,critical_vulnerabilities_count,high_vulnerabilities_count,service_health_status \
+  --include systems,code_locations \
+  --timeseries-interval 24h \
+  --limit 25
+```
+
+Report explicit nonzero values, null/unknown fields, the time window, result pagination, and truncated relations separately. Use product-specific commands for incident, SLO, monitor, or vulnerability detail after identifying the relevant entities.
+
+## Systems and code locations
+
+```bash
+pup --read-only idp entities query 'kind:system AND name:"<system-name>"' \
+  --field name,display_name,owner \
+  --include services \
+  --limit 10
+```
+
+```bash
+pup --read-only idp entities query \
+  'kind:code_location AND repository_id:"github.com/<org>/<repository>"' \
+  --field name,repository_id,path_pattern,source \
+  --include services,systems,repository \
+  --limit 25
+```
+
+Use returned refs to walk from a service to a system or code location. Do not infer a code-to-service edge from similar names.
+
+## Incidents, monitors, and SLOs
+
+```bash
+pup --read-only idp entities query \
+  'kind:incident AND service_names:"<service-name>" AND state:active' \
+  --field public_id,title,state,severity,service_names,teams \
+  --timeseries-interval 24h \
+  --limit 25
+```
+
+```bash
+pup --read-only idp entities query \
+  'kind:monitor AND service_tags:"<service-name>" AND status:"Alert"' \
+  --field name,status,monitor_id,service_tags \
+  --limit 25
+```
+
+```bash
+pup --read-only idp entities query \
+  'kind:slo AND service_names:"<service-name>" AND state:breached' \
+  --field name,state,target_threshold,sli \
+  --limit 25
+```
+
+After graph discovery, use `pup incidents`, `pup monitors`, or `pup slos` for authoritative product detail.
+
+## On-call
+
+For service ownership context, include the declared `current_oncalls` relation:
+
+```bash
+pup --read-only idp entities query 'kind:service AND name:"<service-name>"' \
+  --field name,owner,team \
+  --include current_oncalls \
+  --relation-limit 25
+```
+
+For a provider inventory, describe and query `current_oncall` directly. Treat a truncated relation as a sample, not a full roster.
+
+## GitHub pull requests
+
+Scope every pull-request search by repository. Numeric lookups can collide across repositories, and broad author/reviewer searches can exceed backend project-fanout limits:
+
+```bash
+pup --read-only idp entities query \
+  'kind:integration.github.pull_request AND repository.full_name:"<org>/<repository>" AND number:<number>' \
+  --field title,state,number,updated_at,mergeable,changed_files,html_url \
+  --include repository,author \
+  --limit 10
+```
+
+Open work by reviewer:
+
+```bash
+pup --read-only idp entities query \
+  'kind:integration.github.pull_request AND repository.full_name:"<org>/<repository>" AND reviewer_users.login:"<login>" AND state:open AND draft:false' \
+  --field title,state,updated_at,mergeable,changed_files,html_url \
+  --include repository,author \
+  --limit 25
+```
+
+Do not assign PRs to services unless a declared relation in the live schema supports that join.
+
+## Jira work
+
+```bash
+pup --read-only idp entities query \
+  'kind:integration.jira.issue AND key:"<jira-key>"' \
+  --field key,summary,status,status_category,priority,assignee_name,html_url \
+  --limit 10
+```
+
+Prefer direct fields first; relation includes may fail. Do not infer a service link from project names or text.
+
+## Public API posture
+
+Scope by a service or team relation, then inspect the explicit returned values:
+
+```bash
+pup --read-only idp entities query \
+  'kind:api_endpoint AND service.owner:"<team-handle>" AND endpoint_is_public:true' \
+  --field resource_name,http_method,http_route,endpoint_is_public,endpoint_authenticated,endpoint_is_rate_limited,service_name,team_names \
+  --include service,teams \
+  --limit 25
+```
+
+Do not trust the query predicate alone: verify `endpoint_is_public` on every returned row. Live schema-declared booleans may arrive as JSON booleans or as strings (`"true"` / `"false"`). Normalize only those explicit forms; treat null or absent authentication/rate-limit values as unknown, and report only explicit false values as missing controls.
+
+## Repository-scoped security and code quality
+
+Discover exact deployed kinds first. Representative shapes include:
+
+```bash
+pup --read-only idp entities query \
+  'kind:secret AND repository_id:"github.com/<org>/<repository>"' \
+  --field severity,repository_id \
+  --limit 25
+```
+
+```bash
+pup --read-only idp entities query \
+  'kind:source_code_vulnerability_secfinding AND repository_id:"github.com/<org>/<repository>"' \
+  --field severity,finding_type,repository_id,service_name,code_location_filename,package_decl_filename \
+  --limit 25
+```
+
+```bash
+pup --read-only idp entities query \
+  'kind:code_violation AND associated_service:*<service-name>*' \
+  --field status,k9_severity,associated_service,repository_id \
+  --limit 25
+```
+
+Repository association is authoritative for the repository, not necessarily for each service in a monorepo. Label free-text service matching as inferred and route to `pup security` or `pup static-analysis` when the user needs product-specific detail.
+
+## Bounded Kubernetes inventory
+
+Never query all deployments unscoped:
+
+```bash
+pup --read-only idp entities query \
+  'kind:integration.k8s.deployment AND team:"<team-handle>" AND unavailable_replicas:>0' \
+  --field name,team,service,cluster_name,namespace,ready_replicas,replicas_desired,unavailable_replicas,status,html_url \
+  --limit 25
+```
+
+## Change and deployment context
+
+Start from the service so UEG can return declared change/deployment edges alongside ownership and dependencies:
+
+```bash
+pup --read-only idp entities query 'kind:service AND name:"<service-name>"' \
+  --field name,display_name,owner,service_health_status \
+  --include owner_teams,upstream_services,downstream_services,service_deployments \
+  --relation-limit 3 \
+  --timeseries-interval 24h \
+  --limit 1
+```
+
+Use the returned refs to inspect a deployment kind directly. If `kinds describe service` does not declare `service_deployments` in the current tenant, omit it and use the deployment or Kubernetes kind named by the live schema. UEG establishes the declared graph context; product deployment and telemetry commands establish detailed rollout state.
+
+## Cursor continuation
+
+When `page.next_cursor` is present, repeat the exact query, selection, includes, limits, and time window with:
+
+```bash
+pup --read-only idp entities query '<same-query>' \
+  --field '<same-fields>' \
+  --cursor '<next_cursor>'
+```
+
+Continue only as far as the user's completeness requirement warrants, and state when results or relationship samples remain truncated.

--- a/skills/dd-idp/references/ueg-dsl.md
+++ b/skills/dd-idp/references/ueg-dsl.md
@@ -1,0 +1,116 @@
+# UEG DSL and Pup Query Reference
+
+Use this reference to construct, narrow, and paginate `pup idp entities query` calls. Inspect the result kind with `pup idp kinds describe <kind>` first; live fields, relations, and operators override examples here.
+
+## Required result scope
+
+Every query selects exactly one top-level kind or one concrete entity ref:
+
+```bash
+pup --read-only idp entities query 'kind:service'
+pup --read-only idp entities query 'ref:"ref:service:checkout-api"'
+```
+
+Do not quote a kind value:
+
+```text
+# wrong
+kind:"service"
+
+# right
+kind:service
+```
+
+## Attribute filters
+
+Filter with fields declared by the live kind schema:
+
+```text
+kind:service AND owner:payments
+kind:incident AND state:active
+kind:api_endpoint AND endpoint_is_public:true
+kind:service AND active_incidents_count:>0
+kind:service AND name:*catalog*
+kind:service AND _missing_:owner
+```
+
+Only use comparison, wildcard, missing, or negation syntax when the described field advertises a compatible operator and type.
+
+## Relation filters and traversal
+
+Relation names are schema-defined, not inferred from English. Describe the kind, then use the exact relation name:
+
+```text
+kind:service AND owner_teams.name:payments
+kind:service AND code_locations.repository_id:"github.com/example/checkout-api"
+```
+
+Use `--include <relation>` to return a bounded relationship sample. Each normalized relationship includes `count`, `truncated`, and `sample`. Follow an entity from `sample[].ref` with a concrete-ref query, or query the target kind directly for complete enumeration.
+
+## Boolean logic
+
+Operators are uppercase. Parenthesize alternatives beneath a shared result scope:
+
+```text
+# valid
+kind:service AND (owner:payments OR team:payments)
+
+# invalid: ambiguous result scope
+kind:service OR owner:payments
+```
+
+Use `NOT` or the compact negative form only when the live schema and a positive probe show the filter behaves as intended. Relation absence is not a reliable negative filter.
+
+## Quoting and shell safety
+
+Wrap the whole query in shell single quotes. Quote DSL values that contain spaces, punctuation, or refs with double quotes inside it:
+
+```bash
+pup --read-only idp entities query \
+  'kind:integration.jira.issue AND key:"PAY-123"'
+```
+
+Simple identifiers can remain bare: `owner:payments`.
+
+## Query controls
+
+| Flag | Meaning |
+| --- | --- |
+| `--field name,owner` | Returned attributes; repeatable or comma-delimited |
+| `--include owner_teams` | Expanded declared relations; repeatable or comma-delimited |
+| `--order-by field:asc` | Sort; repeatable or comma-delimited |
+| `--limit 25` | Result page size, 1–100; default 25 |
+| `--cursor <cursor>` | Continue the same query from `page.next_cursor` |
+| `--relation-limit 25` | Per-relation sample cap, 1–100; default 25 |
+| `--timeseries-interval 24h` | Lookback for calculated time-window fields; default 1h |
+| `--include-total-count` | Request a total when the backend can provide one |
+| `--free-text-match partial` | Matching mode only; search text remains in a real field filter |
+| `--raw` | Original JSON:API response; prefer normalized output for reasoning |
+
+Request only the fields and relations needed to answer the question. Start with `--limit 25`; widen only after the query is proven useful.
+
+## Pagination and completeness
+
+Normalized output contains:
+
+```text
+page.limit
+page.truncated
+page.next_cursor
+relationships.<name>.count
+relationships.<name>.truncated
+relationships.<name>.sample
+warnings
+```
+
+When `page.truncated` is true and the user needs complete coverage, repeat the identical query and flags with the returned cursor. Do not claim completeness until no next cursor remains. A complete result page does not make a truncated relationship sample complete; query that related kind directly when necessary.
+
+## Time windows and nulls
+
+Some aggregate fields are calculated over `--timeseries-interval`. Use Go durations such as `1h`, `24h`, and `168h`, and state the window in the answer when it affects meaning.
+
+Treat `null` or a missing field as unknown/not returned. Only report zero, false, healthy, or no findings when the API explicitly returned evidence for that claim.
+
+## Output modes
+
+Normalized JSON is the reasoning contract. Agent mode may wrap it in Pup's `{status,data,metadata}` envelope. Global `--jq` expressions target the command payload before envelope formatting. Use `--raw` only to debug the server contract or access fields the normalized representation intentionally omits.

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -383,7 +383,7 @@ mod tests {
             .expect("dd-idp must be registered");
         let item = list_item(entry);
         assert_eq!(item["type"], "skill");
-        assert_eq!(item["files"].as_array().map(Vec::len), Some(4));
+        assert_eq!(item["files"].as_array().map(Vec::len), Some(3));
         assert!(item.get("platform").is_none());
     }
 
@@ -403,7 +403,6 @@ mod tests {
         let root = tmp.path().join("dd-idp");
         for relative in [
             "SKILL.md",
-            "agents/openai.yaml",
             "references/ueg-dsl.md",
             "references/footguns.md",
             "references/recipes.md",

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -36,6 +36,31 @@ fn resolve_or_bail(input: Option<&str>) -> Result<Vec<String>> {
     Ok(platforms)
 }
 
+fn list_item(entry: &skills::SkillEntry) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "name": entry.name,
+        "type": entry.entry_type,
+        "description": entry.description,
+    });
+    if !entry.files.is_empty() {
+        let object = value
+            .as_object_mut()
+            .expect("skill list item is always a JSON object");
+        object.insert(
+            "files".to_string(),
+            serde_json::json!(entry
+                .files
+                .iter()
+                .map(|(path, _)| *path)
+                .collect::<Vec<_>>()),
+        );
+        if entry.entry_type == "extension" {
+            object.insert("platform".to_string(), serde_json::json!(entry.platform));
+        }
+    }
+    value
+}
+
 pub fn list(cfg: &crate::config::Config, entry_type: Option<String>) -> Result<()> {
     let entries: Vec<_> = skills::SKILLS
         .iter()
@@ -45,28 +70,7 @@ pub fn list(cfg: &crate::config::Config, entry_type: Option<String>) -> Result<(
         })
         .collect();
 
-    let items: Vec<serde_json::Value> = entries
-        .iter()
-        .map(|e| {
-            let mut v = serde_json::json!({
-                "name": e.name,
-                "type": e.entry_type,
-                "description": e.description,
-            });
-            if e.entry_type == "extension" {
-                // serde_json::json!({}) always produces Value::Object, so as_object_mut()
-                // is always Some here; the if-let is a safe defensive pattern.
-                if let Some(obj) = v.as_object_mut() {
-                    obj.insert("platform".to_string(), serde_json::json!(e.platform));
-                    obj.insert(
-                        "files".to_string(),
-                        serde_json::json!(e.files.iter().map(|(r, _)| *r).collect::<Vec<_>>()),
-                    );
-                }
-            }
-            v
-        })
-        .collect();
+    let items: Vec<serde_json::Value> = entries.iter().map(|entry| list_item(entry)).collect();
 
     crate::formatter::format_and_print(
         &items,
@@ -369,6 +373,46 @@ mod tests {
         assert!(file.exists(), "expected {} to exist", file.display());
         let body = std::fs::read_to_string(&file).unwrap();
         assert!(body.contains("name: dd-pup"));
+    }
+
+    #[test]
+    fn list_item_reports_skill_supplementary_files() {
+        let entry = skills::SKILLS
+            .iter()
+            .find(|entry| entry.name == "dd-idp")
+            .expect("dd-idp must be registered");
+        let item = list_item(entry);
+        assert_eq!(item["type"], "skill");
+        assert_eq!(item["files"].as_array().map(Vec::len), Some(4));
+        assert!(item.get("platform").is_none());
+    }
+
+    #[test]
+    fn install_dir_override_writes_complete_dd_idp_bundle() {
+        let tmp = TempDir::new("install_dir_dd_idp");
+        let cfg = base_cfg();
+        install(
+            &cfg,
+            Some("codex".to_string()),
+            Some("dd-idp".to_string()),
+            Some(tmp.path().to_str().unwrap().to_string()),
+            None,
+            false,
+        )
+        .unwrap();
+        let root = tmp.path().join("dd-idp");
+        for relative in [
+            "SKILL.md",
+            "agents/openai.yaml",
+            "references/ueg-dsl.md",
+            "references/footguns.md",
+            "references/recipes.md",
+        ] {
+            assert!(root.join(relative).is_file(), "missing {relative}");
+        }
+        let skill = std::fs::read_to_string(root.join("SKILL.md")).unwrap();
+        assert!(skill.contains("name: dd-idp"));
+        assert!(skill.contains("Schema-first workflow"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1527,40 +1527,40 @@ enum Commands {
         #[command(subcommand)]
         action: HamrActions,
     },
-    /// Internal Developer Portal — agent-native context layer
+    /// Internal Developer Portal — unified entity graph and service context
     ///
-    /// Retrieve service context, ownership, health, dependencies, and
-    /// suggested next actions from the Datadog Service Catalog / IDP.
+    /// Explore connected service, ownership, dependency, health, work, and
+    /// security context through the Datadog Unified Entity Graph (UEG).
     ///
     /// CAPABILITIES:
     ///   • Discover entity kinds and inspect their live query schemas
     ///   • Query entities and traverse declared relationships
-    ///   • Get a full context summary for any entity (assist)
-    ///   • Find entities by name or query (find)
-    ///   • Resolve ownership and on-call (owner)
-    ///   • Show upstream/downstream dependencies (deps)
+    ///   • Get an opinionated legacy service summary (assist)
+    ///   • Run a quick legacy service lookup (find)
+    ///   • Resolve service ownership and on-call (owner)
+    ///   • Show legacy production service dependencies (deps)
     ///   • Register a service definition from YAML (register)
     ///   • Migrate service catalog YAML to v3 schema (migrate-schema)
     ///
     /// EXAMPLES:
-    ///   # Get full context for a service
-    ///   pup idp assist catalog-http
-    ///
-    ///   # Find entities matching a query
-    ///   pup idp find "catalog"
-    ///
     ///   # Discover entity kinds and their schemas
     ///   pup idp kinds list
     ///   pup idp kinds describe service
     ///
-    ///   # Query across the Datadog entity graph
-    ///   pup idp entities query 'kind:service AND owner:payments'
+    ///   # Get connected service and dependency context
+    ///   pup idp entities query 'kind:service AND name:"checkout-api"' \
+    ///     --field name,owner,service_health_status \
+    ///     --include owner_teams,upstream_services,downstream_services \
+    ///     --relation-limit 3
+    ///
+    ///   # Get the opinionated legacy service summary
+    ///   pup idp assist checkout-api
     ///
     ///   # Who owns this service?
-    ///   pup idp owner catalog-http
+    ///   pup idp owner checkout-api
     ///
     ///   # Show dependencies
-    ///   pup idp deps catalog-http
+    ///   pup idp deps checkout-api
     ///
     ///   # Register a service definition
     ///   pup idp register service.datadog.yaml
@@ -5061,10 +5061,10 @@ enum IdpActions {
         #[command(subcommand)]
         action: IdpEntitiesActions,
     },
-    /// Get full context summary with suggested next actions
+    /// Get an opinionated legacy service summary with suggested next actions
     ///
-    /// The flagship IDP command. Makes parallel API calls to return
-    /// a single unified view of any service entity:
+    /// Compatibility helper that combines UEG service data with legacy
+    /// production dependency and on-call lookups:
     ///
     /// RETURNS:
     ///   • Entity info (name, kind, description, lifecycle, tier, owner)
@@ -5075,8 +5075,8 @@ enum IdpActions {
     ///   • Metadata gaps (missing description, lifecycle, tier, runbook, docs)
     ///   • Suggested next actions (based on current health and gaps)
     ///
-    /// START HERE — this is the best first command to run for any entity.
-    /// Use the other commands (owner, deps, find) to drill deeper.
+    /// Use `idp kinds` and `idp entities query` first for schema-driven,
+    /// connected context or kinds beyond services.
     ///
     /// EXAMPLES:
     ///   pup idp assist catalog-http
@@ -5087,10 +5087,11 @@ enum IdpActions {
         /// Entity name (e.g. "catalog-http", "payment-service")
         entity: String,
     },
-    /// Find entities by name or query
+    /// Run a quick legacy service lookup by name or query
     ///
-    /// Search the entity graph for services, resources, or other entities.
-    /// Useful when you don't know the exact entity name.
+    /// Simple text defaults to a bounded wildcard service-name lookup.
+    /// Use `idp entities query` for arbitrary kinds, selected fields and
+    /// relations, explicit pagination, or schema-driven queries.
     ///
     /// QUERY SYNTAX:
     ///   Simple text searches by name. Prefix with kind: to filter by type.
@@ -5118,11 +5119,11 @@ enum IdpActions {
         /// Entity name
         entity: String,
     },
-    /// Show upstream and downstream service dependencies
+    /// Show legacy production upstream and downstream service dependencies
     ///
-    /// Returns which services depend on this entity (upstream)
-    /// and which services this entity calls (downstream).
-    /// Useful for blast-radius analysis before making changes.
+    /// Returns the legacy `env=prod` service-to-service dependency snapshot.
+    /// Use `idp entities query` for declared/runtime graph relations to
+    /// services, datastores, queues, external providers, or inferred services.
     ///
     /// EXAMPLES:
     ///   pup idp deps catalog-http

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -22,10 +22,6 @@ pub struct SkillEntry {
 /// Supplementary files bundled with the `dd-idp` skill.
 static DD_IDP_FILES: &[(&str, &str)] = &[
     (
-        "agents/openai.yaml",
-        include_str!("../skills/dd-idp/agents/openai.yaml"),
-    ),
-    (
         "references/ueg-dsl.md",
         include_str!("../skills/dd-idp/references/ueg-dsl.md"),
     ),
@@ -64,14 +60,6 @@ pub static SKILLS: &[SkillEntry] = &[
         content: include_str!("../skills/dd-pup/SKILL.md"),
         platform: "",
         files: &[],
-    },
-    SkillEntry {
-        name: "dd-idp",
-        description: "Map Datadog services, dependencies, ownership, health, and declared relationships.",
-        entry_type: "skill",
-        content: include_str!("../skills/dd-idp/SKILL.md"),
-        platform: "",
-        files: DD_IDP_FILES,
     },
     SkillEntry {
         name: "dd-monitors",
@@ -152,6 +140,14 @@ pub static SKILLS: &[SkillEntry] = &[
         content: include_str!("../skills/dd-triage-flaky-test/SKILL.md"),
         platform: "",
         files: &[],
+    },
+    SkillEntry {
+        name: "dd-idp",
+        description: "Map Datadog services, dependencies, ownership, health, and declared relationships.",
+        entry_type: "skill",
+        content: include_str!("../skills/dd-idp/SKILL.md"),
+        platform: "",
+        files: DD_IDP_FILES,
     },
     // --- Domain Agents (from datadog-api-claude-plugin) ---
     SkillEntry {
@@ -1817,8 +1813,8 @@ mod tests {
     #[test]
     fn test_install_paths_skill_expands_supplementary_files() {
         static FILES: &[(&str, &str)] = &[
-            ("agents/openai.yaml", "interface: {}"),
             ("references/query.md", "# Query"),
+            ("references/recipes.md", "# Recipes"),
         ];
         let e = SkillEntry {
             files: FILES,
@@ -1830,11 +1826,11 @@ mod tests {
         assert_eq!(paths[0].0, root.join(".codex/skills/dd-idp/SKILL.md"));
         assert_eq!(
             paths[1].0,
-            root.join(".codex/skills/dd-idp/agents/openai.yaml")
+            root.join(".codex/skills/dd-idp/references/query.md")
         );
         assert_eq!(
             paths[2].0,
-            root.join(".codex/skills/dd-idp/references/query.md")
+            root.join(".codex/skills/dd-idp/references/recipes.md")
         );
     }
 
@@ -1991,7 +1987,6 @@ mod tests {
         assert_eq!(
             paths,
             vec![
-                "agents/openai.yaml",
                 "references/ueg-dsl.md",
                 "references/footguns.md",
                 "references/recipes.md",
@@ -2036,7 +2031,6 @@ mod tests {
                 paths.into_iter().map(|(path, _)| path).collect::<Vec<_>>(),
                 vec![
                     root.join("SKILL.md"),
-                    root.join("agents/openai.yaml"),
                     root.join("references/ueg-dsl.md"),
                     root.join("references/footguns.md"),
                     root.join("references/recipes.md"),

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,10 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 pub struct SkillEntry {
     pub name: &'static str,
     pub description: &'static str,
     /// One of: "skill", "agent", "extension".
-    /// - skill / agent: single-file markdown installed under a skills/ dir
+    /// - skill: SKILL.md plus optional supplementary files under a skills/ dir
+    /// - agent: single-file markdown installed under an agents/ or skills/ dir
     /// - extension: multi-file bundle for an AI coding agent platform (e.g. pi)
     pub entry_type: &'static str,
     /// SKILL.md / agent.md body, or empty for entry_type == "extension".
@@ -12,11 +13,31 @@ pub struct SkillEntry {
     /// Platform slug for entry_type == "extension". One of: "pi".
     /// Empty for skills and agents.
     pub platform: &'static str,
-    /// Files to materialize for entry_type == "extension".
-    /// Each tuple is `(relative_path_within_extension_dir, file_contents)`.
-    /// Empty for skills and agents.
+    /// Supplementary files for skills, or all files for extensions.
+    /// Each tuple is `(safe_relative_path_within_entry_dir, file_contents)`.
+    /// Empty for single-file skills and agents.
     pub files: &'static [(&'static str, &'static str)],
 }
+
+/// Supplementary files bundled with the `dd-idp` skill.
+static DD_IDP_FILES: &[(&str, &str)] = &[
+    (
+        "agents/openai.yaml",
+        include_str!("../skills/dd-idp/agents/openai.yaml"),
+    ),
+    (
+        "references/ueg-dsl.md",
+        include_str!("../skills/dd-idp/references/ueg-dsl.md"),
+    ),
+    (
+        "references/footguns.md",
+        include_str!("../skills/dd-idp/references/footguns.md"),
+    ),
+    (
+        "references/recipes.md",
+        include_str!("../skills/dd-idp/references/recipes.md"),
+    ),
+];
 
 /// Files for the `dd-pup-pi` extension bundle (pi coding agent).
 static DD_PUP_PI_FILES: &[(&str, &str)] = &[
@@ -43,6 +64,14 @@ pub static SKILLS: &[SkillEntry] = &[
         content: include_str!("../skills/dd-pup/SKILL.md"),
         platform: "",
         files: &[],
+    },
+    SkillEntry {
+        name: "dd-idp",
+        description: "Map Datadog services, dependencies, ownership, health, and declared relationships.",
+        entry_type: "skill",
+        content: include_str!("../skills/dd-idp/SKILL.md"),
+        platform: "",
+        files: DD_IDP_FILES,
     },
     SkillEntry {
         name: "dd-monitors",
@@ -945,11 +974,41 @@ pub fn install_path(
     }
 }
 
-/// Resolve install destinations for any entry, including multi-file extensions.
+fn bundled_file_path(entry: &SkillEntry, base: &Path, relative: &str) -> anyhow::Result<PathBuf> {
+    let path = Path::new(relative);
+    let is_safe = !relative.is_empty()
+        && !relative.contains('\\')
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)));
+    if !is_safe {
+        anyhow::bail!(
+            "unsafe bundled path '{relative}' for '{}': expected a non-empty relative path without unsafe components or backslashes",
+            entry.name
+        );
+    }
+    Ok(base.join(path))
+}
+
+fn bundled_files(entry: &SkillEntry, base: &Path) -> anyhow::Result<Vec<(PathBuf, String)>> {
+    entry
+        .files
+        .iter()
+        .map(|(relative, content)| {
+            Ok((
+                bundled_file_path(entry, base, relative)?,
+                (*content).to_string(),
+            ))
+        })
+        .collect()
+}
+
+/// Resolve install destinations for any entry, including multi-file skills and extensions.
 ///
-/// Returns a list of `(absolute_path, contents)` tuples. For skills and agents
-/// this is a single-element list. For extensions this expands to one entry
-/// per bundled file.
+/// Returns a list of `(absolute_path, contents)` tuples. Skills always include
+/// their primary `SKILL.md` and may add supplementary files beneath that skill
+/// directory. Agents remain single-file entries. Extensions expand to one
+/// entry per bundled file.
 ///
 /// Returns `Ok(vec![])` (no-op) when the entry isn't applicable to the
 /// platform (e.g. asking for a `pi` extension on `claude-code`).
@@ -978,18 +1037,38 @@ pub fn install_paths(
             };
             root.join(entry.name)
         };
-        return Ok(entry
-            .files
-            .iter()
-            .map(|(rel, body)| (base.join(rel), (*body).to_string()))
-            .collect());
+        return bundled_files(entry, &base);
     }
 
     let Some((path, fmt)) = install_path(entry, platform, project_root, dir_override, user_scope)
     else {
         return Ok(vec![]);
     };
-    Ok(vec![(path, format_content(entry, &fmt))])
+    let mut targets = vec![(path.clone(), format_content(entry, &fmt))];
+    if entry.files.is_empty() {
+        return Ok(targets);
+    }
+    if entry.entry_type != "skill" {
+        anyhow::bail!(
+            "supplementary files are only supported for skill entries, not '{}'",
+            entry.entry_type
+        );
+    }
+    let base = path
+        .parent()
+        .expect("skill install path always has a parent directory");
+    let supplementary = bundled_files(entry, base)?;
+    if supplementary
+        .iter()
+        .any(|(candidate, _)| candidate == &path)
+    {
+        anyhow::bail!(
+            "supplementary files for '{}' must not replace its primary SKILL.md",
+            entry.name
+        );
+    }
+    targets.extend(supplementary);
+    Ok(targets)
 }
 
 #[derive(Debug, PartialEq)]
@@ -1124,20 +1203,32 @@ mod tests {
                     "extension {} must not have content (content is for skills/agents only)",
                     entry.name
                 );
-                for (rel, body) in entry.files {
-                    assert!(!rel.is_empty(), "empty file path in {}", entry.name);
-                    assert!(
-                        !body.is_empty(),
-                        "empty file body for {}:{}",
-                        entry.name,
-                        rel
-                    );
-                }
             } else {
                 assert!(
                     !entry.content.is_empty(),
                     "empty content for {}",
                     entry.name
+                );
+                if entry.entry_type == "agent" {
+                    assert!(
+                        entry.files.is_empty(),
+                        "agent {} must not have supplementary files",
+                        entry.name
+                    );
+                }
+            }
+            for (rel, body) in entry.files {
+                assert!(
+                    bundled_file_path(entry, Path::new("/safe"), rel).is_ok(),
+                    "unsafe file path in {}: {}",
+                    entry.name,
+                    rel
+                );
+                assert!(
+                    !body.is_empty(),
+                    "empty file body for {}:{}",
+                    entry.name,
+                    rel
                 );
             }
         }
@@ -1146,7 +1237,7 @@ mod tests {
     #[test]
     fn test_skill_count() {
         let skills: Vec<_> = SKILLS.iter().filter(|e| e.entry_type == "skill").collect();
-        assert_eq!(skills.len(), 11, "expected 11 skills");
+        assert_eq!(skills.len(), 12, "expected 12 skills");
     }
 
     #[test]
@@ -1724,6 +1815,102 @@ mod tests {
     }
 
     #[test]
+    fn test_install_paths_skill_expands_supplementary_files() {
+        static FILES: &[(&str, &str)] = &[
+            ("agents/openai.yaml", "interface: {}"),
+            ("references/query.md", "# Query"),
+        ];
+        let e = SkillEntry {
+            files: FILES,
+            ..entry("dd-idp", "skill", "body")
+        };
+        let root = PathBuf::from("/tmp/proj");
+        let paths = install_paths(&e, "codex", &root, None, false).unwrap();
+        assert_eq!(paths.len(), 3);
+        assert_eq!(paths[0].0, root.join(".codex/skills/dd-idp/SKILL.md"));
+        assert_eq!(
+            paths[1].0,
+            root.join(".codex/skills/dd-idp/agents/openai.yaml")
+        );
+        assert_eq!(
+            paths[2].0,
+            root.join(".codex/skills/dd-idp/references/query.md")
+        );
+    }
+
+    #[test]
+    fn test_install_paths_skill_bundle_user_scope() {
+        static FILES: &[(&str, &str)] = &[("references/query.md", "# Query")];
+        let e = SkillEntry {
+            files: FILES,
+            ..entry("dd-idp", "skill", "body")
+        };
+        let home = dirs::home_dir().expect("test environment must have a home directory");
+        let paths = install_paths(&e, "codex", Path::new("/unused"), None, true).unwrap();
+        assert_eq!(paths[0].0, home.join(".codex/skills/dd-idp/SKILL.md"));
+        assert_eq!(
+            paths[1].0,
+            home.join(".codex/skills/dd-idp/references/query.md")
+        );
+    }
+
+    #[test]
+    fn test_install_paths_skill_bundle_dir_override() {
+        static FILES: &[(&str, &str)] = &[("references/query.md", "# Query")];
+        let e = SkillEntry {
+            files: FILES,
+            ..entry("dd-idp", "skill", "body")
+        };
+        let paths = install_paths(
+            &e,
+            "claude-code",
+            Path::new("/unused"),
+            Some("/tmp/out"),
+            false,
+        )
+        .unwrap();
+        assert_eq!(paths[0].0, PathBuf::from("/tmp/out/dd-idp/SKILL.md"));
+        assert_eq!(
+            paths[1].0,
+            PathBuf::from("/tmp/out/dd-idp/references/query.md")
+        );
+    }
+
+    #[test]
+    fn test_install_paths_rejects_unsafe_bundle_paths() {
+        let unsafe_bundles: &[&'static [(&'static str, &'static str)]] = &[
+            &[("", "body")],
+            &[("../escape", "body")],
+            &[("/absolute", "body")],
+            &[("./same", "body")],
+            &[("references\\escape", "body")],
+        ];
+        for files in unsafe_bundles {
+            let e = SkillEntry {
+                files,
+                ..entry("dd-idp", "skill", "body")
+            };
+            let err = install_paths(&e, "codex", Path::new("/tmp/proj"), None, false)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("unsafe bundled path"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn test_install_paths_rejects_supplementary_skill_md() {
+        static FILES: &[(&str, &str)] = &[("SKILL.md", "replacement")];
+        let e = SkillEntry {
+            files: FILES,
+            ..entry("dd-idp", "skill", "body")
+        };
+        let err = install_paths(&e, "codex", Path::new("/tmp/proj"), None, false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must not replace"), "got: {err}");
+    }
+
+    #[test]
     fn test_install_paths_skill_on_pi() {
         let root = PathBuf::from("/tmp/proj");
         let e = entry("dd-pup", "skill", "body");
@@ -1790,6 +1977,74 @@ mod tests {
         assert!(names.contains(&"index.ts"));
         assert!(names.contains(&"package.json"));
         assert!(names.contains(&"README.md"));
+    }
+
+    #[test]
+    fn test_dd_idp_entry_registered_with_complete_bundle() {
+        let entry = SKILLS
+            .iter()
+            .find(|entry| entry.name == "dd-idp")
+            .expect("dd-idp must be registered");
+        assert_eq!(entry.entry_type, "skill");
+        assert!(entry.content.contains("name: dd-idp"));
+        let paths: Vec<&str> = entry.files.iter().map(|(path, _)| *path).collect();
+        assert_eq!(
+            paths,
+            vec![
+                "agents/openai.yaml",
+                "references/ueg-dsl.md",
+                "references/footguns.md",
+                "references/recipes.md",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_dd_idp_recipes_preserve_live_query_contracts() {
+        let recipes = DD_IDP_FILES
+            .iter()
+            .find_map(|(path, content)| (*path == "references/recipes.md").then_some(*content))
+            .expect("dd-idp recipes must be bundled");
+
+        assert!(recipes.contains("status:\"Alert\""));
+        assert!(!recipes.contains("status:alert"));
+        assert!(recipes.contains("state:breached"));
+        assert!(!recipes.contains("state:breaching"));
+        assert!(recipes.contains("upstream_services,downstream_services"));
+        assert!(recipes.contains(
+            "repository.full_name:\"<org>/<repository>\" AND reviewer_users.login:\"<login>\""
+        ));
+    }
+
+    #[test]
+    fn test_dd_idp_bundle_installs_on_every_skill_platform() {
+        let entry = SKILLS
+            .iter()
+            .find(|entry| entry.name == "dd-idp")
+            .expect("dd-idp must be registered");
+        let project_root = Path::new("/tmp/project");
+
+        for platform in PLATFORMS
+            .iter()
+            .filter(|platform| !platform.is_extension_only())
+        {
+            let root = skills_dir(platform.name, project_root, false)
+                .expect("skill-capable platform must have a project skills directory")
+                .join("dd-idp");
+            let paths = install_paths(entry, platform.name, project_root, None, false).unwrap();
+            assert_eq!(
+                paths.into_iter().map(|(path, _)| path).collect::<Vec<_>>(),
+                vec![
+                    root.join("SKILL.md"),
+                    root.join("agents/openai.yaml"),
+                    root.join("references/ueg-dsl.md"),
+                    root.join("references/footguns.md"),
+                    root.join("references/recipes.md"),
+                ],
+                "incomplete dd-idp bundle for {}",
+                platform.name
+            );
+        }
     }
 
     #[test]

--- a/src/test_commands.rs
+++ b/src/test_commands.rs
@@ -871,6 +871,31 @@ fn test_idp_entity_graph_commands_parse() {
 }
 
 #[test]
+fn test_idp_legacy_help_routes_connected_context_to_entity_graph() {
+    let idp = crate::Cli::command()
+        .find_subcommand("idp")
+        .expect("idp command should exist")
+        .clone();
+    let assist_help = idp
+        .find_subcommand("assist")
+        .expect("idp assist command should exist")
+        .clone()
+        .render_long_help()
+        .to_string();
+    let deps_help = idp
+        .find_subcommand("deps")
+        .expect("idp deps command should exist")
+        .clone()
+        .render_long_help()
+        .to_string();
+
+    assert!(assist_help.contains("idp entities query"));
+    assert!(!assist_help.contains("flagship"));
+    assert!(deps_help.contains("env=prod"));
+    assert!(deps_help.contains("declared/runtime graph relations"));
+}
+
+#[test]
 fn test_idp_entity_query_rejects_unknown_free_text_match_mode() {
     use clap::Parser;
 


### PR DESCRIPTION
## Summary

Adds a `dd-idp` skill for the entity graph commands added in #776.

The skill helps agents inspect the live schema, query connected service context, follow declared relationships, paginate results, and handle partial or missing data correctly.

This PR also updates Service Catalog and IDP guidance. It keeps `idp assist` and `idp owner` as fast service helpers. It uses `idp entities query` when users need relationship details, traversal, pagination, or kinds other than services.

## Changes

- Add the portable `dd-idp` skill with three focused references: query syntax, correctness pitfalls, and workflows.
- Allow normal skills to install supporting files such as `references/*.md`.
- Reject unsafe supporting-file paths and attempts to replace the main `SKILL.md`.
- Show supporting files in `pup skills list`.
- Update the README, command reference, LLM guide, root skill index, and IDP help.
- Keep existing IDP command behavior unchanged.

## Stale cleanup

- Replace Service Catalog guidance that referenced nonexistent `pup services` and `pup catalog` commands.
- Correct the root skill example from the unsupported `--category` flag to `--type`.

## Why this is useful

`idp assist` is useful for a quick service summary. The entity graph provides richer context in one query when users need explicit relationship types, counts, traversal, pagination, or non-service entities.

Live tests returned ownership, systems, code locations, health fields, dependency counts, truncation details, and related entities that can be queried again. The updated guidance explains when to use each command.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- 89 focused skill and installer tests
- 1,942 full-suite tests passed; only the existing x86_64 extension fixture was filtered on this aarch64 host
- Release build and binary installation smoke test
- Official skill validator
- Installed bundle contains the expected four files and matches the source exactly
- Read-only live tests across services, dependencies, deployments, monitors, SLOs, GitHub pull requests, APIs, and security data
- Independent clean-context evaluation across six workflows: 148/150, with no actionable skill defect

This PR does not change `Cargo.toml` or `Cargo.lock`. The dependency audit reports only the repository's existing `h2` and `rsa` advisories.

## Related

- Follow-up to #776
